### PR TITLE
Gradient-based scaling for RO unit models

### DIFF
--- a/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -48,7 +48,12 @@ import watertap.flowsheets.RO_with_energy_recovery.financials as financials
 
 def main():
     # set up solver
-    solver = get_solver(options={'nlp_scaling_method': 'user-scaling'})
+    solver = get_solver(options=
+            {
+                'bound_push': 1e-20,
+                'mu_init': 1e-6,
+                'tol' : 1e-10,
+            })
 
     # build, set, and initialize
     m = build()
@@ -56,7 +61,7 @@ def main():
     initialize_system(m, solver=solver)
 
     # simulate and display
-    solve(m, solver=solver)
+    solve(m, tee=True, solver=solver)
     print('\n***---Simulation results---***')
     display_system(m)
     display_design(m)
@@ -354,7 +359,7 @@ def optimize_set_up(m):
 
 def optimize(m, solver=None):
     # --solve---
-    solve(m, solver=solver)
+    solve(m, tee=True, solver=solver)
 
 def display_system(m):
     print('---system metrics---')

--- a/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -50,7 +50,7 @@ def main():
     # set up solver
     solver = get_solver(options=
             {
-                'bound_push': 1e-10,
+                'bound_push': 1e-8,
             })
 
     # build, set, and initialize
@@ -158,7 +158,7 @@ def build():
 
 def set_operating_conditions(m, water_recovery=0.5, over_pressure=0.3, solver=None):
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-10})
+        solver = get_solver(options={'bound_push': 1e-8})
 
     # ---specifications---
     # feed
@@ -263,14 +263,14 @@ def calculate_operating_pressure(feed_state_block=None, over_pressure=0.15,
 
 def solve(blk, solver=None, tee=False):
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-10})
+        solver = get_solver(options={'bound_push': 1e-8})
     results = solver.solve(blk, tee=tee)
     assert_optimal_termination(results)
 
 
 def initialize_system(m, solver=None):
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-10})
+        solver = get_solver(options={'bound_push': 1e-8})
     optarg = solver.options
 
     # ---initialize RO---

--- a/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -158,7 +158,7 @@ def build():
 
 def set_operating_conditions(m, water_recovery=0.5, over_pressure=0.3, solver=None):
     if solver is None:
-        solver = get_solver(options={'nlp_scaling_method': 'user-scaling'})
+        solver = get_solver(options={'bound_push': 1e-10})
 
     # ---specifications---
     # feed
@@ -263,14 +263,14 @@ def calculate_operating_pressure(feed_state_block=None, over_pressure=0.15,
 
 def solve(blk, solver=None, tee=False):
     if solver is None:
-        solver = get_solver(options={'nlp_scaling_method': 'user-scaling'})
+        solver = get_solver(options={'bound_push': 1e-10})
     results = solver.solve(blk, tee=tee)
     assert_optimal_termination(results)
 
 
 def initialize_system(m, solver=None):
     if solver is None:
-        solver = get_solver(options={'nlp_scaling_method': 'user-scaling'})
+        solver = get_solver(options={'bound_push': 1e-10})
     optarg = solver.options
 
     # ---initialize RO---

--- a/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -50,9 +50,7 @@ def main():
     # set up solver
     solver = get_solver(options=
             {
-                'bound_push': 1e-20,
-                'mu_init': 1e-6,
-                'tol' : 1e-10,
+                'bound_push': 1e-10,
             })
 
     # build, set, and initialize

--- a/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -48,10 +48,7 @@ import watertap.flowsheets.RO_with_energy_recovery.financials as financials
 
 def main():
     # set up solver
-    solver = get_solver(options=
-            {
-                'bound_push': 1e-8,
-            })
+    solver = get_solver(options={'bound_push': 1e-8})
 
     # build, set, and initialize
     m = build()
@@ -59,7 +56,7 @@ def main():
     initialize_system(m, solver=solver)
 
     # simulate and display
-    solve(m, tee=True, solver=solver)
+    solve(m, solver=solver)
     print('\n***---Simulation results---***')
     display_system(m)
     display_design(m)
@@ -357,7 +354,7 @@ def optimize_set_up(m):
 
 def optimize(m, solver=None):
     # --solve---
-    solve(m, tee=True, solver=solver)
+    solve(m, solver=solver)
 
 def display_system(m):
     print('---system metrics---')

--- a/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -40,7 +40,7 @@ def get_sweep_params(m, use_LHS=False):
 def run_parameter_sweep(results_file, seed=None, use_LHS=False):
 
     # Set up the solver
-    solver = get_solver(options={'bound_push': 1e-8})
+    solver = get_solver(options={'bound_push': 1e-6})
 
     # Build, set, and initialize the system (these steps will change depending on the underlying model)
     m = build()

--- a/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -40,7 +40,7 @@ def get_sweep_params(m, use_LHS=False):
 def run_parameter_sweep(results_file, seed=None, use_LHS=False):
 
     # Set up the solver
-    solver = get_solver(options={'nlp_scaling_method': 'user-scaling'})
+    solver = get_solver(options={'bound_push': 1e-10})
 
     # Build, set, and initialize the system (these steps will change depending on the underlying model)
     m = build()

--- a/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -40,7 +40,7 @@ def get_sweep_params(m, use_LHS=False):
 def run_parameter_sweep(results_file, seed=None, use_LHS=False):
 
     # Set up the solver
-    solver = get_solver(options={'bound_push': 1e-10})
+    solver = get_solver(options={'bound_push': 1e-8})
 
     # Build, set, and initialize the system (these steps will change depending on the underlying model)
     m = build()

--- a/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -40,7 +40,7 @@ def get_sweep_params(m, use_LHS=False):
 def run_parameter_sweep(results_file, seed=None, use_LHS=False):
 
     # Set up the solver
-    solver = get_solver(options={'bound_push': 1e-6})
+    solver = get_solver(options={'bound_push': 1e-8})
 
     # Build, set, and initialize the system (these steps will change depending on the underlying model)
     m = build()

--- a/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -44,9 +44,7 @@ build, set_operating_conditions, initialize_system, solve, optimize_set_up, opti
 
 solver = get_solver(options=
         {
-            'bound_push': 1e-20,
-            'mu_init': 1e-6,
-            'tol' : 1e-10,
+            'bound_push': 1e-10,
         })
 
 # -----------------------------------------------------------------------------

--- a/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -42,7 +42,12 @@ from watertap.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import 
 build, set_operating_conditions, initialize_system, solve, optimize_set_up, optimize, display_system, display_state, display_design)
 
 
-solver = get_solver(options={'nlp_scaling_method': 'user-scaling'})
+solver = get_solver(options=
+        {
+            'bound_push': 1e-20,
+            'mu_init': 1e-6,
+            'tol' : 1e-10,
+        })
 
 # -----------------------------------------------------------------------------
 class TestEnergyRecoverySystem:

--- a/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -44,7 +44,7 @@ build, set_operating_conditions, initialize_system, solve, optimize_set_up, opti
 
 solver = get_solver(options=
         {
-            'bound_push': 1e-10,
+            'bound_push': 1e-8,
         })
 
 # -----------------------------------------------------------------------------

--- a/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -42,10 +42,7 @@ from watertap.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import 
 build, set_operating_conditions, initialize_system, solve, optimize_set_up, optimize, display_system, display_state, display_design)
 
 
-solver = get_solver(options=
-        {
-            'bound_push': 1e-8,
-        })
+solver = get_solver(options={'bound_push': 1e-8})
 
 # -----------------------------------------------------------------------------
 class TestEnergyRecoverySystem:

--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -344,7 +344,7 @@ def initialize(m, verbose=False, solver=None):
     # ---initializing---
     # set up solvers
     if solver is None:
-        solver = get_solver(options={'nlp_scaling_method': 'user-scaling'})
+        solver = get_solver(options={'bound_push': 1e-10})
 
     optarg = solver.options
     do_initialization_pass(m, optarg=optarg, guess_mixers=True)
@@ -369,7 +369,7 @@ def initialize(m, verbose=False, solver=None):
 def solve(m, solver=None, tee=False, raise_on_failure=False):
     # ---solving---
     if solver is None:
