### PR TITLE
Adding methods for zero order reactive separators

### DIFF
--- a/docs/technical_reference/core/sido_methods.rst
+++ b/docs/technical_reference/core/sido_methods.rst
@@ -38,73 +38,42 @@ Variables
 
 The build_sido method creates the following variables in addition to those created by the `StateBlocks`.
 
-=============================== ==================== ============== ===================================================================
-Variable                        Name                 Indices        Notes
-=============================== ==================== ============== ===================================================================
-:math:`r_{t}`                   recovery_vol         time           Fraction of volumetric flow in inlet that goes to treated
-:math:`f_{t,j}`                 removal_mass_solute  time, solutes  Fraction of mass flow of each solute that goes to byproduct stream
-:math:`\Delta P_{treated,t}`    deltaP_treated       time           Pressure difference between inlet and treated stream. Optional.
-:math:`\Delta P_{byproduct,t}`  deltaP_byproduct     time           Pressure difference between inlet and byproduct stream. Optional.
-=============================== ==================== ============== ===================================================================
-
-The :math:`\Delta P_{treated,t}` and :math:`\Delta P_{byproduct,t}` terms are optional and are only created if the `self._has_deltaP_treated` and `self._has_deltaP_byproduct` attributes are `True` respectively.
+=============================== ========================= ============== =====================================================================
+Variable                        Name                      Indices        Notes
+=============================== ========================= ============== =====================================================================
+:math:`r_{t}`                   recovery_frac_mass_H2O    time           Fraction of mass flow of water in inlet that goes to treated stream.
+:math:`f_{t,j}`                 removal_frac_mass_solute  time, solutes  Fraction of mass flow of each solute that goes to byproduct stream.
+=============================== ========================= ============== =====================================================================
 
 Constraints
 -----------
 
-The build_sido method writes the following constraints which relate the inlet state to those in the treated and byproduct streams. As mentioned previously, these constraints are formulated such that they will be linear if `flow_vol`, `conc_mass_comp`, `pressure` and `temperature` are the state variables used by the property package and the recovery and removal fractions are fixed.
-
-First, a volumetric flow recovery equation is written to relate the flowrate at the treated to that at the inlet:
+The build_sido method writes the following constraints which relate the inlet state to those in the treated and byproduct streams.
+First, a mass recovery equation for water is written to relate the flowrate at the treated outlet to that at the inlet:
 
 `water_recovery_equation(t)`:
 
-.. math:: r_t \times Q_{inlet,t} = Q_{treated,t}
+.. math:: r_t \times M_{inlet,t,H2O} = M_{treated,t,H2O}
 
-where :math:`Q_t` is volumetric flowrate at time :math:`t`.
+where :math:`M_{t,H2O}` is mass flowrate of water at time :math:`t`.
 
-Next, a volumetric flow balance is written to relate the flowrate in the byproduct stream to that in the inlet and treated.
+Next, a mass balance for water is written to relate the flowrate in the byproduct stream to that in the inlet and treated streams.
 
 `flow_balance(t)`:
 
-.. math:: Q_{inlet,t} = Q_{treated,t} + Q_{byproduct,t}
+.. math:: M_{inlet,t,H2O} = M_{treated,t,H2O} + M_{byproduct,t,H2O}
 
 Removal constraints are then written for each solute to relate the solute concentration in the byproduct stream to that in the inlet stream.
 
 `solute_removal_equation(t, j)`:
 
-.. math:: f_{t, j} \times C_{inlet,t, j} = (1-r_t) \times C_{byproduct,t,j}
+.. math:: f_{t, j} \times M_{inlet,t,j} = M_{byproduct,t,j}
 
-where :math:`C_{t,j}` is mass concentration of solute :math:`j` at time :math:`t`.
-
-A similar constraint is then written for each solute to relate the solute concentration in the treated stream to that in the inlet stream.
+A mass balance constraint is then written for each solute.
 
 `solute_treated_equation(t, j)`:
 
-.. math:: (1-f_{t, j}) \times C_{inlet,t, j} = r_t \times C_{treated,t,j}
-
-Pressure balances are then written for each stream, including the :math:`\Delta P` terms if present.
-
-`treated_pressure_constraint(t)`:
-
-.. math:: P_{inlet,t} = P_{treated,t} [+ \Delta P_{treated,t}]
-
-`byproduct_pressure_constraint(t)`:
-
-.. math:: P_{inlet,t} = P_{byproduct,t} [+ \Delta P_{byproduct,t}]
-
-where :math:`P_t` is the pressure at time :math:`t`.
-
-Finally, temperature equality constraints are written to equate the temperature in the treated and byproduct streams to that in the inlet.
-
-`treated_temperature_equality(t)`:
-
-.. math:: T_{inlet,t} = T_{treated,t}
-
-`byproduct_temperature_equality(t)`:
-
-.. math:: T_{inlet,t} = T_{byproduct,t}
-
-where :math:`T_t` is the temperature at time :math:`t`.
+.. math:: M_{inlet,t,j} = M_{treated,t,j} + M_{byproduct,t,j}
 
 Module Documentation
 --------------------

