### PR TITLE
Add perturbation helper

### DIFF
--- a/watertap/util/initialization.py
+++ b/watertap/util/initialization.py
@@ -17,8 +17,10 @@ This module contains utility functions for initialization of WaterTAP models.
 
 __author__ = "Adam Atia"
 
-from pyomo.environ import check_optimal_termination
+from pyomo.environ import check_optimal_termination, Var
 from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.scaling import get_scaling_factor, __none_left_mult
+from idaes.core.util import get_solver
 import idaes.logger as idaeslog
 
 _log = idaeslog.getLogger(__name__)
@@ -123,3 +125,102 @@ def assert_no_degrees_of_freedom(blk):
 
     """
     check_dof(blk, True)
+
+
+def assert_no_initialization_perturbation(blk, optarg=None, solver=None):
+    """
+    Assert that IPOPT will *not* move the initialization
+
+    Args:
+        blk: Pyomo block
+        optarg: IPOPT options (default=None) (Should be None if solver is specified)
+        solver: Pyomo IPOPT solver instance (default=None) (Should be None if optarg is specified).
+
+    Returns:
+        None
+    """
+    if solver is not None and optarg is not None:
+        raise ValueError("Supply a solver or optarg, not both")
+    if optarg is None:
+        optarg = {}
+    if solver is None:
+        solver = get_solver(options=optarg)
+    if solver.name != 'ipopt':
+        raise ValueError(f"Solver {solver.name} is not supported")
+
+    options = solver.options
+    bound_push = options.get('bound_push', 1e-2)
+    bound_frac = options.get('bound_frac', 1e-2)
+    bound_relax_factor = options.get('bound_relax_factor', 1e-8)
+    user_scaling = (options.get('nlp_scaling_method', 'gradient-based') == 'user-scaling')
+
+    for v, val, result in generate_initialization_perturbation(blk, bound_push, bound_frac, bound_relax_factor, user_scaling):
+        raise ValueError(f"IPOPT will move scaled initial value for variable {v.name} from {val:e} to {result:e}")
+
+
+def print_initialization_perturbation(blk, bound_push=1e-2, bound_frac=1e-2, bound_relax_factor=1e-8, user_scaling=False):
+    """
+    Print the initialization perturbations performed by IPOPT for a given Block
+
+    Args:
+        blk: Pyomo block
+        bound_push: bound_push to evaluate (same as IPOPT option) (default=1e-2)
+        bound_frac: bound_frac to evaluate (same as IPOPT option) (default=1e-2)
+        bound_relax_factor: bound_relax_factor to evaluate (same as IPOPT option) (default=1e-8)
+        user_scaling: If True, the variables are scaled as if `nlp_scaling_method = user-scaling`
+                       is used. (default=False)
+
+    Returns:
+        None
+    """
+    for v, val, result in generate_initialization_perturbation(blk, bound_push, bound_frac, bound_relax_factor, user_scaling):
+        print(f"IPOPT will move scaled initial value for variable {v.name} from {val:e} to {result:e}")
+
+
+def generate_initialization_perturbation(blk, bound_push=1e-2, bound_frac=1e-2, bound_relax_factor=1e-8, user_scaling=False):
+    """
+    Generate the initialization perturbations performed by IPOPT for a given Block
+
+    Args:
+        blk: Pyomo block
+        bound_push: bound_push to evaluate (same as IPOPT option) (default=1e-2)
+        bound_frac: bound_frac to evaluate (same as IPOPT option) (default=1e-2)
+        bound_relax_factor: bound_relax_factor to evaluate (same as IPOPT option) (default=1e-8)
+        user_scaling: If True, the variables are scaled as if `nlp_scaling_method = user-scaling`
+                       is used. (default=False)
+
+    Yields:
+        tuple: (pyo.Var object, current_value, perturbed_value)
+    """
+    kappa1 = bound_push; kappa2 = bound_frac
+    for v in blk.component_data_objects(Var):
+        if v.value is None:
+            _log.warning(f"Variable {v.name} has no initial value")
+            continue
+        if v.fixed:
+            continue
+        if user_scaling:
+            sf = get_scaling_factor(v, default=1.)
+        else:
+            sf = 1.
+        v_lb = __none_left_mult(v.lb,sf)
+        if v_lb is not None:
+            v_lb -= bound_relax_factor*max(1, abs(v_lb))
+        v_value = v.value*sf
+        v_ub = __none_left_mult(v.ub,sf)
+        if v_ub is not None:
+            v_ub += bound_relax_factor*max(1, abs(v_ub))
+        if v_lb is not None:
+            if v_ub is not None:
+                pl = min( kappa1*max(1, abs(v_lb)), kappa2*(v_ub - v_lb) )
+            else:
+                pl = kappa1*max(1, abs(v_lb))
+            if v_value < v_lb + pl:
+                yield (v, v_value, v_lb+pl)
+        if v_ub is not None:
+            if v_lb is not None:
+                pu = min( kappa1*max(1, abs(v_ub)), kappa2*(v_ub - v_lb) )
+            else:
+                pu = kappa1*max(1, abs(v_ub))
+            if v_value > v_ub - pu:
+                yield (v, v_value, v_ub-pu)

--- a/watertap/util/tests/test_initialization.py
+++ b/watertap/util/tests/test_initialization.py
@@ -13,14 +13,13 @@
 
 import pytest
 
-from pyomo.environ import ConcreteModel, Var, Constraint
+from pyomo.environ import ConcreteModel, Var, Constraint, Block, SolverFactory
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 import idaes.logger as idaeslog
 
-from watertap.util.initialization import (check_solve, check_dof,
-        assert_no_degrees_of_freedom, assert_degrees_of_freedom)
+from watertap.util.initialization import *
 
 __author__ = "Adam Atia"
 
@@ -123,3 +122,100 @@ class TestCheckSolve:
         check_solve(results, logger=_log, fail_flag=True)
 
         m.acon.activate()
+
+
+class TestPerturbationHelper:
+    @pytest.fixture(scope="class")
+    def b(self):
+        b = Block(concrete=True)
+        b.x = Var(bounds=(1e-8, None), initialize=1e-7)
+        b.y = Var(bounds=(1e+1, 1e+2), initialize=1e+3)
+
+        b.z = Var(bounds=(0., 1e-8), initialize=1e-20)
+        b.z.fix()
+
+        b.w = Var(bounds=(None, 1), initialize=0.5)
+
+        return b
+
+    @pytest.mark.unit
+    def test_generate_initialization_perturbation(self, b):
+        r = list(generate_initialization_perturbation(b))
+        assert r[0][0].name == 'x'
+        assert r[1][0].name == 'y'
+
+        assert r[0][1] == 1e-7
+        assert r[1][1] == 1e+3
+
+        assert r[0][2] == 1e-2
+        assert r[1][2] == 99.100000989
+
+        r = list(generate_initialization_perturbation(b, bound_relax_factor=0.))
+        assert r[0][0].name == 'x'
+        assert r[1][0].name == 'y'
+
+        assert r[0][2] == 1.000001e-2
+        assert r[1][2] == 99.1
+
+        r = list(generate_initialization_perturbation(b, bound_relax_factor=0., bound_frac=1e-3))
+        assert r[0][0].name == 'x'
+        assert r[1][0].name == 'y'
+
+        assert r[0][2] == 1.000001e-2
+        assert r[1][2] == 99.91
+
+        r = list(generate_initialization_perturbation(b, bound_relax_factor=0., bound_frac=1e-3, bound_push=1e-3))
+        assert r[0][0].name == 'x'
+        assert r[1][0].name == 'y'
+
+        assert r[0][2] == 1.00001e-3
+        assert r[1][2] == 99.91
+
+        r = list(generate_initialization_perturbation(b, bound_relax_factor=0., bound_frac=1e-3, bound_push=1e-10))
+        assert r[0][0].name == 'y'
+        assert r[0][2] == 100.-1e-8
+
+        r = list(generate_initialization_perturbation(b, bound_push=1e-6))
+        assert r[0][0].name == 'x'
+        assert r[1][0].name == 'y'
+
+        assert r[0][2] == 1.e-6
+        assert r[1][2] == 99.999900999999
+
+    @pytest.mark.unit
+    def test_print_initialization_perturbation(self, b, capsys):
+        print_initialization_perturbation(b, 1e-2, 1e-2, 1e-8, True)
+        captured = capsys.readouterr()
+        assert captured.out == \
+"""IPOPT will move scaled initial value for variable x from 1.000000e-07 to 1.000000e-02
+IPOPT will move scaled initial value for variable y from 1.000000e+03 to 9.910000e+01
+"""
+
+    @pytest.mark.unit
+    def test_assert_no_initialization_perturbation1(self, b):
+        with pytest.raises(ValueError, match=\
+                "IPOPT will move scaled initial value for variable x from 1.000000e-07 to 1.000000e-02"):
+            assert_no_initialization_perturbation(b)
+
+    @pytest.mark.unit
+    def test_assert_no_initialization_perturbation2(self, b):
+        optarg = {'bound_push' : 1e-10}
+        b.y.value = 5e+1
+        assert_no_initialization_perturbation(b, optarg=optarg)
+
+    @pytest.mark.unit
+    def test_assert_no_initialization_perturbation3(self, b):
+        solver = get_solver()
+        solver.options['bound_push'] = 1e-10
+        b.y.value = 5e+1
+        assert_no_initialization_perturbation(b, solver=solver)
+
+    @pytest.mark.unit
+    def test_assert_no_initialization_perturbation4(self, b):
+        with pytest.raises(ValueError, match="Supply a solver or optarg, not both"):
+            assert_no_initialization_perturbation(b, solver=b, optarg=b)
+
+    @pytest.mark.unit
+    def test_assert_no_initialization_perturbation5(self, b):
+        with pytest.raises(ValueError, match="Solver cbc is not supported"):
+            assert_no_initialization_perturbation(b, solver=SolverFactory('cbc'))


### PR DESCRIPTION
## Fixes/Addresses:
Adds a perturbation helper to utils.infeasible.

## Summary/Motivation:
Recent experience with #237 suggests we could use a tool to help tell us when IPOPT will change the initial values.

## Changes proposed in this PR:
- Add generator `generate_initialization_perturbation` and helper functions `print_initialization_perturbation` and `assert_no_initialization_perturbation`
- Tests for the new functionality

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