-        solver = get_solver(options={'nlp_scaling_method':'user-scaling'})
+        solver = get_solver(options={'bound_push': 1e-10})
 
     results = solver.solve(m, tee=tee)
     if check_optimal_termination(results):

--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -344,7 +344,7 @@ def initialize(m, verbose=False, solver=None):
     # ---initializing---
     # set up solvers
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-6})
+        solver = get_solver(options={'bound_push': 1e-8})
 
     optarg = solver.options
     do_initialization_pass(m, optarg=optarg, guess_mixers=True)
@@ -369,7 +369,7 @@ def initialize(m, verbose=False, solver=None):
 def solve(m, solver=None, tee=False, raise_on_failure=False):
     # ---solving---
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-6})
+        solver = get_solver(options={'bound_push': 1e-8})
 
     results = solver.solve(m, tee=tee)
     if check_optimal_termination(results):

--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -136,6 +136,8 @@ def build(number_of_stages=2):
 
     # costing
     financials.get_system_costing(m.fs)
+    # objective
+    m.fs.objective = Objective(expr=m.fs.costing.LCOW)
 
     # connections
 
@@ -383,8 +385,6 @@ def solve(m, solver=None, tee=False, raise_on_failure=False):
 
 
 def optimize_set_up(m, water_recovery=None):
-    # objective
-    m.fs.objective = Objective(expr=m.fs.costing.LCOW)
 
     for pump in m.fs.PrimaryPumps.values():
         pump.control_volume.properties_out[0].pressure.unfix()

--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -243,7 +243,7 @@ def set_operating_conditions(m):
         stage.B_comp.fix(mem_B*B_scale)
         stage.channel_height.fix(height)
         stage.spacer_porosity.fix(spacer_porosity)
-        stage.area.fix(area)
+        stage.area.fix(area/float(idx))
         stage.width.fix(width)
         stage.permeate.pressure[0].fix(pressure_atm)
 

--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -42,7 +42,7 @@ import watertap.property_models.NaCl_prop_pack as props
 
 
 
-def main(number_of_stages):
+def main(number_of_stages, water_recovery=None):
     m = build(number_of_stages)
     set_operating_conditions(m)
     initialize(m)
@@ -52,7 +52,7 @@ def main(number_of_stages):
     display_design(m)
     display_state(m)
 
-    optimize_set_up(m)
+    optimize_set_up(m, water_recovery)
     solve(m)
     print('\n***---Optimization results---***')
     display_system(m)
@@ -489,8 +489,10 @@ def display_system(m):
 
 if __name__ == "__main__":
     import sys
-    if len(sys.argv) != 2:
-        print("Usage: python lsrro.py number_of_stages")
-    else:
+    if len(sys.argv) not in (2,3):
+        print("Usage 1: python lsrro.py number_of_stages")
+        print("Usage 2: python lsrro.py number_of_stages target_water_recovery_fraction")
+    elif len(sys.argv) == 2:
         main(int(sys.argv[1]))
-
+    else:
+        main(int(sys.argv[1]), float(sys.argv[2]))

--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -344,7 +344,7 @@ def initialize(m, verbose=False, solver=None):
     # ---initializing---
     # set up solvers
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-10})
+        solver = get_solver(options={'bound_push': 1e-6})
 
     optarg = solver.options
     do_initialization_pass(m, optarg=optarg, guess_mixers=True)
@@ -369,7 +369,7 @@ def initialize(m, verbose=False, solver=None):
 def solve(m, solver=None, tee=False, raise_on_failure=False):
     # ---solving---
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-10})
+        solver = get_solver(options={'bound_push': 1e-6})
 
     results = solver.solve(m, tee=tee)
     if check_optimal_termination(results):

--- a/watertap/flowsheets/lsrro/tests/test_lsrro.py
+++ b/watertap/flowsheets/lsrro/tests/test_lsrro.py
@@ -186,7 +186,7 @@ class _TestLSRRO:
 
             self._test_fixed_value(ro.channel_height, 1e-3)
             self._test_fixed_value(ro.spacer_porosity, 0.97)
-            self._test_fixed_value(ro.area, 100)
+            self._test_fixed_value(ro.area, 100/float(idx))
             self._test_fixed_value(ro.width, 5)
             self._test_fixed_value(ro.permeate.pressure[0], 101325)
 
@@ -337,10 +337,10 @@ class TestLSRRO_2Stage(_TestLSRRO):
     display_system = \
 """----system metrics----
 Feed: 1.00 kg/s, 70000 ppm
-Product: 0.380 kg/s, 699 ppm
-Volumetric water recovery: 38.0%
-Energy Consumption: 7.7 kWh/m3
-Levelized cost of water: 1.89 $/m3
+Product: 0.297 kg/s, 926 ppm
+Volumetric water recovery: 29.7%
+Energy Consumption: 6.3 kWh/m3
+Levelized cost of water: 1.98 $/m3
 """
     display_design = \
 """--decision variables--
@@ -348,25 +348,25 @@ Stage 1 operating pressure 75.0 bar
 Stage 1 membrane area      100.0 m2
 Stage 1 salt perm. coeff.  0.1 LMH
 Stage 2 operating pressure 75.0 bar
-Stage 2 membrane area      100.0 m2
+Stage 2 membrane area      50.0 m2
 Stage 2 salt perm. coeff.  12.6 LMH
 """
     display_state = \
 """--------state---------
 Feed                : 1.000 kg/s, 70000 ppm, 1.0 bar
 Primary Pump 1 out  : 1.000 kg/s, 70000 ppm, 75.0 bar
-Mixer 1 recycle     : 0.589 kg/s, 38805 ppm, 75.0 bar
-Mixer 1 out         : 1.589 kg/s, 58440 ppm, 75.0 bar
-RO 1 permeate       : 0.380 kg/s, 699 ppm, 1.0 bar
-RO 1 retentate      : 1.209 kg/s, 76588 ppm, 71.1 bar
-Stage 1 Volumetric water recovery: 24.96%, Salt rejection: 98.85%
-Primary Pump 2 out  : 1.209 kg/s, 76588 ppm, 75.0 bar
-RO 2 permeate       : 0.589 kg/s, 38805 ppm, 1.0 bar
-RO 2 retentate      : 0.620 kg/s, 112464 ppm, 72.8 bar
-Stage 2 Volumetric water recovery: 50.06%, Salt rejection: 50.71%
-Booster Pump 2 out  : 0.589 kg/s, 38805 ppm, 75.0 bar
-Disposal            : 0.620 kg/s, 112464 ppm, 1.0 bar
-Product             : 0.380 kg/s, 699 ppm, 1.0 bar
+Mixer 1 recycle     : 0.308 kg/s, 37757 ppm, 75.0 bar
+Mixer 1 out         : 1.308 kg/s, 62417 ppm, 75.0 bar
+RO 1 permeate       : 0.297 kg/s, 926 ppm, 1.0 bar
+RO 1 retentate      : 1.011 kg/s, 80454 ppm, 72.0 bar
+Stage 1 Volumetric water recovery: 23.74%, Salt rejection: 98.58%
+Primary Pump 2 out  : 1.011 kg/s, 80454 ppm, 75.0 bar
+RO 2 permeate       : 0.308 kg/s, 37757 ppm, 1.0 bar
+RO 2 retentate      : 0.703 kg/s, 99118 ppm, 74.0 bar
+Stage 2 Volumetric water recovery: 31.38%, Salt rejection: 54.50%
+Booster Pump 2 out  : 0.308 kg/s, 37757 ppm, 75.0 bar
+Disposal            : 0.703 kg/s, 99118 ppm, 1.0 bar
+Product             : 0.297 kg/s, 926 ppm, 1.0 bar
 """
 
     @pytest.fixture(scope="class")
@@ -374,10 +374,10 @@ Product             : 0.380 kg/s, 699 ppm, 1.0 bar
         data = pyo.ComponentMap()
         fs = model.fs
 
