### PR TITLE
Removing unhelpful and unneeded constraint in 1DRO

### DIFF
--- a/watertap/unit_models/reverse_osmosis_1D.py
+++ b/watertap/unit_models/reverse_osmosis_1D.py
@@ -474,7 +474,7 @@ class ReverseOsmosis1DData(_ReverseOsmosisBaseData):
                          doc="Mass transfer from feed to permeate")
         def eq_connect_mass_transfer(b, t, x, p, j):
             if x == b.feed_side.length_domain.first():
-                return b.permeate_side[t, x].get_material_flow_terms(p, j) == 0
+                return Constraint.Skip
             else:
                 return (b.permeate_side[t, x].get_material_flow_terms(p, j)
                         == -b.feed_side.mass_transfer_term[t, x, p, j] * b.length / b.nfe)
@@ -862,9 +862,6 @@ class ReverseOsmosis1DData(_ReverseOsmosisBaseData):
             iscale.set_scaling_factor(self.length, sf)
 
         # setting scaling factors for variables
-        for v in self.permeate_side[0, 0].flow_mass_phase_comp['Liq',:]:
-            iscale.set_scaling_factor(v, 1e+5)
-
         for sb in (self.mixed_permeate, self.permeate_side):
             for blk in sb.values():
                 for j in self.config.property_package.solute_set:

--- a/watertap/unit_models/tests/test_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_1D.py
@@ -309,8 +309,8 @@ class TestReverseOsmosis():
 
         # test statistics
         assert number_variables(m) == 250
-        assert number_total_constraints(m) == 207
-        assert number_unused_variables(m) == 20
+        assert number_total_constraints(m) == 205
+        assert number_unused_variables(m) == 22
 
     @pytest.mark.integration
     def test_units(self, RO_frame):
@@ -483,8 +483,8 @@ class TestReverseOsmosis():
 
         # test statistics
         assert number_variables(m) == 200
-        assert number_total_constraints(m) == 159
-        assert number_unused_variables(m) == 27
+        assert number_total_constraints(m) == 157
+        assert number_unused_variables(m) == 29
 
         # Test units
         assert_units_consistent(m.fs.unit)
@@ -632,8 +632,8 @@ class TestReverseOsmosis():
 
        # test statistics
         assert number_variables(m) == 204
-        assert number_total_constraints(m) == 159
-        assert number_unused_variables(m) == 28
+        assert number_total_constraints(m) == 157
+        assert number_unused_variables(m) == 30
 
         assert_units_consistent(m.fs.unit)
 
@@ -778,8 +778,8 @@ class TestReverseOsmosis():
 
         # test statistics
         assert number_variables(m) == 204
-        assert number_total_constraints(m) == 159
-        assert number_unused_variables(m) == 28
+        assert number_total_constraints(m) == 157
+        assert number_unused_variables(m) == 30
 
         assert_units_consistent(m.fs.unit)
 
@@ -932,8 +932,8 @@ class TestReverseOsmosis():
 
         # test statistics
         assert number_variables(m) == 227
-        assert number_total_constraints(m) == 184
-        assert number_unused_variables(m) == 20
+        assert number_total_constraints(m) == 182
+        assert number_unused_variables(m) == 22
 
         assert_units_consistent(m.fs.unit)
 
@@ -1093,8 +1093,8 @@ class TestReverseOsmosis():
 
         # test statistics
         assert number_variables(m) == 232
-        assert number_total_constraints(m) == 185
-        assert number_unused_variables(m) == 21
+        assert number_total_constraints(m) == 183
+        assert number_unused_variables(m) == 23
 
         assert_units_consistent(m.fs.unit)
 
@@ -1254,8 +1254,8 @@ class TestReverseOsmosis():
 
         # test statistics
         assert number_variables(m) == 232
-        assert number_total_constraints(m) == 188
-        assert number_unused_variables(m) == 20
+        assert number_total_constraints(m) == 186
+        assert number_unused_variables(m) == 22
 
         assert_units_consistent(m.fs.unit)
 


### PR DESCRIPTION
## Fixes/Addresses: N/A

## Summary/Motivation:
When working on #328 @adam-a-a and I noticed an issue with the 1DRO model.

## Changes proposed in this PR:
- Remove constraint on permeate side inlet. Conflicted with lower bound of `1e-08` in the NaCl property package.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
