### PR TITLE
Correct scaling factors for MW, ``molality_comp`` and ``flow_mol_phase_comp``

### DIFF
--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -672,7 +672,7 @@ class NaClStateBlockData(StateBlockData):
         # scaling factors for parameters
         for j, v in self.params.mw_comp.items():
             if iscale.get_scaling_factor(v) is None:
-                iscale.set_scaling_factor(self.params.mw_comp, 1e-1)
+                iscale.set_scaling_factor(self.params.mw_comp, 1e2)
 
         # these variables do not typically require user input,
         # will not override if the user does provide the scaling factor
@@ -716,7 +716,7 @@ class NaClStateBlockData(StateBlockData):
             for j in self.params.component_list:
                 if iscale.get_scaling_factor(self.flow_mol_phase_comp['Liq', j]) is None:
                     sf = iscale.get_scaling_factor(self.flow_mass_phase_comp['Liq', j])
-                    sf *= iscale.get_scaling_factor(self.params.mw_comp[j])
+                    sf /= iscale.get_scaling_factor(self.params.mw_comp[j])
                     iscale.set_scaling_factor(self.flow_mol_phase_comp['Liq', j], sf)
 
         if self.is_property_constructed('mole_frac_phase_comp'):
@@ -734,7 +734,7 @@ class NaClStateBlockData(StateBlockData):
                 if isinstance(getattr(self.params, j), Solute):
                     if iscale.get_scaling_factor(self.molality_comp[j]) is None:
                         sf = iscale.get_scaling_factor(self.mass_frac_phase_comp['Liq', j])
-                        sf *= iscale.get_scaling_factor(self.params.mw_comp[j])
+                        sf /= iscale.get_scaling_factor(self.params.mw_comp[j])
                         iscale.set_scaling_factor(self.molality_comp[j], sf)
 
         if self.is_property_constructed('enth_flow'):

--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -1022,7 +1022,7 @@ class SeawaterStateBlockData(StateBlockData):
         # scaling factors for parameters
         for j, v in self.params.mw_comp.items():
             if iscale.get_scaling_factor(v) is None:
-                iscale.set_scaling_factor(self.params.mw_comp, 1e-1)
+                iscale.set_scaling_factor(self.params.mw_comp, 1e2)
 
         # these variables do not typically require user input,
         # will not override if the user does provide the scaling factor
@@ -1066,7 +1066,7 @@ class SeawaterStateBlockData(StateBlockData):
             for j in self.params.component_list:
                 if iscale.get_scaling_factor(self.flow_mol_phase_comp['Liq', j]) is None:
                     sf = iscale.get_scaling_factor(self.flow_mass_phase_comp['Liq', j])
-                    sf *= iscale.get_scaling_factor(self.params.mw_comp[j])
+                    sf /= iscale.get_scaling_factor(self.params.mw_comp[j])
                     iscale.set_scaling_factor(self.flow_mol_phase_comp['Liq', j], sf)
 
         if self.is_property_constructed('mole_frac_phase_comp'):

--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -1084,7 +1084,7 @@ class SeawaterStateBlockData(StateBlockData):
                 if isinstance(getattr(self.params, j), Solute):
                     if iscale.get_scaling_factor(self.molality_comp[j]) is None:
                         sf = iscale.get_scaling_factor(self.mass_frac_phase_comp['Liq', j])
-                        sf *= iscale.get_scaling_factor(self.params.mw_comp[j])
+                        sf /= iscale.get_scaling_factor(self.params.mw_comp[j])
                         iscale.set_scaling_factor(self.molality_comp[j], sf)
 
         if self.is_property_constructed('enth_flow'):


### PR DESCRIPTION
## Summary/Motivation:

The scaling factors originally implemented for the molecular weight (kg/mol) is off by three orders of magnitude, and this error was propagated to other scaling factors dependent on the molecular weight (``molality_comp`` and ``flow_mol_phase_comp``). 

This PR corrects this.


## Changes proposed in this PR:
- Set molecular weight scaling factor to 1e2
- Modify scaling factor calculations for ``molality_comp`` and ``flow_mol_phase_comp``

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