-        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.379673
-        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.265454e-3
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.550327
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697345e-1
+        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.296269
+        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.274578e-3
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.633730
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697254e-1
         data[fs.costing.LCOW]   = 1.0
         data[fs.water_recovery] = 0.5
 
@@ -388,12 +388,12 @@ Product             : 0.380 kg/s, 699 ppm, 1.0 bar
         data = pyo.ComponentMap()
         fs = model.fs
 
-        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.379673
-        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.265454e-3
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.550327
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697345e-1
-        data[fs.costing.LCOW]   = 1.88555
-        data[fs.water_recovery] = 0.379939
+        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.296269
+        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.274578e-3
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.633730
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697254e-1
+        data[fs.costing.LCOW]   = 1.98397
+        data[fs.water_recovery] = 0.296544
 
         return data
 
@@ -422,9 +422,9 @@ class TestLSRRO_3Stage(_TestLSRRO):
     display_system = \
 """----system metrics----
 Feed: 1.00 kg/s, 70000 ppm
-Product: 0.462 kg/s, 557 ppm
-Volumetric water recovery: 46.2%
-Energy Consumption: 10.0 kWh/m3
+Product: 0.330 kg/s, 823 ppm
+Volumetric water recovery: 33.0%
+Energy Consumption: 7.8 kWh/m3
 Levelized cost of water: 2.08 $/m3
 """
     display_design = \
@@ -433,35 +433,35 @@ Stage 1 operating pressure 75.0 bar
 Stage 1 membrane area      100.0 m2
 Stage 1 salt perm. coeff.  0.1 LMH
 Stage 2 operating pressure 75.0 bar
-Stage 2 membrane area      100.0 m2
+Stage 2 membrane area      50.0 m2
 Stage 2 salt perm. coeff.  12.6 LMH
 Stage 3 operating pressure 75.0 bar
-Stage 3 membrane area      100.0 m2
+Stage 3 membrane area      33.3 m2
 Stage 3 salt perm. coeff.  12.6 LMH
 """
     display_state = \
 """--------state---------
 Feed                : 1.000 kg/s, 70000 ppm, 1.0 bar
 Primary Pump 1 out  : 1.000 kg/s, 70000 ppm, 75.0 bar
-Mixer 1 recycle     : 0.700 kg/s, 31688 ppm, 75.0 bar
-Mixer 1 out         : 1.700 kg/s, 54222 ppm, 75.0 bar
-RO 1 permeate       : 0.462 kg/s, 557 ppm, 1.0 bar
-RO 1 retentate      : 1.238 kg/s, 74259 ppm, 70.8 bar
-Stage 1 Volumetric water recovery: 28.29%, Salt rejection: 99.01%
-Primary Pump 2 out  : 1.238 kg/s, 74259 ppm, 75.0 bar
-Mixer 2 recycle     : 0.410 kg/s, 56986 ppm, 75.0 bar
-Mixer 2 out         : 1.648 kg/s, 69964 ppm, 75.0 bar
-RO 2 permeate       : 0.700 kg/s, 31688 ppm, 1.0 bar
-RO 2 retentate      : 0.947 kg/s, 98252 ppm, 71.4 bar
-Stage 2 Volumetric water recovery: 43.70%, Salt rejection: 55.96%
-Booster Pump 2 out  : 0.700 kg/s, 31688 ppm, 75.0 bar
-Primary Pump 3 out  : 0.947 kg/s, 98252 ppm, 75.0 bar
-RO 3 permeate       : 0.410 kg/s, 56986 ppm, 1.0 bar
-RO 3 retentate      : 0.538 kg/s, 129683 ppm, 73.3 bar
-Stage 3 Volumetric water recovery: 44.54%, Salt rejection: 43.69%
-Booster Pump 3 out  : 0.410 kg/s, 56986 ppm, 75.0 bar
-Disposal            : 0.538 kg/s, 129683 ppm, 1.0 bar
-Product             : 0.462 kg/s, 557 ppm, 1.0 bar
+Mixer 1 recycle     : 0.348 kg/s, 32663 ppm, 75.0 bar
+Mixer 1 out         : 1.348 kg/s, 60351 ppm, 75.0 bar
+RO 1 permeate       : 0.330 kg/s, 823 ppm, 1.0 bar
+RO 1 retentate      : 1.019 kg/s, 79612 ppm, 71.9 bar
+Stage 1 Volumetric water recovery: 25.55%, Salt rejection: 98.69%
+Primary Pump 2 out  : 1.019 kg/s, 79612 ppm, 75.0 bar
+Mixer 2 recycle     : 0.175 kg/s, 45135 ppm, 75.0 bar
+Mixer 2 out         : 1.194 kg/s, 74561 ppm, 75.0 bar
+RO 2 permeate       : 0.348 kg/s, 32663 ppm, 1.0 bar
+RO 2 retentate      : 0.845 kg/s, 91835 ppm, 73.8 bar
+Stage 2 Volumetric water recovery: 30.10%, Salt rejection: 57.51%
+Booster Pump 2 out  : 0.348 kg/s, 32663 ppm, 75.0 bar
+Primary Pump 3 out  : 0.845 kg/s, 91835 ppm, 75.0 bar
+RO 3 permeate       : 0.175 kg/s, 45135 ppm, 1.0 bar
+RO 3 retentate      : 0.670 kg/s, 104020 ppm, 74.4 bar
+Stage 3 Volumetric water recovery: 21.40%, Salt rejection: 52.48%
+Booster Pump 3 out  : 0.175 kg/s, 45135 ppm, 75.0 bar
+Disposal            : 0.670 kg/s, 104020 ppm, 1.0 bar
+Product             : 0.330 kg/s, 823 ppm, 1.0 bar
 """
 
     @pytest.fixture(scope="class")
@@ -469,10 +469,10 @@ Product             : 0.462 kg/s, 557 ppm, 1.0 bar
         data = pyo.ComponentMap()
         fs = model.fs
 
-        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.461950
-        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.257311e-3
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.468049
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697427e-1
+        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.329389
+        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.271454e-3
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.600609
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697285e-1
         data[fs.costing.LCOW]   = 1.0
         data[fs.water_recovery] = 0.5
 
@@ -483,12 +483,12 @@ Product             : 0.462 kg/s, 557 ppm, 1.0 bar
         data = pyo.ComponentMap()
         fs = model.fs
 
-        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.461950
-        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.257311e-3
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.468049
-        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697427e-1
-        data[fs.costing.LCOW]   = 2.08278
-        data[fs.water_recovery] = 0.462208
+        data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.329390
+        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.271454e-3
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.600609
+        data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.697285e-1
+        data[fs.costing.LCOW]   = 2.07793
+        data[fs.water_recovery] = 0.329661
 
         return data
 

--- a/watertap/flowsheets/lsrro/tests/test_lsrro.py
+++ b/watertap/flowsheets/lsrro/tests/test_lsrro.py
@@ -137,7 +137,7 @@ class _TestLSRRO:
         model.compute_statistics()
         assert model.statistics.number_of_variables == self.number_of_variables
         assert model.statistics.number_of_constraints == self.number_of_constraints
-        assert model.statistics.number_of_objectives == 0
+        assert model.statistics.number_of_objectives == 1
 
         assert_units_consistent(fs)
 

--- a/watertap/flowsheets/lsrro/tests/test_lsrro.py
+++ b/watertap/flowsheets/lsrro/tests/test_lsrro.py
@@ -256,8 +256,8 @@ class TestLSRRO_1Stage(_TestLSRRO):
 
     number_of_stages = 1
 
-    number_of_variables = 291
-    number_of_constraints = 190
+    number_of_variables = 290
+    number_of_constraints = 189
 
     display_system = \
 """----system metrics----
@@ -331,8 +331,8 @@ class TestLSRRO_2Stage(_TestLSRRO):
 
     number_of_stages = 2
 
-    number_of_variables = 536
-    number_of_constraints = 380
+    number_of_variables = 534
+    number_of_constraints = 378
 
     display_system = \
 """----system metrics----
@@ -416,8 +416,8 @@ class TestLSRRO_3Stage(_TestLSRRO):
 
     number_of_stages = 3
 
-    number_of_variables = 781
-    number_of_constraints = 570
+    number_of_variables = 778
+    number_of_constraints = 567
 
     display_system = \
 """----system metrics----