--- a/docs/technical_reference/core/sidor_methods.rst
+++ b/docs/technical_reference/core/sidor_methods.rst
@@ -1,0 +1,100 @@
+Reactive Single Inlet - Double Outlet Helper Methods
+====================================================
+
+.. index::
+   pair: watertap.core.zero_order_sido_reactive;build_sido_reactive
+
+.. currentmodule:: watertap.core.zero_order_sido_reactive
+
+The `build_sido_reactive` method is intended to be used to rapidly construct a standard set of material balance equations for zero-order type models with a single inlet and two outlets that involve chemical reactions (i.e. units that involve both reaction and separation).
+
+Usage
+-----
+
+.. testcode::
+
+  from idaes.core import declare_process_block_class
+  from watertap.core import build_sido_reactive, ZeroOrderBaseData
+
+  @declare_process_block_class("ReactiveSeparationZO")
+  class ReactiveSeparationZOData(ZeroOrderBaseData):
+
+      CONFIG = ZeroOrderBaseData.CONFIG()
+
+      def build(self):
+          super().build()
+
+          self._tech_type = "reactive_separation"
+
+          build_sido_reactive(self)
+
+Model Structure
+---------------
+
+The build_sido_reactive method constructs a simple representation of unit operation with a single inlet (named `inlet`) and two outlets (named `treated` and `byproduct`). A `StateBlock` is constructed for the inlet and each outlet with a `Port` associated with each of these.
+
+Variables
+---------
+
+The build_sido_reactive method creates the following variables in addition to those created by the `StateBlocks`.
+
+=============================== ========================= =============== =====================================================================
+Variable                        Name                      Indices         Notes
+=============================== ========================= =============== =====================================================================
+:math:`r_{t}`                   recovery_frac_mass_H2O    time            Fraction of mass flow of water in inlet that goes to treated stream.
+:math:`f_{t,j}`                 removal_frac_mass_solute  time, solutes   Fraction of mass flow of each solute that goes to byproduct stream.
+:math:`X_{t, r}`                reaction_conversion       time, reaction  Fractional conversion of key reactant via reaction r.
+:math:`\xi_{t, r}`              extent_of_reaction        time, reaction  Extent of reaction r in kg/s.
+=============================== ========================= =============== =====================================================================
+
+Parameters
+----------
+
+The build_sido_reactive method introduces a single indexed parameter.
+
+===================  ================= ==================== =========================================================================
+Parameter            Name              Indices              Notes
+===================  ================= ==================== =========================================================================
+:math:`\nu_{r, j}`   generation_ratio  reaction, component  Mass conversion ratio for component j in reaction r w.r.t. key reactant.
+===================  ================= ==================== =========================================================================
+
+Note that :math:`\nu_{r, j}` should be negative for reactants and positive for products. Generation ratio can either be specified directly as a parameter, or by providing stoichiometric coefficients and molecular weights for each component.
+
+Constraints
+-----------
+
+The build_sido method writes the following constraints which relate the inlet state to those in the treated and byproduct streams.
+First, a constraint for the extent of reaction is written:
+
+.. math:: \xi_{t, r} = X_{t, r} \times M_{in,t,key}
+
+where :math:`M_{t,key}` is mass flowrate of the key reactant for the reaction at time :math:`t`.
+
+Next, a mass recovery equation for water is written to relate the flowrate at the treated outlet to that at the inlet. Note that recovery is applied after any reactions have occurred.
+
+`water_recovery_equation(t)`:
+
+.. math:: r_t \times (M_{inlet,t,H2O} + \sum{\nu_{r,H2O} \times \xi_{t,r}}_r) = M_{treated,t,H2O}
+
+Next, a mass balance for water is written to relate the flowrate in the byproduct stream to that in the inlet and treated streams.
+
+`flow_balance(t)`:
+
+.. math:: M_{inlet,t,H2O} + \sum{\nu_{r,H2O} \times \xi_{t,r}}_r = M_{treated,t,H2O} + M_{byproduct,t,H2O}
+
+Removal constraints are then written for each solute to relate the solute concentration in the byproduct stream to that in the inlet stream. Again, removal is applied after any reactions have occured.
+
+`solute_removal_equation(t, j)`:
+
+.. math:: f_{t, j} \times (M_{inlet,t,j} + \sum{\nu_{r,j} \times \xi_{t,r}}_r) = M_{byproduct,t,j}
+
+A mass balance constraint is then written for each solute.
+
+`solute_treated_equation(t, j)`:
+
+.. math:: M_{inlet,t,j} + \sum{\nu_{r,j} \times \xi_{t,r}}_r = M_{treated,t,j} + M_{byproduct,t,j}
+
+Module Documentation
+--------------------
+
+.. automodule:: watertap.core.zero_order_sido_reactive.build_sido_reactive

--- a/docs/technical_reference/core/sidor_methods.rst
+++ b/docs/technical_reference/core/sidor_methods.rst
@@ -60,6 +60,19 @@ Parameter            Name              Indices              Notes
 
 Note that :math:`\nu_{r, j}` should be negative for reactants and positive for products. Generation ratio can either be specified directly as a parameter, or by providing stoichiometric coefficients and molecular weights for each component.
 
+Expressions
+-----------
+
+The build_sido_reactive method creates an Expression for the generation of each species in each reaction. 
+
+===================  ==================== ========================== ===============================================
+Parameter            Name                 Indices                    Notes
+===================  ==================== ========================== ===============================================
+:math:`G_{t, r, j}`  generation_rxn_comp  time, reaction, component  Mass generation for component j in reaction r.
+===================  ==================== ========================== ===============================================
+
+.. math:: G_{t, r, j} = \nu_{r,j} \times \xi_{t,r}
+
 Constraints
 -----------
 
@@ -74,25 +87,25 @@ Next, a mass recovery equation for water is written to relate the flowrate at th
 
 `water_recovery_equation(t)`:
 
-.. math:: r_t \times (M_{inlet,t,H2O} + \sum{\nu_{r,H2O} \times \xi_{t,r}}_r) = M_{treated,t,H2O}
+.. math:: r_t \times (M_{inlet,t,H2O} + \sum{G_{t, r, H2O}}_r) = M_{treated,t,H2O}
 
 Next, a mass balance for water is written to relate the flowrate in the byproduct stream to that in the inlet and treated streams.
 
 `flow_balance(t)`:
 
