### PR TITLE
Adding leaky isobaric pressure exchanger to unit models

### DIFF
--- a/watertap/unit_models/leaky_pressure_exchanger.py
+++ b/watertap/unit_models/leaky_pressure_exchanger.py
@@ -147,7 +147,7 @@ class PressureExchangerData(UnitModelBlockData):
             bounds=(1e-6, 1),
             domain=NonNegativeReals,
             units=pyunits.dimensionless,
-            doc='Pressure exchanger salt leakage')
+            doc='Pressure exchanger solute leakage')
 
         self.solvent_leakage_fraction = Var(
             self.flowsheet().config.time,
@@ -155,7 +155,7 @@ class PressureExchangerData(UnitModelBlockData):
             bounds=(1e-6, 1),
             domain=NonNegativeReals,
             units=pyunits.dimensionless,
-            doc='Pressure exchanger salt leakage')
+            doc='Pressure exchanger solvent leakage')
         # Build control volume for high pressure side
         self.high_pressure_side = ControlVolume0DBlock(default={
             "dynamic": False,

--- a/watertap/unit_models/leaky_pressure_exchanger.py
+++ b/watertap/unit_models/leaky_pressure_exchanger.py
@@ -186,7 +186,7 @@ class PressureExchangerData(UnitModelBlockData):
             self.flowsheet().config.time,
             self.config.property_package.phase_list,
             self.config.property_package.component_list,
-            doc='mass transferred to low pressure side')
+            doc='Mass transfered on high pressure side')
         def mass_transfer(b, t, p, j):
             return b.properties_in[t].flow_mass_phase_comp[p,j]-b.properties_out[t].flow_mass_phase_comp[p,j]
 
@@ -220,7 +220,7 @@ class PressureExchangerData(UnitModelBlockData):
             self.flowsheet().config.time,
             self.config.property_package.phase_list,
             self.config.property_package.component_list,
-            doc='mass transferred to low pressure side (will be negative, gained mass)')
+            doc='Mass transfered on low pressure side (will be negative, gained mass)')
         def mass_transfer(b, t, p, j):
             return b.properties_in[t].flow_mass_phase_comp[p,j]-b.properties_out[t].flow_mass_phase_comp[p,j]
 
@@ -250,7 +250,7 @@ class PressureExchangerData(UnitModelBlockData):
             self.config.property_package.phase_list,
             self.config.property_package.component_list,
             doc="mass leak from HP inlet to LP outlet")
-        def eq_mass_transfer_from_high_to_low_pressure(b, t, p, j):
+        def eq_mass_transfer_from_high_to_low_pressure_outlet(b, t, p, j):
             comp = self.config.property_package.get_component(j)
             if comp.is_solvent():
                 return (b.low_pressure_side.properties_out[t].flow_mass_phase_comp[p,j]==\
@@ -261,13 +261,13 @@ class PressureExchangerData(UnitModelBlockData):
                 b.high_pressure_side.properties_in[t].flow_mass_phase_comp[p,j]*b.solute_leakage_fraction[t]+
                 b.low_pressure_side.properties_in[t].flow_mass_phase_comp[p,j])
 
-        ### this constraint (eq_mass_high_pressure_outlet) might not be needed###
+        ### this constraint (eq_mass_balance_high_pressure_outlet) might not be needed###
         @self.Constraint(
             self.flowsheet().config.time,
             self.config.property_package.phase_list,
             self.config.property_package.component_list,
             doc="mass loss from HP inlet propagation to HP outlet")