--- a/watertap/flowsheets/lsrro/tests/test_lsrro.py
+++ b/watertap/flowsheets/lsrro/tests/test_lsrro.py
@@ -403,7 +403,7 @@ Product             : 0.380 kg/s, 699 ppm, 1.0 bar
         fs = model.fs
 
         data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.732053
-        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.451388e-3
+        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.451359e-3
         data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.197947
         data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.695486e-1
         data[fs.costing.LCOW]   = 1.21780
@@ -498,10 +498,10 @@ Product             : 0.462 kg/s, 557 ppm, 1.0 bar
         fs = model.fs
 
         data[fs.product.flow_mass_phase_comp[0,'Liq','H2O']]   = 0.732036
-        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.445542e-3
+        data[fs.product.flow_mass_phase_comp[0,'Liq','NaCl']]  = 0.445064e-3
         data[fs.disposal.flow_mass_phase_comp[0,'Liq','H2O']]  = 0.197964
         data[fs.disposal.flow_mass_phase_comp[0,'Liq','NaCl']] = 0.695545e-1
-        data[fs.costing.LCOW]   = 1.22403
+        data[fs.costing.LCOW]   = 1.51258
         data[fs.water_recovery] = 0.732481
 
         return data

--- a/watertap/flowsheets/lsrro/tests/test_lsrro.py
+++ b/watertap/flowsheets/lsrro/tests/test_lsrro.py
@@ -226,8 +226,8 @@ class _TestLSRRO:
         assert captured.out == self.display_state
 
     @pytest.mark.component
-    def test_optimize_set_up(self, model):
-        optimize_set_up(model)
+    def test_optimize_set_up(self, model, optimization_data):
+        optimize_set_up(model, water_recovery=optimization_data[model.fs.water_recovery])
         fs = model.fs
 
         for pump in fs.PrimaryPumps.values():

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -147,7 +147,7 @@ class NaClParameterData(PhysicalParameterBlock):
         self.set_default_scaling('dens_mass_phase', 1e-3, index='Liq')
         self.set_default_scaling('visc_d_phase', 1e3, index='Liq')
         self.set_default_scaling('diffus_phase', 1e9, index='Liq')
-        self.set_default_scaling('osm_coeff', 1e3)
+        self.set_default_scaling('osm_coeff', 1e2)
         self.set_default_scaling('enth_mass_phase', 1e-5, index='Liq')
 
     @classmethod

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -147,7 +147,7 @@ class NaClParameterData(PhysicalParameterBlock):
         self.set_default_scaling('dens_mass_phase', 1e-3, index='Liq')
         self.set_default_scaling('visc_d_phase', 1e3, index='Liq')
         self.set_default_scaling('diffus_phase', 1e9, index='Liq')
-        self.set_default_scaling('osm_coeff', 1e0)
+        self.set_default_scaling('osm_coeff', 1e3)
         self.set_default_scaling('enth_mass_phase', 1e-5, index='Liq')
 
     @classmethod
@@ -673,7 +673,7 @@ class NaClStateBlockData(StateBlockData):
         if self.is_property_constructed('pressure_osm'):
             if iscale.get_scaling_factor(self.pressure_osm) is None:
                 iscale.set_scaling_factor(self.pressure_osm,
-                                          iscale.get_scaling_factor(self.pressure))
+                                          iscale.get_scaling_factor(self.pressure)*1.)
 
         if self.is_property_constructed('mass_frac_phase_comp'):
             for j in self.params.component_list:
@@ -683,12 +683,12 @@ class NaClStateBlockData(StateBlockData):
                               / iscale.get_scaling_factor(self.flow_mass_phase_comp['Liq', 'H2O']))
                         iscale.set_scaling_factor(self.mass_frac_phase_comp['Liq', j], sf)
                     elif j == 'H2O':
-                        iscale.set_scaling_factor(self.mass_frac_phase_comp['Liq', j], 1)
+                        iscale.set_scaling_factor(self.mass_frac_phase_comp['Liq', j], 100)
 
         if self.is_property_constructed('flow_vol_phase'):
             sf = (iscale.get_scaling_factor(self.flow_mass_phase_comp['Liq', 'H2O'])
                   / iscale.get_scaling_factor(self.dens_mass_phase['Liq']))
-            iscale.set_scaling_factor(self.flow_vol_phase, sf)
+            iscale.set_scaling_factor(self.flow_vol_phase, sf*10.)
 
         if self.is_property_constructed('flow_vol'):
             sf = iscale.get_scaling_factor(self.flow_vol_phase)
@@ -747,14 +747,19 @@ class NaClStateBlockData(StateBlockData):
                 iscale.constraint_scaling_transform(c, sf)
 
         # property relationships with phase index, but simple constraint
-        v_str_lst_phase = ['dens_mass_phase', 'flow_vol_phase', 'visc_d_phase',
-                           'diffus_phase', 'enth_mass_phase']
-        for v_str in v_str_lst_phase:
+        for v_str in ('flow_vol_phase', 'visc_d_phase', 'diffus_phase', 'enth_mass_phase'):
             if self.is_property_constructed(v_str):
                 v = getattr(self, v_str)
                 sf = iscale.get_scaling_factor(v['Liq'], default=1, warning=True)
                 c = getattr(self, 'eq_' + v_str)
                 iscale.constraint_scaling_transform(c, sf)
+
+        for v_str in ('dens_mass_phase',):
+            if self.is_property_constructed(v_str):
+                v = getattr(self, v_str)
+                sf = iscale.get_scaling_factor(v['Liq'], default=1, warning=True)
+                c = getattr(self, 'eq_' + v_str)
+                iscale.constraint_scaling_transform(c, sf*10.)
 
         # property relationship indexed by component
         v_str_lst_comp = ['molality_comp']

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -146,7 +146,7 @@ class NaClParameterData(PhysicalParameterBlock):
         self.set_default_scaling('pressure', 1e-6)
         self.set_default_scaling('dens_mass_phase', 1e-3, index='Liq')
         self.set_default_scaling('visc_d_phase', 1e3, index='Liq')
-        self.set_default_scaling('diffus_phase', 1e9, index='Liq')
+        self.set_default_scaling('diffus_phase', 1e10, index='Liq')
         self.set_default_scaling('osm_coeff', 1e1)
         self.set_default_scaling('enth_mass_phase', 1e-5, index='Liq')
 

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -147,7 +147,7 @@ class NaClParameterData(PhysicalParameterBlock):
         self.set_default_scaling('dens_mass_phase', 1e-3, index='Liq')
         self.set_default_scaling('visc_d_phase', 1e3, index='Liq')
         self.set_default_scaling('diffus_phase', 1e9, index='Liq')
-        self.set_default_scaling('osm_coeff', 1e2)
+        self.set_default_scaling('osm_coeff', 1e1)
         self.set_default_scaling('enth_mass_phase', 1e-5, index='Liq')
 
     @classmethod

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -673,7 +673,7 @@ class NaClStateBlockData(StateBlockData):
         if self.is_property_constructed('pressure_osm'):
             if iscale.get_scaling_factor(self.pressure_osm) is None:
                 iscale.set_scaling_factor(self.pressure_osm,
-                                          iscale.get_scaling_factor(self.pressure)*1.)
+                                          iscale.get_scaling_factor(self.pressure))
 
         if self.is_property_constructed('mass_frac_phase_comp'):
             for j in self.params.component_list:

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -738,7 +738,7 @@ class NaClStateBlockData(StateBlockData):
 
         # transforming constraints
         # property relationships with no index, simple constraint
-        v_str_lst_simple = ['osm_coeff', 'pressure_osm']
+        v_str_lst_simple = ('osm_coeff', 'pressure_osm')
         for v_str in v_str_lst_simple:
             if self.is_property_constructed(v_str):
                 v = getattr(self, v_str)
@@ -747,14 +747,14 @@ class NaClStateBlockData(StateBlockData):
                 iscale.constraint_scaling_transform(c, sf)
 
         # property relationships with phase index, but simple constraint
