### PR TITLE
Ensure ipopt-watertap leaves model unchanged

### DIFF
--- a/watertap/core/plugins/solvers.py
+++ b/watertap/core/plugins/solvers.py
@@ -16,7 +16,8 @@ from pyomo.core.base.block import _BlockData
 from pyomo.core.kernel.block import IBlock
 from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
 
-from idaes.core.util.scaling import (constraint_autoscale_large_jac,
+import idaes.core.util.scaling as iscale
+from idaes.core.util.scaling import (
         get_scaling_factor, set_scaling_factor, unset_scaling_factor)
 from idaes.logger import getLogger
 
@@ -77,12 +78,12 @@ class IpoptWaterTAP(IPOPT):
         #       so that repeated calls to solve change the scaling
         #       each time based on the initial values, just like in Ipopt.
         try:
-            constraint_autoscale_large_jac(self._model,
+            iscale.constraint_autoscale_large_jac(self._model,
                     ignore_constraint_scaling=ignore_constraint_scaling,
                     ignore_variable_scaling=ignore_variable_scaling,
                     max_grad=max_grad,
                     min_scale=min_scale)
-        except AssertionError as err:
+        except Exception as err:
             if str(err) == "Error in AMPL evaluation":
                 print("ipopt-watertap: Issue in AMPL function evaluation; Jacobian constraint scaling not applied.")
                 halt_on_ampl_error = self.options.get("halt_on_ampl_error", "yes")
@@ -102,6 +103,7 @@ class IpoptWaterTAP(IPOPT):
             return super()._presolve(*args, **kwds)
         except:
             self._cleanup()
+            raise
 
     def _cleanup(self):
         if self._cleanup_needed:

--- a/watertap/core/plugins/solvers.py
+++ b/watertap/core/plugins/solvers.py
@@ -29,6 +29,7 @@ class IpoptWaterTAP(IPOPT):
 
     def __init__(self, **kwds):
         kwds["name"] = "ipopt-watertap"
+        self._cleanup_needed = False
         super().__init__(**kwds)
 
     def _presolve(self, *args, **kwds):
@@ -47,9 +48,8 @@ class IpoptWaterTAP(IPOPT):
             self.options["constr_viol_tol"] = 1e-08
 
         if not self._is_user_scaling():
-            self._reset_needed = False
-            super()._presolve(*args, **kwds)
-            return
+            self._cleanup_needed = False
+            return super()._presolve(*args, **kwds)
 
         if self._tee:
             print("ipopt-watertap: Ipopt with user variable scaling and IDAES jacobian constraint scaling")
@@ -69,7 +69,7 @@ class IpoptWaterTAP(IPOPT):
 
         self._model = args[0]
         self._cache_scaling_factors()
-        self._reset_needed = True
+        self._cleanup_needed = True
 
         # NOTE: This function sets the scaling factors on the
         #       constraints. Hence we cache the constraint scaling
@@ -89,21 +89,27 @@ class IpoptWaterTAP(IPOPT):
                 if halt_on_ampl_error == "no" :
                     print("ipopt-watertap: halt_on_ampl_error=no, so continuing with optimization.")
                 else:
+                    self._cleanup()
                     raise RuntimeError("Error in AMPL evaluation.\n"
                             "Run ipopt with halt_on_ampl_error=yes and symbolic_solver_labels=True to see the affected function.")
             else:
                 print("Error in constraint_autoscale_large_jac")
+                self._cleanup()
                 raise
 
-        # this creates the NL file, among other things
-        super()._presolve(*args, **kwds)
+        try:
+            # this creates the NL file, among other things
+            return super()._presolve(*args, **kwds)
+        except:
+            self._cleanup()
+
+    def _cleanup(self):
+        if self._cleanup_needed:
+            self._reset_scaling_factors()
+            del self._model
 
     def _postsolve(self):
-        if self._reset_needed:
-            self._reset_scaling_factors()
-            # remove our reference to the model
-            del self._model
-        del self._reset_needed
+        self._cleanup()
         return super()._postsolve()
 
     def _cache_scaling_factors(self):

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -141,6 +141,14 @@ class TestIpoptWaterTAP:
         m.a.value = 1
 
     @pytest.mark.unit
+    def test_presolve_AMPL_evaluation_error_cleans_up(self, m, s):
+        m.a.value = 0
+        with pytest.raises(RuntimeError):
+            s.solve(m)
+        assert not hasattr(s, "_scaling_cache")
+        m.a.value = 1
+
+    @pytest.mark.unit
     def test_presolve_ignore_AMPL_evaluation_error(self, m, s):
         m.a.value = 0
         s.options["halt_on_ampl_error"] = "no"

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -13,7 +13,9 @@
 
 import pytest
 import pyomo.environ as pyo
+import idaes.core.util.scaling as iscale
 
+from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
 from pyomo.common.errors import ApplicationError
 from idaes.core.util.scaling import (set_scaling_factor, get_scaling_factor,
         constraints_with_scale_factor_generator, unscaled_constraints_generator)
@@ -141,6 +143,14 @@ class TestIpoptWaterTAP:
         m.a.value = 1
 
     @pytest.mark.unit
+    def test_presolve_ignore_AMPL_evaluation_error(self, m, s):
+        m.a.value = 0
+        s.options["halt_on_ampl_error"] = "no"
+        s._presolve(m)
+        m.a.value = 1
+        del s.options["halt_on_ampl_error"]
+
+    @pytest.mark.unit
     def test_presolve_AMPL_evaluation_error_cleans_up(self, m, s):
         m.a.value = 0
         with pytest.raises(RuntimeError):
@@ -149,8 +159,27 @@ class TestIpoptWaterTAP:
         m.a.value = 1
 
     @pytest.mark.unit
-    def test_presolve_ignore_AMPL_evaluation_error(self, m, s):
-        m.a.value = 0
-        s.options["halt_on_ampl_error"] = "no"
-        s._presolve(m)
-        m.a.value = 1
+    def test_presolve_ipopt_error_cleans_up(self, m, s):
+        IPOPT_presolve = IPOPT._presolve
+        class IpoptErrorException(Exception):
+            pass
+        def _bad_presolve(*args, **kwargs):
+            raise IpoptErrorException
+        IPOPT._presolve = _bad_presolve
+        with pytest.raises(IpoptErrorException):
+            s.solve(m)
+        assert not hasattr(s, "_scaling_cache")
+        IPOPT._presolve = IPOPT_presolve
+
+    @pytest.mark.unit
+    def test_presolve_constraint_autoscale_large_jac_error_cleans_up(self, m, s):
+        constraint_autoscale_large_jac = iscale.constraint_autoscale_large_jac
+        class CALJErrorException(Exception):
+            pass
+        def _bad_constraint_autoscale_large_jac(*args, **kwargs):
+            raise CALJErrorException
+        iscale.constraint_autoscale_large_jac = _bad_constraint_autoscale_large_jac
+        with pytest.raises(CALJErrorException):
+            s.solve(m)
+        assert not hasattr(s, "_scaling_cache")
+        iscale.constraint_autoscale_large_jac = constraint_autoscale_large_jac


### PR DESCRIPTION
## Fixes/Addresses:
If it errors out, `ipopt-watertap` may leave the model in a modified state.

## Changes proposed in this PR:
- Be more careful about restoring original constraint scaling factors on error
- Add a new tests covering the potential error-out places.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