-.. math:: M_{inlet,t,H2O} + \sum{\nu_{r,H2O} \times \xi_{t,r}}_r = M_{treated,t,H2O} + M_{byproduct,t,H2O}
+.. math:: M_{inlet,t,H2O} + \sum{G_{t, r, H2O}}_r = M_{treated,t,H2O} + M_{byproduct,t,H2O}
 
 Removal constraints are then written for each solute to relate the solute concentration in the byproduct stream to that in the inlet stream. Again, removal is applied after any reactions have occured.
 
 `solute_removal_equation(t, j)`:
 
-.. math:: f_{t, j} \times (M_{inlet,t,j} + \sum{\nu_{r,j} \times \xi_{t,r}}_r) = M_{byproduct,t,j}
+.. math:: f_{t, j} \times (M_{inlet,t,j} + \sum{G_{t, r, j}}_r) = M_{byproduct,t,j}
 
 A mass balance constraint is then written for each solute.
 
 `solute_treated_equation(t, j)`:
 
-.. math:: M_{inlet,t,j} + \sum{\nu_{r,j} \times \xi_{t,r}}_r = M_{treated,t,j} + M_{byproduct,t,j}
+.. math:: M_{inlet,t,j} + \sum{G_{t, r, j}}_r = M_{treated,t,j} + M_{byproduct,t,j}
 
 Module Documentation
 --------------------

--- a/docs/technical_reference/core/zo_form_libraries.rst
+++ b/docs/technical_reference/core/zo_form_libraries.rst
@@ -8,4 +8,5 @@ WaterTap includes a library of helper methods for assembling common model forms 
    
    pt_methods
    sido_methods
+   sidor_methods
    electricity_methods

--- a/watertap/core/__init__.py
+++ b/watertap/core/__init__.py
@@ -17,3 +17,4 @@ from .zero_order_properties import WaterParameterBlock, WaterStateBlock
 from .zero_order_electricity import constant_intensity, pump_electricity
 from .zero_order_pt import build_pt
 from .zero_order_sido import build_sido
+from .zero_order_sido_reactive import build_sido_reactive

--- a/watertap/core/tests/test_sidor_data.yaml
+++ b/watertap/core/tests/test_sidor_data.yaml
@@ -1,0 +1,36 @@
+default:
+  recovery_frac_mass_H2O:
+    value: 0.85
+    units: dimensionless
+  default_removal_frac_mass_solute:
+    value: 0
+    units: dimensionless
+  removal_frac_mass_solute:
+    A:
+      value: 0.50
+      units: dimensionless
+    B:
+      value: 0.40
+      units: dimensionless
+  reactions:
+    Rxn1:
+      key_reactant: A
+      conversion: 0.8
+      stoichiometry:
+        A:
+          conversion_ratio: -1
+        B:
+          conversion_ratio: 1
+    Rxn2:
+      key_reactant: B
+      conversion: 0.1
+      stoichiometry:
+        H2O:
+          order: -1
+          molecular_weight: 18
+        B:
+          order: -1
+          molecular_weight: 20
+        C:
+          order: 2
+          molecular_weight: 22