-        for v_str in ('flow_vol_phase', 'visc_d_phase', 'diffus_phase', 'enth_mass_phase'):
+        for v_str in ('flow_vol_phase', 'visc_d_phase', 'diffus_phase'):
             if self.is_property_constructed(v_str):
                 v = getattr(self, v_str)
                 sf = iscale.get_scaling_factor(v['Liq'], default=1, warning=True)
                 c = getattr(self, 'eq_' + v_str)
                 iscale.constraint_scaling_transform(c, sf)
 
-        for v_str in ('dens_mass_phase',):
+        for v_str in ('dens_mass_phase', 'enth_mass_phase'):
             if self.is_property_constructed(v_str):
                 v = getattr(self, v_str)
                 sf = iscale.get_scaling_factor(v['Liq'], default=1, warning=True)

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -930,7 +930,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
         # Set solver and options
         if optarg is None:
-            optarg = {'bound_push': 1e-6}
+            optarg = {'bound_push': 1e-8}
         opt = get_solver(solver, optarg)
 
         # assumptions

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -1290,7 +1290,7 @@ class ReverseOsmosisData(UnitModelBlockData):
 
         for ind, c in self.eq_permeate_production.items():
             sf = iscale.get_scaling_factor(self.mass_transfer_phase_comp[ind])
-            iscale.constraint_scaling_transform(c, sf)
+            iscale.constraint_scaling_transform(c, sf/10.)
 
         for ind, c in self.eq_flux_io.items():
             sf = iscale.get_scaling_factor(self.flux_mass_io_phase_comp[ind])
@@ -1298,7 +1298,7 @@ class ReverseOsmosisData(UnitModelBlockData):
 
         for ind, c in self.eq_connect_mass_transfer.items():
             sf = iscale.get_scaling_factor(self.mass_transfer_phase_comp[ind])
-            iscale.constraint_scaling_transform(c, sf)
+            iscale.constraint_scaling_transform(c, sf/10.)
 
         for ind, c in self.eq_connect_enthalpy_transfer.items():
             sf = iscale.get_scaling_factor(self.feed_side.enthalpy_transfer[ind])
@@ -1356,7 +1356,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         if hasattr(self, 'eq_N_Re_io'):
             for ind, c in self.eq_N_Re_io.items():
                 sf = iscale.get_scaling_factor(self.N_Re_io[ind])
-                iscale.constraint_scaling_transform(c, sf*1e3)
+                iscale.constraint_scaling_transform(c, sf*1e4)
 
         if hasattr(self, 'eq_N_Sc_io'):
             for ind, c in self.eq_N_Sc_io.items():

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -376,13 +376,6 @@ class ReverseOsmosisData(UnitModelBlockData):
             units=pyunits.dimensionless,
             doc='Observed solute rejection')
 
-        #self.over_pressure_ratio = Var(
-        #    self.flowsheet().config.time,
-        #    initialize=1.1,
-        #    bounds=(0.5, 5),
-        #    units=pyunits.dimensionless,
-        #    doc='Over pressure ratio')
-
         if self.config.concentration_polarization_type == ConcentrationPolarizationType.fixed:
             self.cp_modulus = Var(
                 self.flowsheet().config.time,
@@ -889,12 +882,12 @@ class ReverseOsmosisData(UnitModelBlockData):
                     1 - (b.permeate_side.properties_mixed[t].conc_mass_phase_comp['Liq', j] /
                          b.feed_side.properties_in[t].conc_mass_phase_comp['Liq', j]))
 