-        def eq_mass_high_pressure_outlet(b, t, p, j):
+        def eq_mass_balance_high_pressure_outlet(b, t, p, j):
             comp = self.config.property_package.get_component(j)
             if comp.is_solvent():
                 return (b.high_pressure_side.properties_out[t].flow_mass_phase_comp[p,j]==\
@@ -456,12 +456,12 @@ class PressureExchangerData(UnitModelBlockData):
             sf = iscale.get_scaling_factor(self.low_pressure_side.properties_in[t].pressure)
             iscale.constraint_scaling_transform(c, sf)
 
-        for (t,p,j), c in self.eq_mass_transfer_from_high_to_low_pressure.items():
+        for (t,p,j), c in self.eq_mass_transfer_from_high_to_low_pressure_outlet.items():
             sf = iscale.get_scaling_factor(self.high_pressure_side.properties_in[t].flow_mass_phase_comp[p,j])
             sf = sf*iscale.get_scaling_factor(self.low_pressure_side.properties_in[t].flow_mass_phase_comp[p,j])
             iscale.constraint_scaling_transform(c, sf)
 
-        for (t,p,j), c in self.eq_mass_high_pressure_outlet.items():
+        for (t,p,j), c in self.eq_mass_balance_high_pressure_outlet.items():
             sf = iscale.get_scaling_factor(self.high_pressure_side.properties_in[t].flow_mass_phase_comp[p,j])
             iscale.constraint_scaling_transform(c, sf)
 

--- a/watertap/unit_models/leaky_pressure_exchanger.py
+++ b/watertap/unit_models/leaky_pressure_exchanger.py
@@ -1,0 +1,460 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+
+# Import Pyomo libraries
+from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.environ import (Block,
+                           Var,
+                           Suffix,
+                           NonNegativeReals,
+                           Reals,
+                           value,
+                           units as pyunits)
+
+# Import IDAES cores
+import idaes.logger as idaeslog
+from idaes.core import (ControlVolume0DBlock,
+                        declare_process_block_class,
+                        MaterialBalanceType,
+                        EnergyBalanceType,
+                        MomentumBalanceType,
+                        UnitModelBlockData,
+                        useDefault)
+from idaes.core.util import get_solver
+from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.initialization import revert_state_vars
+from idaes.core.util.tables import create_stream_table_dataframe
+import idaes.core.util.scaling as iscale
+
+_log = idaeslog.getLogger(__name__)
+
+@declare_process_block_class("LeakyPressureExchanger")
+class PressureExchangerData(UnitModelBlockData):
+    """
+    Standard Pressure Exchanger Unit Model Class:
+    - steady state only
+    """
+    CONFIG = ConfigBlock()
+
+    CONFIG.declare("dynamic", ConfigValue(
+        domain=In([False]),
+        default=False,
+        description="Dynamic model flag - must be False",
+        doc="""Indicates whether this model will be dynamic or not,
+    **default** = False. Pressure exchangers do not support dynamic behavior."""))
+    CONFIG.declare("has_holdup", ConfigValue(
+        default=False,
+        domain=In([False]),
+        description="Holdup construction flag - must be False",
+        doc="""Indicates whether holdup terms should be constructed or not.
+    **default** - False. Pressure exchangers do not have defined volume, thus
+    this must be False."""))
+    CONFIG.declare("material_balance_type", ConfigValue(
+        default=MaterialBalanceType.useDefault,
+        domain=In(MaterialBalanceType),
+        description="Material balance construction flag",
+        doc="""Indicates what type of mass balance should be constructed,
+    **default** - MaterialBalanceType.useDefault.
+    **Valid values:** {
+    **MaterialBalanceType.useDefault - refer to property package for default
+    balance type
+    **MaterialBalanceType.none** - exclude material balances,
+    **MaterialBalanceType.componentPhase** - use phase component balances,
+    **MaterialBalanceType.componentTotal** - use total component balances,
+    **MaterialBalanceType.elementTotal** - use total element balances,
+    **MaterialBalanceType.total** - use total material balance.}"""))
+    CONFIG.declare("energy_balance_type", ConfigValue(
+        default=EnergyBalanceType.useDefault,
+        domain=In(EnergyBalanceType),
+        description="Energy balance construction flag",
+        doc="""Indicates what type of energy balance should be constructed,
+    **default** - EnergyBalanceType.useDefault.
+    **Valid values:** {
+    **EnergyBalanceType.useDefault - refer to property package for default
+    balance type
+    **EnergyBalanceType.none** - exclude energy balances,
+    **EnergyBalanceType.enthalpyTotal** - single enthalpy balance for material,
+    **EnergyBalanceType.enthalpyPhase** - enthalpy balances for each phase,
+    **EnergyBalanceType.energyTotal** - single energy balance for material,
+    **EnergyBalanceType.energyPhase** - energy balances for each phase.}"""))
+    CONFIG.declare("momentum_balance_type", ConfigValue(
+        default=MomentumBalanceType.pressureTotal,
+        domain=In(MomentumBalanceType),
+        description="Momentum balance construction flag",
+        doc="""Indicates what type of momentum balance should be constructed,
+    **default** - MomentumBalanceType.pressureTotal.
+    **Valid values:** {
+    **MomentumBalanceType.none** - exclude momentum balances,
+    **MomentumBalanceType.pressureTotal** - single pressure balance for material,
+    **MomentumBalanceType.pressurePhase** - pressure balances for each phase,
+    **MomentumBalanceType.momentumTotal** - single momentum balance for material,
+    **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
+    CONFIG.declare("property_package", ConfigValue(
+        default=useDefault,
+        domain=is_physical_parameter_block,
+        description="Property package to use for control volume",
+        doc="""Property parameter object used to define property calculations,
+        **default** - useDefault.
+        **Valid values:** {
+        **useDefault** - use default package from parent model or flowsheet,
+        **PhysicalParameterObject** - a PhysicalParameterBlock object.}"""))
+    CONFIG.declare("property_package_args", ConfigBlock(
+        implicit=True,
+        description="Arguments to use for constructing property packages",
+        doc="""A ConfigBlock with arguments to be passed to a property block(s)
+        and used when constructing these,
+        **default** - None.
+        **Valid values:** {
+        see property package for documentation.}"""))
+
+    def build(self):
+        super().build()
+
+        # Pressure exchanger supports only liquid phase
+        if self.config.property_package.phase_list != ['Liq']:
+            raise ConfigurationError(
+                "Pressure exchanger model only supports one liquid phase ['Liq'],"
+                "the property package has specified the following phases {}"
+                    .format(self.config.property_package.phase_list))
+
+        self.scaling_factor = Suffix(direction=Suffix.EXPORT)
+
+
+        units_meta = self.config.property_package.get_metadata().get_derived_units
+
+        self.efficiency_pressure_exchanger = Var(
+            self.flowsheet().config.time,
+            initialize=0.95,
+            bounds=(1e-6, 1),
+            domain=NonNegativeReals,
+            units=pyunits.dimensionless,
+            doc='Pressure exchanger efficiency')
+
+        self.solute_leakage_fraction = Var(
+            self.flowsheet().config.time,
+            initialize=0.05,
+            bounds=(1e-6, 1),
+            domain=NonNegativeReals,
+            units=pyunits.dimensionless,
+            doc='Pressure exchanger salt leakage')
+
+        self.solvent_leakage_fraction = Var(
+            self.flowsheet().config.time,
+            initialize=0.05,
+            bounds=(1e-6, 1),
+            domain=NonNegativeReals,
+            units=pyunits.dimensionless,
+            doc='Pressure exchanger salt leakage')
+        # Build control volume for high pressure side
+        self.high_pressure_side = ControlVolume0DBlock(default={
+            "dynamic": False,
+            "has_holdup": False,
+            "property_package": self.config.property_package,
+            "property_package_args": self.config.property_package_args})
+
+        self.high_pressure_side.add_state_blocks(
+            has_phase_equilibrium=False)
+
+        self.high_pressure_side.add_material_balances(
+            balance_type=self.config.material_balance_type,
+            has_mass_transfer=True)
+
+        self.high_pressure_side.add_momentum_balances(
+            balance_type=self.config.momentum_balance_type,
+            has_pressure_change=True)
+
+        self.high_pressure_side.deltaP.setub(0)
+
+        @self.high_pressure_side.Expression(
+            self.flowsheet().config.time,
+            doc='Work transferred to high pressure side fluid (should be negative)')
+        def work(b, t):
+            return b.properties_in[t].flow_vol * b.deltaP[t]
+        # @self.high_pressure_side.Expression(
+        #     self.flowsheet().config.time,
+        #     self.config.property_package.phase_list,
+        #     self.config.property_package.component_list,
+        #     doc='Salt transferred from high pressure side (Should be negative)')
+        # def salt_transfer(b,t,p,j):
+        #     return b.properties_in[t].conc_mass_phase_comp[p,j] * b.salt_leakage_percentage[t]
+        #Build control volume for low pressure side
+        self.low_pressure_side = ControlVolume0DBlock(default={
+            "dynamic": False,
+            "has_holdup": False,
+            "property_package": self.config.property_package,
+            "property_package_args": self.config.property_package_args})
+
+        self.low_pressure_side.add_state_blocks(
+            has_phase_equilibrium=False)
+
+        self.low_pressure_side.add_material_balances(
+            balance_type=self.config.material_balance_type,
+            has_mass_transfer=True)
+
+        self.low_pressure_side.add_momentum_balances(
+            balance_type=self.config.momentum_balance_type,
+            has_pressure_change=True)
+
+        self.low_pressure_side.deltaP.setlb(0)
+
+        @self.low_pressure_side.Expression(
+            self.flowsheet().config.time,
+            doc='Work transferred to low pressure side fluid')
+        def work(b, t):
+            return b.properties_in[t].flow_vol * b.deltaP[t]
+        # @self.high_pressure_side.Expression(
+        #     self.flowsheet().config.time,
+        #     doc='Salt transferred to low pressure side')
+        # def salt_transfer(b):
+        #     return b.high_pressure_side.properties_in[t].conc_mass_phase_comp[p,j] * b.salt_leakage_percentage[t]
+        #Add Ports
+        self.add_inlet_port(name='high_pressure_inlet', block=self.high_pressure_side)
+        self.add_outlet_port(name='high_pressure_outlet', block=self.high_pressure_side)
+        self.add_inlet_port(name='low_pressure_inlet', block=self.low_pressure_side)
+        self.add_outlet_port(name='low_pressure_outlet', block=self.low_pressure_side)
+
+        # Performance equations
+        @self.Constraint(
+            self.flowsheet().config.time,
+            doc="Pressure transfer")
+        def eq_pressure_transfer(b, t):
+            return (b.low_pressure_side.deltaP[t] ==
+                    b.efficiency_pressure_exchanger[t] * -b.high_pressure_side.deltaP[t])
+
+        @self.Constraint(
+            self.flowsheet().config.time,
+            doc="Equal volumetric flow rate")
+        def eq_equal_flow_vol(b, t):
+            return (b.high_pressure_side.properties_in[t].flow_vol ==
+                    b.low_pressure_side.properties_in[t].flow_vol)
+
+        @self.Constraint(
+            self.flowsheet().config.time,
+            self.config.property_package.phase_list,
+            self.config.property_package.component_list,
+            doc="mass leak from HP inlet to LP outlet")
+        def eq_leak_HP_to_LP(b, t, p, j):
+            comp = self.config.property_package.get_component(j)
+            if comp.is_solvent():
+                return (b.low_pressure_side.properties_out[t].flow_mass_phase_comp[p,j]==\
+                b.high_pressure_side.properties_in[t].flow_mass_phase_comp[p,j]*b.solvent_leakage_fraction[t]+
+                b.low_pressure_side.properties_in[t].flow_mass_phase_comp[p,j])
+            if comp.is_solute():
+                return (b.low_pressure_side.properties_out[t].flow_mass_phase_comp[p,j]==\
+                b.high_pressure_side.properties_in[t].flow_mass_phase_comp[p,j]*b.solute_leakage_fraction[t]+
+                b.low_pressure_side.properties_in[t].flow_mass_phase_comp[p,j])
+
+        @self.Constraint(
+            self.flowsheet().config.time,
+            self.config.property_package.phase_list,
+            self.config.property_package.component_list,
+            doc="mass loss from HP inlet propagation to HP outlet")
+        def eq_salt_in_HP(b, t,p, j):
+            comp = self.config.property_package.get_component(j)
+            if comp.is_solvent():
+                return (b.high_pressure_side.properties_out[t].flow_mass_phase_comp[p,j]==\
+                b.high_pressure_side.properties_in[t].flow_mass_phase_comp[p,j]*(1-b.solvent_leakage_fraction[t]))
+            if comp.is_solute():
+                return (b.high_pressure_side.properties_out[t].flow_mass_phase_comp[p,j]==\
+                b.high_pressure_side.properties_in[t].flow_mass_phase_comp[p,j]*(1-b.solute_leakage_fraction[t]))
+
+        @self.Constraint(
+            self.flowsheet().config.time,
+            doc="Equal low pressure on both sides")
+        def eq_equal_low_pressure(b, t):
+            return (b.high_pressure_side.properties_out[t].pressure ==
+                    b.low_pressure_side.properties_in[t].pressure)
+
+        @self.low_pressure_side.Constraint(
+            self.flowsheet().config.time,
+            doc="Isothermal constraint")
+        def eq_isothermal_temperature(b, t):
+            return b.properties_in[t].temperature == b.properties_out[t].temperature
+
+        @self.high_pressure_side.Constraint(
+            self.flowsheet().config.time,
+            doc="Isothermal constraint")
+        def eq_isothermal_temperature(b, t):
+            return b.properties_in[t].temperature == b.properties_out[t].temperature
+
+    def initialize(
+            self,
+            state_args=None,
+            routine=None,
+            outlvl=idaeslog.NOTSET,
+            solver=None,
+            optarg=None):
+        """
+        General wrapper for pressure exchanger initialization routine
+
+        Keyword Arguments:
+            routine : str stating which initialization routine to execute
+                        * None - currently no specialized routine for Pressure exchanger unit
+            state_args : a dict of arguments to be passed to the property
+                         package(s) to provide an initial state for
+                         initialization (see documentation of the specific
+                         property package) (default = {}).
+            outlvl : sets output level of initialization routine (default=idaeslog.NOTSET)
+            optarg : solver options dictionary object, if None provided an empty
+                     dictionary will be used (default=None)
+            solver : solver object or string indicating which solver to use during
+                     initialization, if None provided the default solver will be used
+                     (default = None)
+        Returns: None
+        """
+        # Get loggers
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="properties")
+
+        # Set solver and options
+        opt = get_solver(solver, optarg)
+
+        # initialize inlets
+        flags_low_in = self.low_pressure_side.properties_in.initialize(
+            outlvl=outlvl,
+            optarg=optarg,
+            solver=solver,
+            state_args=state_args,
+            hold_state=True)
+        flags_high_in = self.high_pressure_side.properties_in.initialize(
+            outlvl=outlvl,
+            optarg=optarg,
+            solver=solver,
+            state_args=state_args,
+            hold_state=True)
+        init_log.info_high("Initialize inlets complete")
+
+        # check that inlets are feasible
+        if (value(self.low_pressure_side.properties_in[0].pressure)
+                > value(self.high_pressure_side.properties_in[0].pressure)):
+            raise ConfigurationError(
+                "Initializing pressure exchanger failed because "
+                "the low pressure side inlet has a higher pressure "
+                "than the high pressure side inlet")
+        if (abs(value(self.low_pressure_side.properties_in[0].flow_vol)
+                - value(self.high_pressure_side.properties_in[0].flow_vol))
+                / value(self.high_pressure_side.properties_in[0].flow_vol)
+                > 1e-4):  # flow_vol values are not within 0.1%
+            raise ConfigurationError(
+                "Initializing pressure exchanger failed because "
+                "the volumetric flow rates are not equal for both inlets")
+        else:  # volumetric flow is equal, deactivate flow constraint for the solve
+            self.eq_equal_flow_vol.deactivate()
+
+        # initialize outlets from inlets and update pressure
+        def propogate_state(sb1, sb2):
+            state_dict_1 = sb1.define_state_vars()
+            state_dict_2 = sb2.define_state_vars()
+            for k in state_dict_1.keys():
+                if state_dict_1[k].is_indexed():
+                    for m in state_dict_1[k].keys():
+                        state_dict_2[k][m].value = state_dict_1[k][m].value
+                else:
+                    state_dict_2[k].value = state_dict_1[k].value
+
+        # low pressure side
+        propogate_state(self.low_pressure_side.properties_in[0],
+                        self.low_pressure_side.properties_out[0])
+        self.low_pressure_side.properties_out[0].pressure = (
+                self.low_pressure_side.properties_in[0].pressure.value
+                + self.efficiency_pressure_exchanger[0].value
+                * (self.high_pressure_side.properties_in[0].pressure.value
+                   - self.low_pressure_side.properties_in[0].pressure.value))
+        # high pressure side
+        propogate_state(self.high_pressure_side.properties_in[0],
+                        self.high_pressure_side.properties_out[0])
+        self.high_pressure_side.properties_out[0].pressure.value = \
+            self.low_pressure_side.properties_in[0].pressure.value
+        init_log.info_high("Initialize outlets complete")
+
+        # Solve unit
+        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+            res = opt.solve(self, tee=slc.tee)
+        init_log.info("Initialization complete: {}".format(idaeslog.condition(res)))
+
+        # release state of fixed variables
+        self.low_pressure_side.properties_in.release_state(flags_low_in)
+        self.high_pressure_side.properties_in.release_state(flags_high_in)
+
+        # reactivate volumetric flow constraint
+        self.eq_equal_flow_vol.activate()
+
+    def get_costing(self, module=None):
+        self.costing = Block()
+        module.LeakyPressureExchanger_costing(self.costing)
+
+    def calculate_scaling_factors(self):
+        super().calculate_scaling_factors()
+
+        # scale variables
+        if iscale.get_scaling_factor(self.efficiency_pressure_exchanger) is None:
+            # efficiency should always be between 0.1-1
+            iscale.set_scaling_factor(self.efficiency_pressure_exchanger, 1)
+
+        # scale expressions
+        if iscale.get_scaling_factor(self.low_pressure_side.work) is None:
+            sf = iscale.get_scaling_factor(self.low_pressure_side.properties_in[0].flow_vol)
+            sf = sf * iscale.get_scaling_factor(self.low_pressure_side.deltaP[0])
+            iscale.set_scaling_factor(self.low_pressure_side.work, sf)
+
+        if iscale.get_scaling_factor(self.high_pressure_side.work) is None:
+            sf = iscale.get_scaling_factor(self.high_pressure_side.properties_in[0].flow_vol)
+            sf = sf * iscale.get_scaling_factor(self.high_pressure_side.deltaP[0])
+            iscale.set_scaling_factor(self.high_pressure_side.work, sf)
+
+        # transform constraints
+        for t, c in self.low_pressure_side.eq_isothermal_temperature.items():
+            sf = iscale.get_scaling_factor(self.low_pressure_side.properties_in[t].temperature)
+            iscale.constraint_scaling_transform(c, sf)
+
+        for t, c in self.high_pressure_side.eq_isothermal_temperature.items():
+            sf = iscale.get_scaling_factor(self.high_pressure_side.properties_in[t].temperature)
+            iscale.constraint_scaling_transform(c, sf)
+
+        for t, c in self.eq_pressure_transfer.items():
+            sf = iscale.get_scaling_factor(self.low_pressure_side.deltaP[t])
+            iscale.constraint_scaling_transform(c, sf)
+
+        for t, c in self.eq_equal_flow_vol.items():
+            sf = iscale.get_scaling_factor(self.low_pressure_side.properties_in[t].flow_vol)
+            iscale.constraint_scaling_transform(c, sf)
+
+        for t, c in self.eq_equal_low_pressure.items():
+            sf = iscale.get_scaling_factor(self.low_pressure_side.properties_in[t].pressure)
+            iscale.constraint_scaling_transform(c, sf)
+
+    def _get_stream_table_contents(self, time_point=0):
+        return create_stream_table_dataframe(
+                {
+                    "HP Side In" : self.high_pressure_inlet,
+                    "HP Side Out" : self.high_pressure_outlet,
+                    "LP Side In" : self.low_pressure_inlet,
+                    "LP Side Out" : self.low_pressure_outlet,
+                },
+                time_point=time_point)
+
+    def _get_performance_contents(self, time_point=0):
+        t = time_point
+        return { "vars" : { "Efficiency" : self.efficiency_pressure_exchanger[t],
+                            "HP Side Pressure Change" : self.high_pressure_side.deltaP[t],
+                            "LP Side Pressure Change" : self.low_pressure_side.deltaP[t],
+
+                          },
+                "exprs" : {
+                            "HP Side Mechanical Work" : self.high_pressure_side.work[t],
+                            "LP Side Mechanical Work" : self.low_pressure_side.work[t],
+                          },
+                "params" : {
+                           },
+               }

--- a/watertap/unit_models/tests/test_leaky_pressure_exchanger.py
+++ b/watertap/unit_models/tests/test_leaky_pressure_exchanger.py
@@ -100,8 +100,8 @@ def test_build():
     # test unit constraints
     unit_cons_lst = ['eq_pressure_transfer', \
     'eq_equal_flow_vol', 'eq_equal_low_pressure',\
-    'eq_mass_transfer_from_high_to_low_pressure',
-    'eq_mass_high_pressure_outlet']
+    'eq_mass_transfer_from_high_to_low_pressure_outlet',
+    'eq_mass_balance_high_pressure_outlet']
     for c in unit_cons_lst:
         assert hasattr(m.fs.unit, c)
         con = getattr(m.fs.unit, c)

--- a/watertap/unit_models/tests/test_leaky_pressure_exchanger.py
+++ b/watertap/unit_models/tests/test_leaky_pressure_exchanger.py
@@ -1,0 +1,283 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+import pytest
+from pyomo.environ import (ConcreteModel,
+                           Var,
+                           Expression,
+                           Constraint,
+                           TerminationCondition,
+                           SolverStatus,
+                           value)
+from pyomo.network import Port
+from idaes.core import (FlowsheetBlock,
+                        MaterialBalanceType,
+                        EnergyBalanceType,
+                        MomentumBalanceType)
+from watertap.unit_models.leaky_pressure_exchanger import LeakyPressureExchanger
+import watertap.property_models.seawater_prop_pack as props
+
+from idaes.core.util.model_statistics import (degrees_of_freedom,
+                                              number_variables,
+                                              number_total_constraints,
+                                              fixed_variables_set,
+                                              activated_constraints_set,
+                                              number_unused_variables)
+from idaes.core.util import get_solver
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util.initialization import solve_indexed_blocks
+from idaes.core.util.exceptions import BalanceTypeNotSupportedError
+from idaes.core.util.scaling import (calculate_scaling_factors,
+                                     unscaled_variables_generator,
+                                     unscaled_constraints_generator,
+                                     badly_scaled_var_generator)
+
+# -----------------------------------------------------------------------------
+# Get default solver for testing
+solver = get_solver(options={'bound_push':1e-8})
+
+
+# # -----------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_config():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={'dynamic': False})
+    m.fs.properties = props.SeawaterParameterBlock()
+    m.fs.unit = LeakyPressureExchanger(default={'property_package': m.fs.properties})
+
+    # check unit config arguments
+    assert len(m.fs.unit.config) == 7
+
+    assert not m.fs.unit.config.dynamic
+    assert not m.fs.unit.config.has_holdup
+    assert m.fs.unit.config.material_balance_type == \
+           MaterialBalanceType.useDefault
+    assert m.fs.unit.config.energy_balance_type == \
+           EnergyBalanceType.useDefault
+    assert m.fs.unit.config.momentum_balance_type == \
+           MomentumBalanceType.pressureTotal
+    assert m.fs.unit.config.property_package is m.fs.properties
+
+@pytest.mark.unit
+def test_build():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={'dynamic': False})
+    m.fs.properties = props.SeawaterParameterBlock()
+    m.fs.unit = LeakyPressureExchanger(default={'property_package': m.fs.properties})
+
+    # test ports and state variables
+    port_lst = ['low_pressure_inlet', 'low_pressure_outlet',
+                'high_pressure_inlet', 'high_pressure_outlet']
+    port_vars_lst = ['flow_mass_phase_comp', 'pressure', 'temperature']
+    for port_str in port_lst:
+        assert hasattr(m.fs.unit, port_str)
+        port = getattr(m.fs.unit, port_str)
+        assert len(port.vars) == 3
+        assert isinstance(port, Port)
+        for var_str in port_vars_lst:
+            assert hasattr(port, var_str)
+            var = getattr(port, var_str)
+            assert isinstance(var, Var)
+
+    # test unit variables
+    assert hasattr(m.fs.unit, 'efficiency_pressure_exchanger')
+    assert isinstance(m.fs.unit.efficiency_pressure_exchanger, Var)
+    assert hasattr(m.fs.unit, 'solute_leakage_fraction')
+    assert isinstance(m.fs.unit.solute_leakage_fraction, Var)
+    assert hasattr(m.fs.unit, 'solvent_leakage_fraction')
+    assert isinstance(m.fs.unit.solvent_leakage_fraction, Var)
+
+    # test unit constraints
+    unit_cons_lst = ['eq_pressure_transfer', \
+    'eq_equal_flow_vol', 'eq_equal_low_pressure',\
+    'eq_mass_transfer_from_high_to_low_pressure',
+    'eq_mass_high_pressure_outlet']
+    for c in unit_cons_lst:
+        assert hasattr(m.fs.unit, c)
+        con = getattr(m.fs.unit, c)
+        assert isinstance(con, Constraint)
+
+    # test control volumes, only terms directly used by pressure exchanger
+    cv_list = ['low_pressure_side', 'high_pressure_side']
+    cv_var_lst = ['deltaP']
+    cv_con_lst = ['eq_isothermal_temperature']
+    cv_exp_lst = ['work','mass_transfer']
+    for cv_str in cv_list:
+        assert hasattr(m.fs.unit, cv_str)
+        cv = getattr(m.fs.unit, cv_str)
+        for cv_var_str in cv_var_lst:
+            cv_var = getattr(cv, cv_var_str)
+            assert isinstance(cv_var, Var)
+        for cv_con_str in cv_con_lst:
+            cv_con = getattr(cv, cv_con_str)
+            assert isinstance(cv_con, Constraint)
+        for cv_exp_str in cv_exp_lst:
+            cv_exp = getattr(cv, cv_exp_str)
+            assert isinstance(cv_exp, Expression)
+
+    # test state blocks, only terms directly used by pressure exchanger
+    cv_stateblock_lst = ['properties_in', 'properties_out']
+    stateblock_var_lst = ['pressure', 'temperature']
+    stateblock_exp_lst = ['flow_vol']
+    for cv_str in cv_list:
+        cv = getattr(m.fs.unit, cv_str)
+        for cv_sb_str in cv_stateblock_lst:
+            assert hasattr(cv, cv_sb_str)
+            cv_sb = getattr(cv, cv_sb_str)
+            for sb_var_str in stateblock_var_lst:
+                assert hasattr(cv_sb[0], sb_var_str)
+                sb_var = getattr(cv_sb[0], sb_var_str)
+                assert isinstance(sb_var, Var)
+            for sb_exp_str in stateblock_exp_lst:
+                assert hasattr(cv_sb[0], sb_exp_str)
+                sb_exp = getattr(cv_sb[0], sb_exp_str)
+                assert isinstance(sb_exp, Expression)
+
+    # test statistics
+    assert number_variables(m.fs.unit) == 45
+    assert number_total_constraints(m.fs.unit) == 35
+    assert number_unused_variables(m.fs.unit) == 0
+
+class TestPressureExchanger():
+    @pytest.fixture(scope="class")
+    def unit_frame(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(default={'dynamic': False})
+        m.fs.properties = props.SeawaterParameterBlock()
+        m.fs.unit = LeakyPressureExchanger(default={'property_package': m.fs.properties})
+
+
+        # Specify inlet conditions
+        temperature = 25 + 273.15
+        flow_vol = 1e-3
+        lowP_mass_frac_TDS = 0.035
+        lowP_pressure = 101325
+        highP_mass_frac_TDS = 0.07
+        highP_pressure = 50e5
+
+
+        m.fs.unit.low_pressure_side.properties_in[0].flow_vol_phase['Liq'].fix(flow_vol)
+        m.fs.unit.low_pressure_side.properties_in[0].mass_frac_phase_comp['Liq', 'TDS'].fix(lowP_mass_frac_TDS)
+        m.fs.unit.low_pressure_side.properties_in[0].pressure.fix(lowP_pressure)
+        m.fs.unit.low_pressure_side.properties_in[0].temperature.fix(temperature)
+
+        m.fs.unit.high_pressure_side.properties_in[0].flow_vol_phase['Liq'].fix(flow_vol)
+        m.fs.unit.high_pressure_side.properties_in[0].mass_frac_phase_comp['Liq', 'TDS'].fix(highP_mass_frac_TDS)
+        m.fs.unit.high_pressure_side.properties_in[0].pressure.fix(highP_pressure)
+        m.fs.unit.high_pressure_side.properties_in[0].temperature.fix(temperature)
+
+        # solve inlet conditions and only fix state variables (i.e. unfix flow_vol and mass_frac_phase)
+        results = solver.solve(m.fs.unit.low_pressure_side.properties_in[0])
+        assert results.solver.termination_condition == TerminationCondition.optimal
+        m.fs.unit.low_pressure_side.properties_in[0].flow_mass_phase_comp['Liq', 'TDS'].fix()
+        m.fs.unit.low_pressure_side.properties_in[0].flow_vol_phase['Liq'].unfix()
+        m.fs.unit.low_pressure_side.properties_in[0].mass_frac_phase_comp['Liq', 'TDS'].unfix()
+
+        results = solver.solve(m.fs.unit.high_pressure_side.properties_in[0])
+        assert results.solver.termination_condition == TerminationCondition.optimal
+        m.fs.unit.high_pressure_side.properties_in[0].flow_mass_phase_comp['Liq', 'H2O'].fix()
+        m.fs.unit.high_pressure_side.properties_in[0].flow_mass_phase_comp['Liq', 'TDS'].fix()
+        m.fs.unit.high_pressure_side.properties_in[0].flow_vol_phase['Liq'].unfix()
+        m.fs.unit.high_pressure_side.properties_in[0].mass_frac_phase_comp['Liq', 'TDS'].unfix()
+
+        # Specify unit
+        efficiency = 0.95
+        solute_leakage_fraction=0.05
+        solvent_leakage_fraction=0.1
+        m.fs.unit.efficiency_pressure_exchanger.fix(efficiency)
+        m.fs.unit.solute_leakage_fraction.fix(solute_leakage_fraction)
+        m.fs.unit.solvent_leakage_fraction.fix(solvent_leakage_fraction)
+        return m
+
+    @pytest.mark.unit
+    def test_dof(self, unit_frame):
+        assert degrees_of_freedom(unit_frame) == 0
+
+    @pytest.mark.unit
+    def test_calculate_scaling(self, unit_frame):
+        m = unit_frame
+        calculate_scaling_factors(m)
+
+        # check that all variables have scaling factors
+        unscaled_var_list = list(unscaled_variables_generator(m.fs.unit, include_fixed=True))
+        assert len(unscaled_var_list) == 0
+        # check that all constraints have been scaled
+        unscaled_constraint_list = list(unscaled_constraints_generator(m))
+        assert len(unscaled_constraint_list) == 0
+
+    @pytest.mark.component
+    def test_initialize(self, unit_frame):
+        m = unit_frame
+        kwargs = {'solver': 'ipopt',
+                  'optarg': {'bound_push': 1e-8}}
+        initialization_tester(unit_frame, **kwargs)
+
+
+    @pytest.mark.component
+    def test_var_scaling(self, unit_frame):
+        m = unit_frame
+        badly_scaled_var_lst = list(badly_scaled_var_generator(m))
+        assert badly_scaled_var_lst == []
+
+    @pytest.mark.component
+    def test_solve(self, unit_frame):
+        m = unit_frame
+        results = solver.solve(m)
+
+        # Check for optimal solution
+        assert results.solver.termination_condition == \
+               TerminationCondition.optimal
+        assert results.solver.status == SolverStatus.ok
+
+    @pytest.mark.component
+    def test_solution(self, unit_frame):
+        m = unit_frame
+        assert (pytest.approx(0.9877, rel=1e-3) ==
+                value(m.fs.unit.low_pressure_inlet.flow_mass_phase_comp[0, 'Liq', 'H2O']))
+        assert (pytest.approx(3.582e-2, rel=1e-3) ==
+                value(m.fs.unit.low_pressure_inlet.flow_mass_phase_comp[0, 'Liq', 'TDS']))
+        assert (pytest.approx(4.755e6, rel=1e-3) ==
+                value(m.fs.unit.low_pressure_outlet.pressure[0]))
+        assert (pytest.approx(0.9767, rel=1e-3) ==
+                value(m.fs.unit.high_pressure_inlet.flow_mass_phase_comp[0, 'Liq', 'H2O']))
+        assert (pytest.approx(7.352e-2, rel=1e-3) ==
+                value(m.fs.unit.high_pressure_inlet.flow_mass_phase_comp[0, 'Liq', 'TDS']))
+        assert (pytest.approx(4.654e6, rel=1e-3) ==
+                value(m.fs.unit.low_pressure_side.deltaP[0]))
+        assert (pytest.approx(4.654e3, rel=1e-3) ==
+                value(m.fs.unit.low_pressure_side.work[0]))
+        assert (pytest.approx(-4.899e6, rel=1e-3) ==
+                value(m.fs.unit.high_pressure_side.deltaP[0]))
+        assert (pytest.approx(-4.899e3, rel=1e-3) ==
+                value(m.fs.unit.high_pressure_side.work[0]))
+        ### testing mass transport
+        assert (pytest.approx(0.09767, rel=1e-3) ==
+                value(m.fs.unit.high_pressure_side.mass_transfer[0, 'Liq', 'H2O']))
+        assert (pytest.approx(0.003676 , rel=1e-3) ==
+                value(m.fs.unit.high_pressure_side.mass_transfer[0, 'Liq', 'TDS']))
+        assert (pytest.approx(0.09767, rel=1e-3) ==
+                -value(m.fs.unit.low_pressure_side.mass_transfer[0, 'Liq', 'H2O']))
+        assert (pytest.approx(0.003676 , rel=1e-3) ==
+                -value(m.fs.unit.low_pressure_side.mass_transfer[0, 'Liq', 'TDS']))
+        assert (pytest.approx(0.87903, rel=1e-3) ==
+                value(m.fs.unit.high_pressure_outlet.flow_mass_phase_comp[0, 'Liq', 'H2O']))
+        assert (pytest.approx(0.06984, rel=1e-3) ==
+                value(m.fs.unit.high_pressure_outlet.flow_mass_phase_comp[0, 'Liq', 'TDS']))
+        assert (pytest.approx(1.08537, rel=1e-3) ==
+                value(m.fs.unit.low_pressure_outlet.flow_mass_phase_comp[0, 'Liq', 'H2O']))
+        assert (pytest.approx(0.03950, rel=1e-3) ==
+                value(m.fs.unit.low_pressure_outlet.flow_mass_phase_comp[0, 'Liq', 'TDS']))
+
+    @pytest.mark.unit
+    def test_report(self, unit_frame):
+        unit_frame.fs.unit.report()


### PR DESCRIPTION
## Fixes/Addresses:
This adds a modified pressure exchanger unit model that include mass leakage from high pressure to low pressure as would be observed in real isobaric devices.  

## Summary/Motivation:
Real isobaric pressure exchangers have some leakage from high pressure side to low pressure side. 
In piston type pressure exchangers this is a result of imperfect seals allowing for equal passage of salt and water
In direct contact devices, the high pressure fluid directly contacts low pressure fluid in "contact volume cylinder" which results in some mixing of the two fluid, and can lead to unequal rate of salt and liquid passage.  

## Changes proposed in this PR:
This model added two variables to configure solvent and slolute passage to existing model.
The transfer of mass from high pressure side to low pressure side is achieved by two newly added constraints eq_mass_transfer_from_high_to_low_pressure and eq_mass_high_pressure_outlet. 

In eq_mass_transfer_from_high_to_low_pressure constraint the low pressure (LP) outlet phase composition is forced to be equal to sum of LP inlet phase composition + high pressure (HP) inlet phase composition multiplied by solute or solvent leakage factors.  
eq_mass_high_pressure_outlet is a redundant constraint (I think....) but it computes out the HP outlet phase composition, by multiplying the HP inlet phase composition with solute or solvent leakage factors. 

This was tested in an isobaric ro flowsheet (not included in this pull) and does not cause issues.

There is also a test_leaky_pressure_exchanger script that includes a mass balance check (building on the test_pressure_exchanger), which passes the tests.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
