### PR TITLE
Reference bound relax fix

### DIFF
--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -39,6 +39,11 @@ class TestIpoptWaterTAP:
 
         m.o = pyo.Objective(expr=m.a+b.o)
 
+        # references are tricky, could cause a variable
+        # to be iterated over several times in
+        # component_data_objects
+        m.b_a = pyo.Reference(b.a)
+
         return m
 
     def _test_bounds(self, m):

--- a/watertap/examples/chemistry/tests/test_pH_dependent_solubility.py
+++ b/watertap/examples/chemistry/tests/test_pH_dependent_solubility.py
@@ -367,7 +367,8 @@ def run_case1(xOH=1e-7/55.2, xH=1e-7/55.2, xCaOH2=1e-20, xCa=1e-20,
 
     ## ==================== END Scaling for this problem ===========================
     init_options = {**solver.options}
-    init_options["bound_relax_factor"] = 1.0e-04
+    init_options["constr_viol_tol"] = 1.0e-04
+    init_options["tol"] = 1.0e-06
     model.fs.unit.initialize(optarg=init_options, outlvl=idaeslog.DEBUG)
 
     assert degrees_of_freedom(model) == 0
@@ -1921,14 +1922,13 @@ def run_case4(xOH=1e-7/55.2, xH=1e-7/55.2,
     assert isinstance(model.fs.unit.control_volume.properties_in[0.0].scaling_factor, Suffix)
 
     ## ==================== END Scaling for this problem ===========================
-
-    init_options = {**solver.options}
-    init_options["bound_relax_factor"] = 1.0e-02
-    model.fs.unit.initialize(optarg=init_options, outlvl=idaeslog.DEBUG)
+    model.fs.unit.initialize(optarg=solver.options, outlvl=idaeslog.DEBUG)
 
     assert degrees_of_freedom(model) == 0
 
-    results = solver.solve(model, tee=True)
+    with idaes.temporary_config_ctx():
+        solver.options["tol"] = 1.0e-12
+        results = solver.solve(model, tee=True)
 
     assert results.solver.termination_condition == TerminationCondition.optimal
     assert results.solver.status == SolverStatus.ok

--- a/watertap/examples/chemistry/tests/test_pH_dependent_solubility.py
+++ b/watertap/examples/chemistry/tests/test_pH_dependent_solubility.py
@@ -1926,9 +1926,9 @@ def run_case4(xOH=1e-7/55.2, xH=1e-7/55.2,
 
     assert degrees_of_freedom(model) == 0
 
-    with idaes.temporary_config_ctx():
-        solver.options["tol"] = 1.0e-12
-        results = solver.solve(model, tee=True)
+    solver.options["tol"] = 1.0e-12
+    results = solver.solve(model, tee=True)
+    del solver.options["tol"]
 
     assert results.solver.termination_condition == TerminationCondition.optimal
     assert results.solver.status == SolverStatus.ok

--- a/watertap/examples/chemistry/tests/test_solids.py
+++ b/watertap/examples/chemistry/tests/test_solids.py
@@ -329,7 +329,9 @@ def run_case1(xA, xB, xAB=1e-25, scaling=True, rxn_config=None):
 
     assert degrees_of_freedom(model) == 0
 
+    solver.options["bound_relax_factor"] = 1.0e-02
     results = solver.solve(model, tee=True)
+    del solver.options["bound_relax_factor"]
 
     assert results.solver.termination_condition == TerminationCondition.optimal
     assert results.solver.status == SolverStatus.ok


### PR DESCRIPTION
## Fixes: #333

## Summary/Motivation:
`ipopt-watertap` won't necessarily reset bounds if the variable is `Reference`d somewhere else on the same model.

## Changes proposed in this PR:
- Use `ComponentMap` so each `_VarData` only gets changed once, and reset once.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