-        #@self.Constraint(self.flowsheet().config.time)
-        #def eq_over_pressure_ratio(b, t):
-        #    return (b.feed_side.properties_out[t].pressure ==
-        #            b.over_pressure_ratio[t]
-        #            * (b.feed_side.properties_out[t].pressure_osm
-        #            - b.permeate_side.properties_out[t].pressure_osm))
+        @self.Expression(self.flowsheet().config.time,
+                         doc='Over pressure ratio')
+        def over_pressure_ratio(b, t):
+            return (b.feed_side.properties_out[t].pressure_osm
+                    - b.permeate_side.properties_out[t].pressure_osm) / \
+                    b.feed_side.properties_out[t].pressure
 
     def initialize(blk,
                    initialize_guess=None,
@@ -937,7 +930,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
         # Set solver and options
         if optarg is None:
-            optarg = {'nlp_scaling_method': 'user-scaling'}
+            optarg = {'bound_push': 1e-10}
         opt = get_solver(solver, optarg)
 
         # assumptions
@@ -1193,9 +1186,6 @@ class ReverseOsmosisData(UnitModelBlockData):
             if iscale.get_scaling_factor(v) is None:
                 iscale.set_scaling_factor(v, 1)
 
-        #if iscale.get_scaling_factor(self.over_pressure_ratio) is None:
-        #    iscale.set_scaling_factor(self.over_pressure_ratio, 1e-5)
-
         if hasattr(self, 'cp_modulus'):
             if iscale.get_scaling_factor(self.cp_modulus) is None:
                 sf = iscale.get_scaling_factor(self.cp_modulus)
@@ -1209,12 +1199,12 @@ class ReverseOsmosisData(UnitModelBlockData):
         if hasattr(self, 'N_Re_io'):
             for t, x in self.N_Re_io.keys():
                 if iscale.get_scaling_factor(self.N_Re_io[t, x]) is None:
-                    iscale.set_scaling_factor(self.N_Re_io[t, x], 1e-3)
+                    iscale.set_scaling_factor(self.N_Re_io[t, x], 1e-2)
 
         if hasattr(self, 'N_Sc_io'):
             for t, x in self.N_Sc_io.keys():
                 if iscale.get_scaling_factor(self.N_Sc_io[t, x]) is None:
-                    iscale.set_scaling_factor(self.N_Sc_io[t, x], 1e-3)
+                    iscale.set_scaling_factor(self.N_Sc_io[t, x], 1e-2)
 
         if hasattr(self, 'N_Sh_io'):
             for t, x in self.N_Sh_io.keys():
@@ -1312,7 +1302,7 @@ class ReverseOsmosisData(UnitModelBlockData):
 
         for ind, c in self.eq_connect_enthalpy_transfer.items():
             sf = iscale.get_scaling_factor(self.feed_side.enthalpy_transfer[ind])
-            iscale.constraint_scaling_transform(c, sf*100.)
+            iscale.constraint_scaling_transform(c, sf*10.)
 
         for t, c in self.eq_permeate_isothermal.items():
             sf = iscale.get_scaling_factor(self.feed_side.properties_in[t].temperature)
@@ -1366,12 +1356,12 @@ class ReverseOsmosisData(UnitModelBlockData):
         if hasattr(self, 'eq_N_Re_io'):
             for ind, c in self.eq_N_Re_io.items():
                 sf = iscale.get_scaling_factor(self.N_Re_io[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*1e3)
 
         if hasattr(self, 'eq_N_Sc_io'):
             for ind, c in self.eq_N_Sc_io.items():
                 sf = iscale.get_scaling_factor(self.N_Sc_io[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*1e3)
 
         if hasattr(self, 'eq_N_Sh_io'):
             for ind, c in self.eq_N_Sh_io.items():
@@ -1394,12 +1384,12 @@ class ReverseOsmosisData(UnitModelBlockData):
         if hasattr(self, 'eq_velocity_io'):
             for ind, c in self.eq_velocity_io.items():
                 sf = iscale.get_scaling_factor(self.velocity_io[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*100.)
 
         if hasattr(self, 'eq_friction_factor_darcy_io'):
             for ind, c in self.eq_friction_factor_darcy_io.items():
                 sf = iscale.get_scaling_factor(self.friction_factor_darcy_io[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf/10.)
 
         if hasattr(self, 'eq_dP_dx_io'):
             for ind, c in self.eq_dP_dx_io.items():
@@ -1442,6 +1432,3 @@ class ReverseOsmosisData(UnitModelBlockData):
             sf = iscale.get_scaling_factor(self.rejection_phase_comp[t, 'Liq', j])
             iscale.constraint_scaling_transform(c, sf)
 
-        #for t, c in self.eq_over_pressure_ratio.items():
-        #    sf = iscale.get_scaling_factor(self.over_pressure_ratio[t])
-        #    iscale.constraint_scaling_transform(c, sf)

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -930,7 +930,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
         # Set solver and options
         if optarg is None:
-            optarg = {'bound_push': 1e-10}
+            optarg = {'bound_push': 1e-6}
         opt = get_solver(solver, optarg)
 
         # assumptions
@@ -1431,4 +1431,3 @@ class ReverseOsmosisData(UnitModelBlockData):
         for (t, j), c in self.eq_rejection_phase_comp.items():
             sf = iscale.get_scaling_factor(self.rejection_phase_comp[t, 'Liq', j])
             iscale.constraint_scaling_transform(c, sf)
-

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -1037,9 +1037,8 @@ class ReverseOsmosisData(UnitModelBlockData):
 
         # ---------------------------------------------------------------------
         # Solve unit
-        #with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-        #    res = opt.solve(blk, tee=slc.tee)
-        res = opt.solve(blk, tee=True)
+        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+            res = opt.solve(blk, tee=slc.tee)
         check_solve(res, checkpoint='Initialization Step 3', logger=init_log, fail_flag=fail_on_warning)
         # ---------------------------------------------------------------------
         # Release Inlet state

--- a/watertap/unit_models/reverse_osmosis_1D.py
+++ b/watertap/unit_models/reverse_osmosis_1D.py
@@ -1022,7 +1022,7 @@ class ReverseOsmosis1DData(UnitModelBlockData):
 
         # Create solver
         if optarg is None:
-            optarg = {'nlp_scaling_method': 'user-scaling'}
+            optarg = {'bound_push': 1e-8}
 
         opt = get_solver(solver, optarg)
 
@@ -1156,16 +1156,11 @@ class ReverseOsmosis1DData(UnitModelBlockData):
         super().calculate_scaling_factors()
         # setting scaling factors for variables
         for j in self.config.property_package.component_list:
-            if j in self.config.property_package.solvent_set:
-                iscale.set_scaling_factor(self.permeate_side[0, 0].flow_mass_phase_comp['Liq', j], 1e+5)
-            elif j in self.config.property_package.solute_set:
-                iscale.set_scaling_factor(self.permeate_side[0, 0].flow_mass_phase_comp['Liq', j], 1e+5)
-            else:
-                raise RuntimeError(f"Unexpected non-solvent and non-solute component {j}")
+            iscale.set_scaling_factor(self.permeate_side[0, 0].flow_mass_phase_comp['Liq', j], 1e+5)
 
         # these variables should have user input, if not there will be a warning
         if iscale.get_scaling_factor(self.area) is None:
-            sf = iscale.get_scaling_factor(self.area, default=1, warning=True)
+            sf = iscale.get_scaling_factor(self.area, default=10, warning=True)
             iscale.set_scaling_factor(self.area, sf)
 
         if iscale.get_scaling_factor(self.width) is None:
@@ -1173,10 +1168,14 @@ class ReverseOsmosis1DData(UnitModelBlockData):
             iscale.set_scaling_factor(self.width, sf)
 
         if iscale.get_scaling_factor(self.length) is None:
-            sf = iscale.get_scaling_factor(self.length, default=1, warning=True)
+            sf = iscale.get_scaling_factor(self.length, default=10, warning=True)
             iscale.set_scaling_factor(self.length, sf)
 
         # will not override if the user provides the scaling factor
+        ## default of 1 set by ControlVolume1D
+        if iscale.get_scaling_factor(self.area_cross) == 1:
+            iscale.set_scaling_factor(self.area_cross, 100)
+
         if iscale.get_scaling_factor(self.A_comp) is None:
             iscale.set_scaling_factor(self.A_comp, 1e12)
 
@@ -1243,12 +1242,12 @@ class ReverseOsmosis1DData(UnitModelBlockData):
         if hasattr(self, 'N_Re'):
             for t, x in self.N_Re.keys():
                 if iscale.get_scaling_factor(self.N_Re[t, x]) is None:
-                    iscale.set_scaling_factor(self.N_Re[t, x], 1e-3)
+                    iscale.set_scaling_factor(self.N_Re[t, x], 1e-1)
 
         if hasattr(self, 'N_Sc'):
             for t, x in self.N_Sc.keys():
                 if iscale.get_scaling_factor(self.N_Sc[t, x]) is None:
-                    iscale.set_scaling_factor(self.N_Sc[t, x], 1e-3)
+                    iscale.set_scaling_factor(self.N_Sc[t, x], 1e-1)
 
         if hasattr(self, 'N_Sh'):
             for t, x in self.N_Sh.keys():
@@ -1277,23 +1276,19 @@ class ReverseOsmosis1DData(UnitModelBlockData):
                 else:
                     sf = iscale.get_scaling_factor(self.flux_mass_phase_comp[t, x, p, j])\
                          * iscale.get_scaling_factor(self.width)
-                    comp = self.config.property_package.get_component(j)
-                    if comp.is_solute:
-                        sf *= 1e-1  # solute typically has mass transfer 2 orders magnitude less than flow
                     iscale.set_scaling_factor(v, sf/100.)
 
         for (t, x, p, j), v in self.mass_transfer_phase_comp.items():
             if iscale.get_scaling_factor(v) is None:
                 sf = iscale.get_scaling_factor(self.feed_side.properties[t, x].get_material_flow_terms(p, j)) \
                      / iscale.get_scaling_factor(self.feed_side.length)
-                comp = self.config.property_package.get_component(j)
-                if comp.is_solute:
-                    sf *= 1e2  # solute typically has mass transfer 2 orders magnitude less than flow
+                if x == 0:
+                    sf *= 10.
                 iscale.set_scaling_factor(v, sf)
 
         if hasattr(self, 'deltaP'):
             for v in self.feed_side.pressure_dx.values():
-                iscale.set_scaling_factor(v, 1e-3)
+                iscale.set_scaling_factor(v, 1e-5)
         else:
             for v in self.feed_side.pressure_dx.values():
                 iscale.set_scaling_factor(v, 1e5)
@@ -1305,14 +1300,14 @@ class ReverseOsmosis1DData(UnitModelBlockData):
 
         for ind, c in self.eq_connect_mass_transfer.items():
             sf = iscale.get_scaling_factor(self.mass_transfer_phase_comp[ind])
-            iscale.constraint_scaling_transform(c, sf)
+            iscale.constraint_scaling_transform(c, sf*10.)
 
         sf = iscale.get_scaling_factor(self.area)
-        iscale.constraint_scaling_transform(self.eq_area, sf)
+        iscale.constraint_scaling_transform(self.eq_area, sf/10.)
 
         for ind, c in self.eq_permeate_production.items():
-            # TODO: revise this scaling factor; setting to 1 for now
-            iscale.constraint_scaling_transform(c, 1)
+            # TODO: revise this scaling factor; setting to 100 for now
+            iscale.constraint_scaling_transform(c, 100.)
 
         for ind, c in self.eq_flux_mass.items():
             sf = iscale.get_scaling_factor(self.flux_mass_phase_comp[ind])
@@ -1345,7 +1340,7 @@ class ReverseOsmosis1DData(UnitModelBlockData):
         for (t, x, j), c in self.feed_side.eq_concentration_polarization.items():
             prop_interface = self.feed_side.properties_interface[t, x]
             sf = iscale.get_scaling_factor(prop_interface.conc_mass_phase_comp['Liq', j])
-            iscale.constraint_scaling_transform(c, sf)
+            iscale.constraint_scaling_transform(c, sf*10.)
 
         for (t, x), c in self.feed_side.eq_equal_temp_interface.items():
             prop_interface = self.feed_side.properties_interface[t, x]
@@ -1365,26 +1360,26 @@ class ReverseOsmosis1DData(UnitModelBlockData):
         if hasattr(self, 'eq_Kf'):
             for ind, c in self.eq_Kf.items():
                 sf = iscale.get_scaling_factor(self.Kf[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*10.)
 
         if hasattr(self, 'eq_N_Re'):
             for ind, c in self.eq_N_Re.items():
                 sf = iscale.get_scaling_factor(self.N_Re[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*1e4)
 
         if hasattr(self, 'eq_N_Sc'):
             for ind, c in self.eq_N_Sc.items():
                 sf = iscale.get_scaling_factor(self.N_Sc[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*1e4)
 
         if hasattr(self, 'eq_N_Sh'):
             for ind, c in self.eq_N_Sh.items():
                 sf = iscale.get_scaling_factor(self.N_Sh[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*1e1)
 
         if hasattr(self, 'eq_area_cross'):
             sf = iscale.get_scaling_factor(self.area_cross)
-            iscale.constraint_scaling_transform(self.eq_area_cross, sf)
+            iscale.constraint_scaling_transform(self.eq_area_cross, sf*10.)
 
         if hasattr(self, 'eq_dh'):
             sf = iscale.get_scaling_factor(self.dh)
@@ -1404,12 +1399,12 @@ class ReverseOsmosis1DData(UnitModelBlockData):
         if hasattr(self, 'eq_velocity'):
             for ind, c in self.eq_velocity.items():
                 sf = iscale.get_scaling_factor(self.velocity[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf*1e4)
 
         if hasattr(self, 'eq_friction_factor_darcy'):
             for ind, c in self.eq_friction_factor_darcy.items():
                 sf = iscale.get_scaling_factor(self.friction_factor_darcy[ind])
-                iscale.constraint_scaling_transform(c, sf)
+                iscale.constraint_scaling_transform(c, sf/10.)
 
         if hasattr(self, 'eq_dP_dx'):
             for ind, c in self.eq_dP_dx.items():

--- a/watertap/unit_models/reverse_osmosis_1D.py
+++ b/watertap/unit_models/reverse_osmosis_1D.py
@@ -1156,7 +1156,13 @@ class ReverseOsmosis1DData(UnitModelBlockData):
         super().calculate_scaling_factors()
         # setting scaling factors for variables
         for j in self.config.property_package.component_list:
-            iscale.set_scaling_factor(self.permeate_side[0, 0].flow_mass_phase_comp['Liq', j], 0)
+            if j in self.config.property_package.solvent_set:
+                iscale.set_scaling_factor(self.permeate_side[0, 0].flow_mass_phase_comp['Liq', j], 1e+5)
+            elif j in self.config.property_package.solute_set:
+                iscale.set_scaling_factor(self.permeate_side[0, 0].flow_mass_phase_comp['Liq', j], 1e+5)
+            else:
+                raise RuntimeError(f"Unexpected non-solvent and non-solute component {j}")
+
         # these variables should have user input, if not there will be a warning
         if iscale.get_scaling_factor(self.area) is None:
             sf = iscale.get_scaling_factor(self.area, default=1, warning=True)
@@ -1273,8 +1279,8 @@ class ReverseOsmosis1DData(UnitModelBlockData):
                          * iscale.get_scaling_factor(self.width)
                     comp = self.config.property_package.get_component(j)
                     if comp.is_solute:
-                        sf *= 1e2  # solute typically has mass transfer 2 orders magnitude less than flow
-                    iscale.set_scaling_factor(v, sf)
+                        sf *= 1e-1  # solute typically has mass transfer 2 orders magnitude less than flow
+                    iscale.set_scaling_factor(v, sf/100.)
 
         for (t, x, p, j), v in self.mass_transfer_phase_comp.items():
             if iscale.get_scaling_factor(v) is None:

--- a/watertap/unit_models/tests/test_nanofiltration_0D.py
+++ b/watertap/unit_models/tests/test_nanofiltration_0D.py
@@ -39,7 +39,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver()
+solver = get_solver(options={'bound_push':1e-10})
 
 class TestNanoFiltration():
     @pytest.fixture(scope="class")
@@ -188,7 +188,6 @@ class TestNanoFiltration():
     @pytest.mark.component
     def test_solve(self, NF_frame):
         m = NF_frame
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution

--- a/watertap/unit_models/tests/test_nanofiltration_0D.py
+++ b/watertap/unit_models/tests/test_nanofiltration_0D.py
@@ -39,7 +39,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-10})
+solver = get_solver(options={'bound_push':1e-8})
 
 class TestNanoFiltration():
     @pytest.fixture(scope="class")

--- a/watertap/unit_models/tests/test_pressure_exchanger.py
+++ b/watertap/unit_models/tests/test_pressure_exchanger.py
@@ -43,7 +43,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver()
+solver = get_solver(options={'bound_push':1e-10})
 
 
 # # -----------------------------------------------------------------------------
@@ -168,7 +168,6 @@ class TestPressureExchanger():
         m.fs.unit.high_pressure_side.properties_in[0].temperature.fix(temperature)
 
         # solve inlet conditions and only fix state variables (i.e. unfix flow_vol and mass_frac_phase)
-        solver.options['nlp_scaling_method'] = 'user-scaling'
         results = solver.solve(m.fs.unit.low_pressure_side.properties_in[0])
         assert results.solver.termination_condition == TerminationCondition.optimal
         m.fs.unit.low_pressure_side.properties_in[0].flow_mass_phase_comp['Liq', 'TDS'].fix()
@@ -207,7 +206,7 @@ class TestPressureExchanger():
     def test_initialize(self, unit_frame):
         m = unit_frame
         kwargs = {'solver': 'ipopt',
-                  'optarg': {'nlp_scaling_method': 'user-scaling'}}
+                  'optarg': {'bound_push': 1e-10}}
         initialization_tester(unit_frame, **kwargs)
 
 
@@ -220,7 +219,6 @@ class TestPressureExchanger():
     @pytest.mark.component
     def test_solve(self, unit_frame):
         m = unit_frame
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution

--- a/watertap/unit_models/tests/test_pressure_exchanger.py
+++ b/watertap/unit_models/tests/test_pressure_exchanger.py
@@ -43,7 +43,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-10})
+solver = get_solver(options={'bound_push':1e-8})
 
 
 # # -----------------------------------------------------------------------------
@@ -206,7 +206,7 @@ class TestPressureExchanger():
     def test_initialize(self, unit_frame):
         m = unit_frame
         kwargs = {'solver': 'ipopt',
-                  'optarg': {'bound_push': 1e-10}}
+                  'optarg': {'bound_push': 1e-8}}
         initialization_tester(unit_frame, **kwargs)
 
 

--- a/watertap/unit_models/tests/test_pump_isothermal.py
+++ b/watertap/unit_models/tests/test_pump_isothermal.py
@@ -34,7 +34,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-10})
+solver = get_solver(options={'bound_push':1e-8})
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/unit_models/tests/test_pump_isothermal.py
+++ b/watertap/unit_models/tests/test_pump_isothermal.py
@@ -34,7 +34,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver()
+solver = get_solver(options={'bound_push':1e-10})
 
 
 # -----------------------------------------------------------------------------
@@ -129,7 +129,6 @@ class TestPumpIsothermal():
     @pytest.mark.component
     def test_solve(self, Pump_frame):
         m = Pump_frame
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution

--- a/watertap/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_0D.py
@@ -45,7 +45,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-10})
+solver = get_solver(options={'bound_push':1e-6})
 
 # -----------------------------------------------------------------------------
 @pytest.mark.unit