--- a/watertap/core/tests/test_zero_order_sido_reactive.py
+++ b/watertap/core/tests/test_zero_order_sido_reactive.py
@@ -1,0 +1,551 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+"""
+Tests for general zero-order property package
+"""
+import pytest
+from io import StringIO
+import os
+
+from idaes.core import declare_process_block_class, FlowsheetBlock
+from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_solver
+import idaes.core.util.scaling as iscale
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
+                           Constraint,
+                           Param,
+                           Set,
+                           value,
+                           Var)
+from pyomo.network import Port
+from pyomo.util.check_units import assert_units_consistent
+
+
+from watertap.core import (
+    Database, WaterParameterBlock, WaterStateBlock, ZeroOrderBaseData)
+from watertap.core.zero_order_sido_reactive import (
+    build_sido_reactive,
+    initialize_sidor,
+    calculate_scaling_factors_sidor,
+    _get_Q_sidor)
+
+solver = get_solver()
+
+local_path = os.path.dirname(os.path.abspath(__file__))
+
+
+@declare_process_block_class("DerivedSIDOR")
+class DerivedSIDORData(ZeroOrderBaseData):
+    def build(self):
+        super().build()
+
+        self._tech_type = "test_sidor_data"
+
+        build_sido_reactive(self)
+
+
+class TestSIDOR:
+    @pytest.fixture(scope="module")
+    def model(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        m.fs.unit = DerivedSIDOR(
+            default={"property_package": m.fs.water_props,
+                     "database": m.db})
+
+        m.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(1000)
+        m.fs.unit.inlet.flow_mass_comp[0, "A"].fix(10)
+        m.fs.unit.inlet.flow_mass_comp[0, "B"].fix(20)
+        m.fs.unit.inlet.flow_mass_comp[0, "C"].fix(30)
+
+        m.fs.unit.load_parameters_from_database(use_default_removal=True)
+
+        return m
+
+    @pytest.mark.unit
+    def test_private_attributes(self, model):
+        assert model.fs.unit._has_recovery_removal is True
+        assert model.fs.unit._fixed_perf_vars == []
+        assert model.fs.unit._initialize is initialize_sidor
+        assert model.fs.unit._scaling is calculate_scaling_factors_sidor
+        assert model.fs.unit._get_Q is _get_Q_sidor
+        assert model.fs.unit._stream_table_dict == {
+            "Inlet": model.fs.unit.inlet,
+            "Treated": model.fs.unit.treated,
+            "Byproduct": model.fs.unit.byproduct}
+        assert model.fs.unit._perf_var_dict == {
+            "Water Recovery": model.fs.unit.recovery_frac_mass_H2O,
+            "Solute Removal": model.fs.unit.removal_frac_mass_solute,
+            "Reaction Extent": model.fs.unit.extent_of_reaction}
+
+    @pytest.mark.unit
+    def test_build(self, model):
+        assert isinstance(model.fs.unit.properties_in, WaterStateBlock)
+        assert isinstance(model.fs.unit.properties_treated, WaterStateBlock)
+        assert isinstance(model.fs.unit.properties_byproduct, WaterStateBlock)
+
+        assert isinstance(model.fs.unit.inlet, Port)
+        assert isinstance(model.fs.unit.treated, Port)
+        assert isinstance(model.fs.unit.byproduct, Port)
+
+        assert isinstance(model.fs.unit.recovery_frac_mass_H2O, Var)
+        assert len(model.fs.unit.recovery_frac_mass_H2O) == 1
+        assert isinstance(model.fs.unit.removal_frac_mass_solute, Var)
+        assert len(model.fs.unit.removal_frac_mass_solute) == 3
+
+        assert isinstance(model.fs.unit.water_recovery_equation, Constraint)
+        assert len(model.fs.unit.water_recovery_equation) == 1
+        assert isinstance(model.fs.unit.water_balance, Constraint)
+        assert len(model.fs.unit.water_balance) == 1
+        assert isinstance(model.fs.unit.solute_removal_equation, Constraint)
+        assert len(model.fs.unit.solute_removal_equation) == 3
+        assert isinstance(model.fs.unit.solute_treated_equation, Constraint)
+        assert len(model.fs.unit.solute_treated_equation) == 3
+
+        assert isinstance(model.fs.unit.reaction_set, Set)
+        assert isinstance(model.fs.unit.generation_ratio, Param)
+
+        assert isinstance(model.fs.unit.reaction_conversion, Var)
+        assert isinstance(model.fs.unit.extent_of_reaction, Var)
+
+        assert isinstance(model.fs.unit.reaction_extent_equation, Constraint)
+
+        for r in model.fs.unit.reaction_set:
+            assert r in ["Rxn1", "Rxn2"]
+            assert (0, r) in model.fs.unit.reaction_conversion
+            assert (0, r) in model.fs.unit.extent_of_reaction
+            assert (0, r) in model.fs.unit.reaction_extent_equation
+            for j in model.fs.water_props.component_list:
+                assert (r, j) in model.fs.unit.generation_ratio
+
+    @pytest.mark.unit
+    def test_key_components(self, model):
+        assert (str(model.fs.unit.properties_in[0].flow_mass_comp["A"]) in
+                str(model.fs.unit.reaction_extent_equation[0, "Rxn1"].body))
+        assert (str(model.fs.unit.properties_in[0].flow_mass_comp["B"]) in
+                str(model.fs.unit.reaction_extent_equation[0, "Rxn2"].body))
+
+    @pytest.mark.unit
+    def test_loading_data(self, model):
+        # RXn 1 is all conversion ratios
+        # Rxn 2 is all stocihiometry (incl. water)
+        cfactor = {"Rxn1": {"A": -1, "B": 1, "C": 0, "H2O": 0},
+                   "Rxn2": {"A": 0, "B": -1, "C": 22*2/20, "H2O": -1*18/20}}
+
+        for (r, j), p in model.fs.unit.generation_ratio.items():
+            assert value(p) == cfactor[r][j]
+
+        assert model.fs.unit.reaction_conversion[0, "Rxn1"].value == 0.8
+        assert model.fs.unit.reaction_conversion[0, "Rxn2"].value == 0.1
+
+        assert model.fs.unit.recovery_frac_mass_H2O[0].value == 0.85
+        assert model.fs.unit.removal_frac_mass_solute[0, "A"].value == 0.5
+        assert model.fs.unit.removal_frac_mass_solute[0, "B"].value == 0.4
+        assert model.fs.unit.removal_frac_mass_solute[0, "C"].value == 0.0
+
+    @pytest.mark.unit
+    def test_degrees_of_freedom(self, model):
+        assert degrees_of_freedom(model) == 0
+
+    @pytest.mark.component
+    def test_unit_consistency(self, model):
+        assert_units_consistent(model)
+
+    @pytest.mark.component
+    def test_scaling(self, model):
+        iscale.calculate_scaling_factors(model)
+
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.water_recovery_equation[0]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.water_balance[0]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.solute_removal_equation[0, "A"]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.solute_removal_equation[0, "B"]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.solute_removal_equation[0, "C"]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.solute_treated_equation[0, "A"]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.solute_treated_equation[0, "B"]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.solute_treated_equation[0, "C"]) == 1e5
+
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.reaction_extent_equation[0, "Rxn1"]) == 1e5
+        assert iscale.get_constraint_transform_applied_scaling_factor(
+            model.fs.unit.reaction_extent_equation[0, "Rxn2"]) == 1e5
+
+    @pytest.mark.component
+    def test_initialization(self, model):
+        initialization_tester(model)
+
+    @pytest.mark.component
+    def test_solve(self, model):
+        results = solver.solve(model)
+
+        # Check for optimal solution
+        assert check_optimal_termination(results)
+
+    @pytest.mark.component
+    def test_solution(self, model):
+        model.fs.unit.treated.display()
+        model.fs.unit.byproduct.display()
+        assert (pytest.approx((1000-0.1*20*18/20)*0.85, rel=1e-5) ==
+                value(model.fs.unit.treated.flow_mass_comp[0, "H2O"]))
+        assert (pytest.approx((1000-0.1*20*18/20)*0.15, rel=1e-5) ==
+                value(model.fs.unit.byproduct.flow_mass_comp[0, "H2O"]))
+
+        assert (pytest.approx((10*0.2)*(1-0.5), rel=1e-5) ==
+                value(model.fs.unit.treated.flow_mass_comp[0, "A"]))
+        assert (pytest.approx((10*0.2)*0.5, rel=1e-5) ==
+                value(model.fs.unit.byproduct.flow_mass_comp[0, "A"]))
+        assert (pytest.approx((20+0.8*10-0.1*20)*(1-0.4), rel=1e-5) ==
+                value(model.fs.unit.treated.flow_mass_comp[0, "B"]))
+        assert (pytest.approx((20+0.8*10-0.1*20)*0.4, rel=1e-5) ==
+                value(model.fs.unit.byproduct.flow_mass_comp[0, "B"]))
+        assert (pytest.approx(30+0.1*20*2*22/20, rel=1e-5) ==
+                value(model.fs.unit.treated.flow_mass_comp[0, "C"]))
+        assert (pytest.approx(0, rel=1e-5) ==
+                value(model.fs.unit.byproduct.flow_mass_comp[0, "C"]))
+
+    # Conservation would be similar to above, as need to calculate generation
+
+    @pytest.mark.component
+    def test_report(self, model):
+        stream = StringIO()
+        model.fs.unit.report(ostream=stream)
+
+        output = """
+====================================================================================
+Unit : fs.unit                                                             Time: 0.0
+------------------------------------------------------------------------------------
+    Unit Performance
+
+    Variables: 
+
+    Key                    : Value   : Fixed : Bounds
+    Reaction Extent [Rxn1] :  8.0000 : False : (None, None)
+    Reaction Extent [Rxn2] :  2.0000 : False : (None, None)
+        Solute Removal [A] : 0.50000 :  True : (0, None)
+        Solute Removal [B] : 0.40000 :  True : (0, None)
+        Solute Removal [C] :  0.0000 :  True : (0, None)
+            Water Recovery : 0.85000 :  True : (1e-08, 1.0000001)
+
+------------------------------------------------------------------------------------
+    Stream Table
+                            Inlet  Treated  Byproduct
+    Volumetric Flowrate    1.0600 0.89947     0.16113
+    Mass Concentration H2O 943.40  943.30      929.25
+    Mass Concentration A   9.4340  1.1118      6.2062
+    Mass Concentration B   18.868  17.344      64.544
+    Mass Concentration C   28.302  38.245  6.2062e-13
+====================================================================================
+"""
+
+        assert output == stream.getvalue()
+
+
+class TestSIDORErrors:
+    @pytest.mark.unit
+    def test_reaction_list(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files["test_sidor_data"]["default"] = {}
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                KeyError,
+                match="fs.unit - database provided does not contain a list of "
+                "reactions for this technology."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_missing_conversion(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                KeyError,
+                match="fs.unit - database provided does not "
+                "contain an entry for conversion for reaction Rxn3."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_missing_key_reactant(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                KeyError,
+                match="fs.unit - database provided does not "
+                "contain an entry for key_reactant for reaction Rxn3."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_invlaid_key_reactant(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+        R3["key_reactant"] = "foo"
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                ValueError,
+                match="fs.unit - key_reactant foo for reaction Rxn3 "
+                "is not in the component list used by the assigned property "
+                "package."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_missing_stoichiometry(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+        R3["key_reactant"] = "A"
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                KeyError,
+                match="fs.unit - database provided does not "
+                "contain an entry for stoichiometry for reaction Rxn3."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_ratio_and_order(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+        R3["key_reactant"] = "A"
+        R3["stoichiometry"] = {"A": {"order": 1, "conversion_ratio": 1}}
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                RuntimeError,
+                match="fs.unit - database provides entries for both "
+                "conversion_ratio and reaction order in reaction Rxn3. "
+                "Please provide only one or the other."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_no_ratio_or_order(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+        R3["key_reactant"] = "A"
+        R3["stoichiometry"] = {"A": {}}
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                RuntimeError,
+                match="fs.unit - database provided does not "
+                "contain any information for conversion_ratio or reaction "
+                "order w.r.t. species A in reaction Rxn3."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_order_no_mw(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+        R3["key_reactant"] = "B"
+        R3["stoichiometry"] = {"A": {"order": 1},
+                               "B": {"order": 1, "molecular_weight": 1}}
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                KeyError,
+                match="fs.unit - database provided does not "
+                "contain an entry for molecular_weight w.r.t. "
+                "species A in reaction Rxn3."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_order_no_key_order(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+        R3["key_reactant"] = "B"
+        R3["stoichiometry"] = {"A": {"order": 1, "molecular_weight": 1}}
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                KeyError,
+                match="fs.unit - database provided does not "
+                "contain an entry for order w.r.t. species "
+                "B in reaction Rxn3."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})
+
+    @pytest.mark.unit
+    def test_order_no_key_mw(self):
+        m = ConcreteModel()
+
+        m.db = Database(dbpath=local_path)
+
+        # Load data from YAML so that we can modify it
+        m.db._get_technology("test_sidor_data")
+        m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"] = {}
+        R3 = m.db._cached_files[
+            "test_sidor_data"]["default"]["reactions"]["Rxn3"]
+        R3["conversion"] = 0.5
+        R3["key_reactant"] = "B"
+        R3["stoichiometry"] = {"A": {"order": 1, "molecular_weight": 1},
+                               "B": {"order": 1}}
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.water_props = WaterParameterBlock(
+            default={"solute_list": ["A", "B", "C"]})
+
+        with pytest.raises(
+                KeyError,
+                match="fs.unit - database provided does not "
+                "contain an entry for molecular_weight w.r.t. "
+                "species B in reaction Rxn3."):
+            m.fs.unit = DerivedSIDOR(
+                default={"property_package": m.fs.water_props,
+                         "database": m.db})

--- a/watertap/core/zero_order_base.py
+++ b/watertap/core/zero_order_base.py
@@ -266,9 +266,9 @@ class ZeroOrderBaseData(UnitModelBlockData):
         var_dict = {}
 
         for k, v in self._perf_var_dict.items():
-            if k == "Solute Removal":
-                for j, vd in self.removal_frac_mass_solute[time_point, :].wildcard_items():
-                    var_dict[f"Solute Removal [{j}]"] = vd
+            if k in ["Solute Removal", "Reaction Extent"]:
+                for j, vd in v[time_point, :].wildcard_items():
+                    var_dict[f"{k} [{j}]"] = vd
             elif v.is_indexed():
                 var_dict[k] = v[time_point]
             else:

--- a/watertap/core/zero_order_sido_reactive.py
+++ b/watertap/core/zero_order_sido_reactive.py
@@ -1,0 +1,418 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+"""
+This module contains methods for constructing the material balances for
+zero-order single inlet-double outlet (SIDO) unit models with chemical
+reactions.
+"""
+
+import idaes.logger as idaeslog
+from idaes.core.util import get_solver
+import idaes.core.util.scaling as iscale
+
+from pyomo.environ import NonNegativeReals, Param, Set, Var, units as pyunits
+
+# Some more inforation about this module
+__author__ = "Andrew Lee"
+
+# Set up logger
+_log = idaeslog.getLogger(__name__)
+
+
+def build_sido_reactive(self):
+    """
+    Helper method for constructing material balances for zero-order type models
+    with one inlet and two outlets including chemcial reactions.
+
+    Three StateBlocks are added with corresponding Ports:
+        * properties_inlet
+        * properties_treated
+        * properties_byproduct
+
+    Additional variables are:
+        * recovery_vol (indexed by time)
+        * removal_frac_mass_solute (indexed by time and solute)
+        * extent_of_reaction (indexed by time and reactions)
+
+    Four additional constraints are added to represent the material balances
+        * water_recovery_equation (indexed by time)
+        * flow_balance (indexed by time)
+        * solute_removal_equation (indexed by time and solute)
+        * solute_treated_equation (indexed by time and solute)
+
+    This method also sets private attributes on the unit model with references
+    to the appropriate initialization and scaling methods to use and to return
+    the inlet volumetric flow rate.
+    """
+    self._has_recovery_removal = True
+    self._initialize = initialize_sidor
+    self._scaling = calculate_scaling_factors_sidor
+
+    # Create state blocks for inlet and outlets
+    tmp_dict = dict(**self.config.property_package_args)
+    tmp_dict["has_phase_equilibrium"] = False
+    tmp_dict["defined_state"] = True
+
+    self.properties_in = self.config.property_package.build_state_block(
+        self.flowsheet().time,
+        doc="Material properties at inlet",
+        default=tmp_dict)
+
+    tmp_dict_2 = dict(**tmp_dict)
+    tmp_dict_2["defined_state"] = False
+
+    self.properties_treated = \
+        self.config.property_package.build_state_block(
+            self.flowsheet().time,
+            doc="Material properties of treated water",
+            default=tmp_dict_2)
+    self.properties_byproduct = \
+        self.config.property_package.build_state_block(
+            self.flowsheet().time,
+            doc="Material properties of byproduct stream",
+            default=tmp_dict_2)
+
+    # Create Ports
+    self.add_port("inlet", self.properties_in, doc="Inlet port")
+    self.add_port("treated",
+                  self.properties_treated,
+                  doc="Treated water outlet port")
+    self.add_port("byproduct",
+                  self.properties_byproduct,
+                  doc="Byproduct outlet port")
+
+    # Load reaction identifiers from database
+    dbparams = self.config.database.get_unit_operation_parameters(
+        self._tech_type,
+        subtype=self.config.process_subtype)
+    try:
+        rxn_ids = list(dbparams["reactions"].keys())
+    except KeyError:
+        raise KeyError(
+            f"{self.name} - database provided does not contain a list of "
+            f"reactions for this technology.")
+    # Create indexing set for reactions
+    self.reaction_set = Set(initialize=rxn_ids)
+
+    # Add performance variables
+    self.recovery_frac_mass_H2O = Var(
+        self.flowsheet().time,
+        initialize=0.8,
+        domain=NonNegativeReals,
+        units=pyunits.dimensionless,
+        bounds=(1E-8, 1.0000001),
+        doc='Mass recovery fraction of water in the treated stream')
+    self.removal_frac_mass_solute = Var(
+        self.flowsheet().time,
+        self.config.property_package.solute_set,
+        domain=NonNegativeReals,
+        initialize=0.01,
+        units=pyunits.dimensionless,
+        doc='Solute removal fraction on a mass basis')
+
+    self.reaction_conversion = Var(
+        self.flowsheet().time,
+        self.reaction_set,
+        initialize=0.5,
+        units=pyunits.dimensionless,
+        doc='Reaction conversion based on key reactant')
+
+    # Load reaction conversions
+    for (t, r), v in self.reaction_conversion.items():
+        try:
+            conv = dbparams["reactions"][r]["conversion"]
+        except KeyError:
+            raise KeyError(
+                f"{self.name} - database provided does not "
+                f"contain an entry for conversion for reaction {r}.")
+        v.fix(conv)
+
+    # Intermediate variables and parameters
+    self.extent_of_reaction = Var(
+        self.flowsheet().time,
+        self.reaction_set,
+        initialize=0,
+        units=pyunits.kg/pyunits.s,
+        doc='Reaction extent on a mass basis based on key reactant')
+
+    # Reaction extent equation
+    @self.Constraint(self.flowsheet().time,
+                     self.reaction_set,
+                     doc='Calcuation of reaction extent from conversion')
+    def reaction_extent_equation(b, t, r):
+        # Get key reactant from database
+        try:
+            key_reactant = dbparams["reactions"][r]["key_reactant"]
+        except KeyError:
+            raise KeyError(
+                f"{self.name} - database provided does not "
+                f"contain an entry for key_reactant for reaction {r}.")
+        if key_reactant not in b.properties_in[0].component_list:
+            raise ValueError(
+                f"{self.name} - key_reactant {key_reactant} for reaction {r} "
+                f"is not in the component list used by the assigned property "
+                f"package.")
+        return (b.extent_of_reaction[t, r] ==
+                b.reaction_conversion[t, r] *
+                b.properties_in[t].flow_mass_comp[key_reactant])
+
+    self.generation_ratio = Param(
+        self.reaction_set,
+        self.config.property_package.component_list,
+        initialize=0,
+        mutable=True,
+        units=pyunits.dimensionless,
+        doc="Mass ratio for generation of species w.r.t. key species")
+    # Load generation ratio data
+    for (r, j), p in self.generation_ratio.items():
+        # Check to see whether to use stoichiometry or conversion ratio
+        try:
+            stoich = dbparams["reactions"][r]["stoichiometry"]
+        except KeyError:
+            raise KeyError(
+                f"{self.name} - database provided does not "
+                f"contain an entry for stoichiometry for reaction {r}.")
+        if j in stoich:
+            if ("conversion_ratio" in stoich[j].keys() and
+                    "order" not in stoich[j].keys()):
+                cratio = stoich[j]["conversion_ratio"]
+            elif ("conversion_ratio" in stoich[j].keys() and
+                    "order" in stoich[j].keys()):
+                raise RuntimeError(
+                    f"{self.name} - database provides entries for both "
+                    f"conversion_ratio and reaction order in reaction {r}. "
+                    f"Please provide only one or the other.")
+            elif "order" in stoich[j].keys():
+                key_reactant = dbparams["reactions"][r]["key_reactant"]
+                if j == key_reactant:
+                    cratio = -1
+                else:
+                    nu_j = cratio = stoich[j]["order"]
+                    try:
+                        nu_k = cratio = stoich[key_reactant]["order"]
+                    except KeyError:
+                        raise KeyError(
+                            f"{self.name} - database provided does not "
+                            f"contain an entry for order w.r.t. species "
+                            f"{key_reactant} in reaction {r}.")
+                    try:
+                        MW_j = cratio = stoich[j]["molecular_weight"]
+                    except KeyError:
+                        raise KeyError(
+                            f"{self.name} - database provided does not "
+                            f"contain an entry for molecular_weight w.r.t. "
+                            f"species {j} in reaction {r}.")
+                    try:
+                        MW_k = cratio = stoich[key_reactant]["molecular_weight"]
+                    except KeyError:
+                        raise KeyError(
+                            f"{self.name} - database provided does not "
+                            f"contain an entry for molecular_weight w.r.t. "
+                            f"species {key_reactant} in reaction {r}.")
+                    cratio = -(nu_j*MW_j)/(nu_k*MW_k)
+            else:
+                raise RuntimeError(
+                    f"{self.name} - database provided does not "
+                    f"contain any information for conversion_ratio or reaction "
+                    f"order w.r.t. species {j} in reaction {r}.")
+            p.set_value(cratio)
+
+    # TODO: Need to test error mesasges abaove
+
+    # Add performance constraints
+    # Water recovery
+    @self.Constraint(self.flowsheet().time, doc='Water recovery equation')
+    def water_recovery_equation(b, t):
+        return (b.recovery_frac_mass_H2O[t] *
+                (b.properties_in[t].flow_mass_comp["H2O"] +
+                 sum(b.generation_ratio[r, "H2O"]*b.extent_of_reaction[t, r]
+                     for r in self.reaction_set)) ==
+                b.properties_treated[t].flow_mass_comp["H2O"])
+
+    # Flow balance
+    @self.Constraint(self.flowsheet().time, doc='Overall flow balance')
+    def water_balance(b, t):
+        return (b.properties_in[t].flow_mass_comp["H2O"] +
+                sum(b.generation_ratio[r, "H2O"]*b.extent_of_reaction[t, r]
+                    for r in self.reaction_set) ==
+                b.properties_treated[t].flow_mass_comp["H2O"] +
+                b.properties_byproduct[t].flow_mass_comp["H2O"])
+
+    # Solute removal
+    @self.Constraint(self.flowsheet().time,
+                     self.config.property_package.solute_set,
+                     doc='Solute removal equations')
+    def solute_removal_equation(b, t, j):
+        return (b.removal_frac_mass_solute[t, j] *
+                (b.properties_in[t].flow_mass_comp[j] +
+                 sum(b.generation_ratio[r, j]*b.extent_of_reaction[t, r]
+                     for r in self.reaction_set)) ==
+                b.properties_byproduct[t].flow_mass_comp[j])
+
+    # Solute concentration of treated stream
+    @self.Constraint(self.flowsheet().time,
+                     self.config.property_package.solute_set,
+                     doc='Constraint for solute concentration in treated '
+                     'stream.')
+    def solute_treated_equation(b, t, j):
+        return (b.properties_in[t].flow_mass_comp[j] +
+                sum(b.generation_ratio[r, j]*b.extent_of_reaction[t, r]
+                    for r in self.reaction_set) ==
+                b.properties_treated[t].flow_mass_comp[j] +
+                b.properties_byproduct[t].flow_mass_comp[j])
+
+    self._stream_table_dict = {"Inlet": self.inlet,
+                               "Treated": self.treated,
+                               "Byproduct": self.byproduct}
+
+    self._perf_var_dict["Water Recovery"] = self.recovery_frac_mass_H2O
+    self._perf_var_dict["Solute Removal"] = self.removal_frac_mass_solute
+    self._perf_var_dict["Reaction Extent"] = self.extent_of_reaction
+
+    self._get_Q = _get_Q_sidor
+
+
+def initialize_sidor(blk, state_args=None, outlvl=idaeslog.NOTSET,
+                     solver=None, optarg=None):
+    '''
+    Initialization routine for single inlet-double outlet unit models with
+    reactions.
+
+    Keyword Arguments:
+        state_args : a dict of arguments to be passed to the property
+                        package(s) to provide an initial state for
+                        initialization (see documentation of the specific
+                        property package) (default = {}).
+        outlvl : sets output level of initialization routine
+        optarg : solver options dictionary object (default=None, use
+                  default solver options)
+        solver : str indicating which solver to use during
+                  initialization (default = None, use default IDAES solver)
+
+    Returns:
+        None
+    '''
+    if optarg is None:
+        optarg = {}
+
+    # Set solver options
+    init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
+    solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+
+    solver_obj = get_solver(solver, optarg)
+
+    # Get initial guesses for inlet if none provided
+    if state_args is None:
+        state_args = {}
+        state_dict = (
+            blk.properties_in[
+                blk.flowsheet().time.first()]
+            .define_port_members())
+
+        for k in state_dict.keys():
+            if state_dict[k].is_indexed():
+                state_args[k] = {}
+                for m in state_dict[k].keys():
+                    state_args[k][m] = state_dict[k][m].value
+            else:
+                state_args[k] = state_dict[k].value
+
+    # ---------------------------------------------------------------------
+    # Initialize control volume block
+    flags = blk.properties_in.initialize(
+        outlvl=outlvl,
+        optarg=optarg,
+        solver=solver,
+        state_args=state_args,
+        hold_state=True
+    )
+    blk.properties_treated.initialize(
+        outlvl=outlvl,
+        optarg=optarg,
+        solver=solver,
+        state_args=state_args,
+        hold_state=False
+    )
+    blk.properties_byproduct.initialize(
+        outlvl=outlvl,
+        optarg=optarg,
+        solver=solver,
+        state_args=state_args,
+        hold_state=False
+    )
+
+    init_log.info_high('Initialization Step 1 Complete.')
+
+    # ---------------------------------------------------------------------
+    # Solve unit
+    with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+        results = solver_obj.solve(blk, tee=slc.tee)
+
+    init_log.info_high(
+        "Initialization Step 2 {}.".format(idaeslog.condition(results))
+    )
+
+    # ---------------------------------------------------------------------
+    # Release Inlet state
+    blk.properties_in.release_state(flags, outlvl)
+
+    init_log.info('Initialization Complete: {}'
+                  .format(idaeslog.condition(results)))
+
+
+def calculate_scaling_factors_sidor(self):
+    # Get default scale factors and do calculations from base classes
+    for t, v in self.water_recovery_equation.items():
+        iscale.constraint_scaling_transform(
+            v, iscale.get_scaling_factor(
+                self.properties_in[t].flow_mass_comp["H2O"],
+                default=1,
+                warning=True,
+                hint=" for water recovery"))
+
+    for t, v in self.water_balance.items():
+        iscale.constraint_scaling_transform(
+            v, iscale.get_scaling_factor(
+                self.properties_in[t].flow_mass_comp["H2O"],
+                default=1,
+                warning=False))  # would just be a duplicate of above
+
+    for (t, j), v in self.solute_removal_equation.items():
+        iscale.constraint_scaling_transform(
+            v, iscale.get_scaling_factor(
+                self.properties_in[t].flow_mass_comp[j],
+                default=1,
+                warning=True,
+                hint=" for solute removal"))
+
+    for (t, j), v in self.solute_treated_equation.items():
+        iscale.constraint_scaling_transform(
+            v, iscale.get_scaling_factor(
+                self.properties_in[t].flow_mass_comp[j],
+                default=1,
+                warning=False))  # would just be a duplicate of above
+
+    dbparams = self.config.database.get_unit_operation_parameters(
+        self._tech_type,
+        subtype=self.config.process_subtype)
+    for (t, r), v in self.reaction_extent_equation.items():
+        key_reactant = dbparams["reactions"][r]["key_reactant"]
+        iscale.constraint_scaling_transform(
+            v, iscale.get_scaling_factor(
+                self.properties_in[t].flow_mass_comp[key_reactant],
+                default=1,
+                warning=False))  # would just be a duplicate of above
+
+
+def _get_Q_sidor(self, t):
+    return self.properties_in[t].flow_vol

--- a/watertap/core/zero_order_sido_reactive.py
+++ b/watertap/core/zero_order_sido_reactive.py
@@ -227,8 +227,6 @@ def build_sido_reactive(self):
                     f"order w.r.t. species {j} in reaction {r}.")
             p.set_value(cratio)
 
-    # TODO: Need to test error mesasges abaove
-
     # Add performance constraints
     # Water recovery
     @self.Constraint(self.flowsheet().time, doc='Water recovery equation')


### PR DESCRIPTION
## Fixes/Addresses: None

## Summary/Motivation:
The PR adds a new helper method for creating zero-order mass balances for systems involving both reactions and separations.

## Changes proposed in this PR:
- New `zero_order_sido_reactive module
- Updates documentation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
