### PR TITLE
Excise bound_push Part 1

### DIFF
--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -43,7 +43,7 @@ import watertap.examples.flowsheets.RO_with_energy_recovery.financials as financ
 
 def main():
     # set up solver
-    solver = get_solver(options={'bound_push': 1e-8})
+    solver = get_solver()
 
     # build, set, and initialize
     m = build()
@@ -150,7 +150,7 @@ def build():
 
 def set_operating_conditions(m, water_recovery=0.5, over_pressure=0.3, solver=None):
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-8})
+        solver = get_solver()
 
     # ---specifications---
     # feed
@@ -255,14 +255,14 @@ def calculate_operating_pressure(feed_state_block=None, over_pressure=0.15,
 
 def solve(blk, solver=None, tee=False):
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-8})
+        solver = get_solver()
     results = solver.solve(blk, tee=tee)
     assert_optimal_termination(results)
 
 
 def initialize_system(m, solver=None):
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-8})
+        solver = get_solver()
     optarg = solver.options
 
     # ---initialize RO---

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -40,7 +40,7 @@ def get_sweep_params(m, use_LHS=False):
 def run_parameter_sweep(results_file, seed=None, use_LHS=False):
 
     # Set up the solver
-    solver = get_solver(options={'bound_push': 1e-8})
+    solver = get_solver()
 
     # Build, set, and initialize the system (these steps will change depending on the underlying model)
     m = build()

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -42,7 +42,7 @@ from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recover
 build, set_operating_conditions, initialize_system, solve, optimize_set_up, optimize, display_system, display_state, display_design)
 
 
-solver = get_solver(options={'bound_push': 1e-8})
+solver = get_solver()
 
 # -----------------------------------------------------------------------------
 class TestEnergyRecoverySystem:

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -340,7 +340,7 @@ def initialize(m, verbose=False, solver=None):
     # ---initializing---
     # set up solvers
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-8})
+        solver = get_solver()
 
     optarg = solver.options
     do_initialization_pass(m, optarg=optarg, guess_mixers=True)
@@ -365,7 +365,7 @@ def initialize(m, verbose=False, solver=None):
 def solve(m, solver=None, tee=False, raise_on_failure=False):
     # ---solving---
     if solver is None:
-        solver = get_solver(options={'bound_push': 1e-8})
+        solver = get_solver()
 
     results = solver.solve(m, tee=tee)
     if check_optimal_termination(results):

--- a/watertap/unit_models/nanofiltration_ZO.py
+++ b/watertap/unit_models/nanofiltration_ZO.py
@@ -378,9 +378,6 @@ class NanofiltrationData(UnitModelBlockData):
         """
         init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
-        # Set solver options
-        if optarg is None:
-            optarg = {'bound_push': 1e-8}
 
         opt = get_solver(solver, optarg)
 

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -618,8 +618,6 @@ class ReverseOsmosisData(_ReverseOsmosisBaseData):
         init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
         # Set solver and options
-        if optarg is None:
-            optarg = {'bound_push': 1e-8}
         opt = get_solver(solver, optarg)
 
         # assumptions

--- a/watertap/unit_models/reverse_osmosis_1D.py
+++ b/watertap/unit_models/reverse_osmosis_1D.py
@@ -722,9 +722,6 @@ class ReverseOsmosis1DData(_ReverseOsmosisBaseData):
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
 
         # Create solver
-        if optarg is None:
-            optarg = {'bound_push': 1e-8}
-
         opt = get_solver(solver, optarg)
 
         init_log.info('Starting Initialization Step 1: initialize blocks.')

--- a/watertap/unit_models/tests/test_nanofiltration_0D.py
+++ b/watertap/unit_models/tests/test_nanofiltration_0D.py
@@ -39,7 +39,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-8})
+solver = get_solver()
 
 class TestNanoFiltration():
     @pytest.fixture(scope="class")

--- a/watertap/unit_models/tests/test_nanofiltration_ZO.py
+++ b/watertap/unit_models/tests/test_nanofiltration_ZO.py
@@ -262,7 +262,6 @@ class TestNanofiltration():
 
         initialization_tester(m)
 
-        solver.options = {'bound_push': 1e-8}
         results = solver.solve(m)
 
         # Check for optimal solution

--- a/watertap/unit_models/tests/test_pressure_exchanger.py
+++ b/watertap/unit_models/tests/test_pressure_exchanger.py
@@ -43,7 +43,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-8})
+solver = get_solver()
 
 
 # # -----------------------------------------------------------------------------
@@ -205,9 +205,7 @@ class TestPressureExchanger():
     @pytest.mark.component
     def test_initialize(self, unit_frame):
         m = unit_frame
-        kwargs = {'solver': 'ipopt',
-                  'optarg': {'bound_push': 1e-8}}
-        initialization_tester(unit_frame, **kwargs)
+        initialization_tester(unit_frame)
 
 
     @pytest.mark.component

--- a/watertap/unit_models/tests/test_pump_isothermal.py
+++ b/watertap/unit_models/tests/test_pump_isothermal.py
@@ -34,7 +34,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-8})
+solver = get_solver()
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_0D.py
@@ -45,7 +45,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-8})
+solver = get_solver()
 
 # -----------------------------------------------------------------------------
 @pytest.mark.unit

--- a/watertap/unit_models/tests/test_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_1D.py
@@ -49,7 +49,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_solver(options={'bound_push':1e-8})
+solver = get_solver()
 # -----------------------------------------------------------------------------
 @pytest.mark.unit
 def test_config():


### PR DESCRIPTION
## Addresses #243 
Part 2/3. Follow-up from #270.

## Summary/Motivation:
Removes `bound_push` Ipopt option from the codebase, *except* in the full_treatment_train directory.

## Changes proposed in this PR:
- Remove `bound_push` from unit model initialization and test
- Remove `bound_push` from example RO w/ ERD and LSRRO flowsheets

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