--- a/watertap/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_0D.py
@@ -45,7 +45,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver()
+solver = get_solver(options={'bound_push':1e-10})
 
 # -----------------------------------------------------------------------------
 @pytest.mark.unit
@@ -231,11 +231,11 @@ class TestReverseOsmosis():
                                'recovery_vol_phase': Var,
                                'recovery_mass_phase_comp': Var,
                                'rejection_phase_comp': Var,
-                               'over_pressure_ratio': Var,
                                'deltaP': Var,
                                'cp_modulus': Var,
                                'mass_transfer_phase_comp': Var,
                                'flux_mass_phase_comp_avg': Expression,
+                               'over_pressure_ratio': Expression,
                                'eq_mass_transfer_term': Constraint,
                                'eq_permeate_production': Constraint,
                                'eq_flux_io': Constraint,
@@ -245,7 +245,7 @@ class TestReverseOsmosis():
                                'eq_recovery_vol_phase': Constraint,
                                'eq_recovery_mass_phase_comp': Constraint,
                                'eq_rejection_phase_comp': Constraint,
-                               'eq_over_pressure_ratio': Constraint}
+                               }
         for (obj_str, obj_type) in unit_objs_type_dict.items():
             obj = getattr(m.fs.unit, obj_str)
             assert isinstance(obj, obj_type)
@@ -289,8 +289,8 @@ class TestReverseOsmosis():
             assert isinstance(obj, obj_type)
 
         # test statistics
-        assert number_variables(m) == 125
-        assert number_total_constraints(m) == 97
+        assert number_variables(m) == 124
+        assert number_total_constraints(m) == 96
         assert number_unused_variables(m) == 7  # vars from property package parameters
 
     @pytest.mark.unit
@@ -331,7 +331,6 @@ class TestReverseOsmosis():
     @pytest.mark.component
     def test_solve(self, RO_frame):
         m = RO_frame
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -424,8 +423,8 @@ class TestReverseOsmosis():
         m.fs.unit.Kf_io[0, 'out', 'NaCl'].fix(kf)
 
         # test statistics
-        assert number_variables(m) == 126
-        assert number_total_constraints(m) == 97
+        assert number_variables(m) == 125
+        assert number_total_constraints(m) == 96
         assert number_unused_variables(m) == 7  # vars from property package parameters
 
         # test degrees of freedom
@@ -458,7 +457,6 @@ class TestReverseOsmosis():
         assert badly_scaled_var_lst == []
 
         # test solve
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -526,8 +524,8 @@ class TestReverseOsmosis():
         m.fs.unit.length.fix(length)
 
         # test statistics
-        assert number_variables(m) == 141
-        assert number_total_constraints(m) == 111
+        assert number_variables(m) == 140
+        assert number_total_constraints(m) == 110
         assert number_unused_variables(m) == 0  # vars from property package parameters
 
         # test degrees of freedom
@@ -556,7 +554,6 @@ class TestReverseOsmosis():
         assert badly_scaled_var_lst == []
 
         # test solve
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m, tee=True)
 
         # Check for optimal solution
@@ -622,8 +619,8 @@ class TestReverseOsmosis():
         m.fs.unit.length.fix(16)
 
         # test statistics
-        assert number_variables(m) == 147
-        assert number_total_constraints(m) == 118
+        assert number_variables(m) == 146
+        assert number_total_constraints(m) == 117
         assert number_unused_variables(m) == 0  # vars from property package parameters
 
         # test degrees of freedom
@@ -652,7 +649,6 @@ class TestReverseOsmosis():
         assert badly_scaled_var_lst == []
 
         # test solve
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m, tee=True)
 
         # Check for optimal solution
@@ -726,8 +722,8 @@ class TestReverseOsmosis():
         m.fs.unit.dP_dx.fix(-membrane_pressure_drop / length)
 
         # test statistics
-        assert number_variables(m) == 142
-        assert number_total_constraints(m) == 112
+        assert number_variables(m) == 141
+        assert number_total_constraints(m) == 111
         assert number_unused_variables(m) == 0
 
         # test degrees of freedom
@@ -756,7 +752,6 @@ class TestReverseOsmosis():
         assert badly_scaled_var_lst == []
 
         # test solve
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m, tee=True)
 
         # Check for optimal solution

--- a/watertap/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_0D.py
@@ -45,7 +45,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-6})
+solver = get_solver(options={'bound_push':1e-8})
 
 # -----------------------------------------------------------------------------
 @pytest.mark.unit

--- a/watertap/unit_models/tests/test_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_1D.py
@@ -49,7 +49,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver()
+solver = get_solver(options={'bound_push':1e-6})
 # -----------------------------------------------------------------------------
 @pytest.mark.unit
 def test_config():
@@ -323,10 +323,7 @@ class TestReverseOsmosis():
         m = RO_frame
 
         m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e1, index=('Liq', 'H2O'))
-        m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e4, index=('Liq', 'NaCl'))
-
-        set_scaling_factor(m.fs.unit.permeate_side[0, 0].flow_mass_phase_comp['Liq', 'H2O'], 0)
-        set_scaling_factor(m.fs.unit.permeate_side[0, 0].flow_mass_phase_comp['Liq', 'NaCl'], 0)
+        m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e3, index=('Liq', 'NaCl'))
 
         for x in m.fs.unit.feed_side.length_domain:
             set_scaling_factor(m.fs.unit.mass_transfer_phase_comp[0, x, 'Liq', 'NaCl'], 1e3)
@@ -354,7 +351,6 @@ class TestReverseOsmosis():
     def test_solve(self, RO_frame):
         m = RO_frame
 
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -517,7 +513,6 @@ class TestReverseOsmosis():
         assert badly_scaled_var_lst == []
 
         # Solve
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -667,7 +662,6 @@ class TestReverseOsmosis():
         assert badly_scaled_var_lst == []
 
         # Solve
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -813,7 +807,6 @@ class TestReverseOsmosis():
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
 
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -974,7 +967,6 @@ class TestReverseOsmosis():
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
 
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -1140,7 +1132,6 @@ class TestReverseOsmosis():
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
 
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution
@@ -1306,7 +1297,6 @@ class TestReverseOsmosis():
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
 
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
         results = solver.solve(m)
 
         # Check for optimal solution

--- a/watertap/unit_models/tests/test_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_1D.py
@@ -49,7 +49,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-6})
+solver = get_solver(options={'bound_push':1e-8})
 # -----------------------------------------------------------------------------
 @pytest.mark.unit
 def test_config():


### PR DESCRIPTION
## Fixes/Addresses:
Makes various tweaks to both the RO unit models and NaCl Property Package to enable gradient-based scaling to be used with these models. The scaling changes we made such that Jacobians had reasonable condition numbers (`< 1e6`) when applying gradient-scaling.

## Summary/Motivation:
Ensure WaterTAP unit models are broadly compatible with the larger universe of IDAES models, including chemistry models.

## Changes proposed in this PR:
1. Constraint scaling tweaks to 0D & 1D RO models
2. Constraint scaling tweaks to NaCl property package
3. Replace 0DRO `Var` `over_pressure_ratio` with `Expression`
4. Creating new standard ipopt options in unit models, their tests, and basic flowsheet examples for `bound_push = 1e-08`.
5. Changes to flowsheet unit tests due 1 & 4

## Open Questions / For Discussion:
1. Since WaterTAP models can have small bounds, should we be updating `idaes.cfg["ipopt"]["options"]["bound_push"]` when WaterTAP is imported? A value of `1e-08` is needed to initialize the 1DRO model, but a larger global value could be chosen. We can effectively disable IPOPT's bound's pushing by setting `bound_push` small enough, which ensures a model initialized through standard IDAES methods will not have its starting point modified by IPOPT.
2.  In particular, we run into issues with variables with small (`< 1e-6`) lower bounds and no or much larger upper bounds. The bounds push in IPOPT, [described in the paper on p. 20](http://cepac.cheme.cmu.edu/pasilectures/biegler/ipopt.pdf), will push small initial values on variable with a small LB no or large UB to ~`1e-2` with default settings, sometimes destroying a "good" initialization. In tests I observed that pushing a small variable up a single order of magnitude (e.g., from `1e-6` to `1e-5`)  would cause issues for the RO unit model.
3. For an interior point method (like IPOPT) it is important to have an interior starting point. Perhaps the correct thing to do is to write an initializer for WaterTAP / IDAES models which performs bounds pushing with more finesse than IPOPT's `bound_push`/`bound_frac` options, and then disable IPOPT's bounds pushing. 
4. We could avoid the issues in (2) by doing one or several of the following: 
    1. ensuring our models have variable with bounds that are within an order of magnitude
    1. are unbounded if bounds are not really necessary
    1. manually scaling some problematic variables in WaterTAP models to avoid small bounds
    1. or maintaining `user-scaling`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
