### PR TITLE
Migrate WT3 ozonation and ozone_aop unit models.

### DIFF
--- a/watertap/data/techno_economic/ozonation.yaml
+++ b/watertap/data/techno_economic/ozonation.yaml
@@ -1,6 +1,6 @@
 default:
   recovery_frac_mass_H2O:
-    value: 0.9999
+    value: 1
     units: dimensionless
     reference: Texas Water Development Board IT3PR User Manual
   default_removal_frac_mass_solute:
@@ -26,9 +26,22 @@ default:
     total_coliforms_fecal_ecoli:
       value: 0.997225
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and\uFFFD E.\
-        \ Coli)"
+      constituent_longform: "Total Coliforms (including fecal coliform and E.Coli)"
     viruses_enteric:
       value: 0.997225
       units: dimensionless
       constituent_longform: Viruses (enteric)
+  contact_time:
+    value: 1  
+    units: min
+  concentration_time:  
+    value: 1
+    units: mg/(L*min)
+  mass_transfer_efficiency:
+    value: 0.8      
+    units: dimensionless
+  specific_energy_coeff:
+    value: 5      
+    units: kWh/lb
+    reference: B. Mundy et al. (2018) doi.org/10.1080/01919512.2018.1467187 - Energy consumption 
+      for ozone generator, ozone destruct, nitrogen feed system, cooling water pumps, and other misc. energy uses. 

--- a/watertap/data/techno_economic/ozone_aop.yaml
+++ b/watertap/data/techno_economic/ozone_aop.yaml
@@ -1,8 +1,8 @@
 default:
   recovery_frac_mass_H2O:
-    value: 0.9999
+    value: 1
     units: dimensionless
-    reference: 'EPA model: https://www.epa.gov/sdwa/drinking-water-treatment-technology-unit-cost-models'
+    reference: Texas Water Development Board IT3PR User Manual
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless
@@ -26,9 +26,26 @@ default:
     total_coliforms_fecal_ecoli:
       value: 0.997225
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and\uFFFD E.\
-        \ Coli)"
+      constituent_longform: "Total Coliforms (including fecal coliform and E.Coli)"
     viruses_enteric:
       value: 0.997225
       units: dimensionless
       constituent_longform: Viruses (enteric)
+  contact_time:
+    value: 1  
+    units: min
+  concentration_time:  
+    value: 1
+    units: mg/(L*min)
+  mass_transfer_efficiency:
+    value: 0.8      
+    units: dimensionless
+  specific_energy_coeff:
+    value: 5      
+    units: kWh/lb
+    reference: B. Mundy et al. (2018) doi.org/10.1080/01919512.2018.1467187 - Energy consumption 
+      for ozone generator, ozone destruct, nitrogen feed system, cooling water pumps, and other misc. energy uses. 
+  oxidant_dose:
+    value: 5
+    units: mg/L
+

--- a/watertap/unit_models/zero_order/__init__.py
+++ b/watertap/unit_models/zero_order/__init__.py
@@ -20,3 +20,5 @@ from .sedimentation_zo import SedimentationZO
 from .coag_and_floc_zo import CoagulationFlocculationZO
 from .uv_zo import UVZO
 from .uv_aop_zo import UVAOPZO
+from .ozone_zo import OzoneZO
+from .ozone_aop_zo import OzoneAOPZO

--- a/watertap/unit_models/zero_order/ozone_aop_zo.py
+++ b/watertap/unit_models/zero_order/ozone_aop_zo.py
@@ -1,0 +1,59 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+"""
+This module contains a zero-order representation of a Ozone-AOP unit.
+operation.
+"""
+
+from pyomo.environ import units as pyunits, Var
+from idaes.core import declare_process_block_class
+from watertap.unit_models.zero_order.ozone_zo import OzoneZOData
+
+# Some more information about this module
+__author__ = "Kurban Sitterley"
+
+
+@declare_process_block_class("OzoneAOPZO")
+class OzoneAOPZOData(OzoneZOData):
+    """
+    Zero-Order model for a Ozone-AOP unit operation.
+    """
+
+    CONFIG = OzoneZOData.CONFIG()
+
+    def build(self):
+        super().build()
+
+        self._tech_type = "ozone_aop"
+
+
+        self.oxidant_dose = Var(self.flowsheet().time,
+                                units=pyunits.mg/pyunits.L,
+                                doc="Oxidant dosage")
+
+        self.chemical_flow_mass = Var(self.flowsheet().time,
+                                    units=pyunits.kg/pyunits.s,
+                                    bounds=(0, None),
+                                    doc="Mass flow rate of oxidant solution")
+
+        self._fixed_perf_vars.append(self.oxidant_dose)
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Oxidant mass flow constraint")
+        def chemical_flow_mass_constraint(b, t):
+            return (b.chemical_flow_mass[t] ==
+                    pyunits.convert(b.oxidant_dose[t]
+                    * b.properties_in[t].flow_vol, to_units=pyunits.kg/pyunits.s))
+
+        self._perf_var_dict["Oxidant Dosage (mg/L)"] = self.oxidant_dose
+        self._perf_var_dict["Oxidant Flow (kg/s)"] = self.chemical_flow_mass

--- a/watertap/unit_models/zero_order/ozone_zo.py
+++ b/watertap/unit_models/zero_order/ozone_zo.py
@@ -1,0 +1,106 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+"""
+This module contains a zero-order representation of a Ozone reactor unit.
+operation.
+"""
+
+from pyomo.environ import units as pyunits, Var
+from pyomo.common.config import ConfigValue, In
+from idaes.core.util.exceptions import ConfigurationError
+from idaes.core import declare_process_block_class
+from watertap.core import build_siso, ZeroOrderBaseData
+
+# Some more information about this module
+__author__ = "Kurban Sitterley"
+
+
+@declare_process_block_class("OzoneZO")
+class OzoneZOData(ZeroOrderBaseData):
+    """
+    Zero-Order model for a Ozone unit operation.
+    """
+
+    CONFIG = ZeroOrderBaseData.CONFIG()
+
+    def build(self):
+        super().build()
+
+        self._tech_type = "ozonation"
+
+        build_siso(self)
+
+        if 'toc' not in self.config.property_package.config.solute_list:
+            raise ConfigurationError("TOC must be in solute list for Ozonation or Ozone/AOP")
+
+
+        self.contact_time = Var(self.flowsheet().time,
+                                units=pyunits.minute,
+                                doc="Ozone contact time")
+
+        self.concentration_time = Var(self.flowsheet().time,
+                                       units=pyunits.mg/(pyunits.liter*pyunits.minute),
+                                       doc="CT value for ozone contactor")
+
+        self.mass_transfer_efficiency = Var(self.flowsheet().time,
+                                            units=pyunits.dimensionless,
+                                            doc="Ozone mass transfer efficiency")
+                                    
+
+        self.specific_energy_coeff = Var(self.flowsheet().time,
+                                        units=pyunits.kWh/pyunits.lb,
+                                        bounds=(0, None),
+                                        doc="Specific energy consumption for ozone generation")
+
+        self._fixed_perf_vars.append(self.contact_time)
+        self._fixed_perf_vars.append(self.concentration_time)
+        self._fixed_perf_vars.append(self.mass_transfer_efficiency)
+        self._fixed_perf_vars.append(self.specific_energy_coeff)
+
+        self.ozone_flow_mass = Var(self.flowsheet().time,
+                                    units=pyunits.lb/pyunits.hr,
+                                    bounds=(0, None),
+                                    doc="Mass flow rate of ozone")
+        
+        self.ozone_consumption = Var(self.flowsheet().time,
+                                    units=pyunits.mg/pyunits.liter,
+                                    doc="Ozone consumption")
+
+        self.ozone_generation_power = Var(self.flowsheet().time,
+                                        units=pyunits.kW,
+                                        bounds=(0, None),
+                                        doc="Ozone generation power")
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Ozone consumption constraint")
+        def ozone_consumption_constraint(b, t):
+            return (b.ozone_consumption[t] ==
+                    ((pyunits.convert(b.properties_in[t].conc_mass_comp['toc'], to_units=pyunits.mg/pyunits.liter)
+                    + self.concentration_time[t] * self.contact_time[t])) / self.mass_transfer_efficiency[t])
+
+        @self.Constraint(self.flowsheet().time,
+                    doc='Ozone mass flow constraint')
+        def ozone_flow_mass_constraint(b, t):
+            return b.ozone_flow_mass[t] == pyunits.convert(b.properties_in[t].flow_vol * b.ozone_consumption[t], to_units=pyunits.lb/pyunits.hr)
+
+        @self.Constraint(self.flowsheet().time,
+                    doc='Ozone power constraint')
+        def ozone_generation_power_constraint(b, t):
+            return b.ozone_generation_power[t] == b.specific_energy_coeff[t] * b.ozone_flow_mass[t]
+
+        self._perf_var_dict["Ozone Contact Time (min)"] = self.contact_time
+        self._perf_var_dict["Ozone CT Value (mg/(L*min))"] = self.concentration_time
+        self._perf_var_dict["Ozone Mass Transfer Efficiency"] = self.mass_transfer_efficiency
+        self._perf_var_dict["Ozone Mass Flow (lb/hr)"] = self.ozone_flow_mass
+        self._perf_var_dict["Ozone Unit Power Demand (kW)"] = self.ozone_generation_power
+    

--- a/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
@@ -1,0 +1,382 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+"""
+Tests for zero-order Ozone/AOP model
+"""
+import pytest
+from io import StringIO
+
+from pyomo.environ import (
+    check_optimal_termination, ConcreteModel, Constraint, value, Var)
+from pyomo.util.check_units import assert_units_consistent
+
+from idaes.core import FlowsheetBlock
+from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util import get_solver
+from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.testing import initialization_tester
+
+from watertap.unit_models.zero_order import OzoneAOPZO
+from watertap.core.wt_database import Database
+from watertap.core.zero_order_properties import WaterParameterBlock
+
+solver = get_solver()
+
+
+class TestOzoneZO_with_default_removal:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = ConcreteModel()
+        m.db = Database()
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+        m.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", 
+                                                                    "toc", 
+                                                                    "giardia_lamblia",
+                                                                    "eeq", 
+                                                                    "total_coliforms_fecal_ecoli", 
+                                                                    "viruses_enteric",
+                                                                    "tss"]})
+
+        m.fs.unit = OzoneAOPZO(default={ "property_package": m.fs.params,
+                                            "database": m.db})
+
+        m.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(100)
+        m.fs.unit.inlet.flow_mass_comp[0, "cryptosporidium"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "toc"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "giardia_lamblia"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "eeq"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "total_coliforms_fecal_ecoli"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "viruses_enteric"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "tss"].fix(1)
+
+        return m
+
+    @pytest.mark.unit
+    def test_toc_in_solute_list(self):
+        model = ConcreteModel()
+        model.db = Database()
+
+        model.fs = FlowsheetBlock(default={"dynamic": False})
+        model.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", 
+                                                                        "giardia_lamblia",
+                                                                        "eeq"]})
+        with pytest.raises(ConfigurationError,
+                            match="TOC must be in solute list for Ozonation or Ozone/AOP"):
+
+
+            model.fs.unit = OzoneAOPZO(default={ "property_package": model.fs.params,
+                                                "database": model.db})
+
+
+    @pytest.mark.unit
+    def test_build(self, model):
+        assert model.fs.unit.config.database == model.db
+        assert model.fs.unit._tech_type == "ozone_aop"
+        assert isinstance(model.fs.unit.contact_time, Var)
+        assert isinstance(model.fs.unit.concentration_time, Var)
+        assert isinstance(model.fs.unit.mass_transfer_efficiency, Var)
+        assert isinstance(model.fs.unit.ozone_flow_mass, Var)
+        assert isinstance(model.fs.unit.ozone_consumption, Var)
+        assert isinstance(model.fs.unit.ozone_generation_power, Var)
+        assert isinstance(model.fs.unit.specific_energy_coeff, Var)
+        assert isinstance(model.fs.unit.oxidant_dose, Var)
+        assert isinstance(model.fs.unit.chemical_flow_mass, Var)
+        assert isinstance(model.fs.unit.ozone_consumption_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_flow_mass_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_generation_power_constraint, Constraint)
+        assert isinstance(model.fs.unit.chemical_flow_mass_constraint, Constraint)
+
+
+    @pytest.mark.component
+    def test_load_parameters(self, model):
+        data = model.db.get_unit_operation_parameters("ozone_aop")
+        model.fs.unit.load_parameters_from_database(use_default_removal=True)
+        assert model.fs.unit.recovery_frac_mass_H2O[0].fixed
+        assert model.fs.unit.recovery_frac_mass_H2O[0].value == 1
+
+        for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
+            assert v.fixed
+            if j not in data["removal_frac_mass_solute"]:
+                assert v.value == data["default_removal_frac_mass_solute"]["value"]
+            else:
+                assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+        assert model.fs.unit.contact_time[0].fixed
+        assert model.fs.unit.contact_time[0].value == data["contact_time"]["value"]
+        assert model.fs.unit.concentration_time[0].fixed
+        assert model.fs.unit.concentration_time[0].value == data["concentration_time"]["value"]
+        assert model.fs.unit.mass_transfer_efficiency[0].fixed
+        assert model.fs.unit.mass_transfer_efficiency[0].value == data["mass_transfer_efficiency"]["value"]
+        assert model.fs.unit.specific_energy_coeff[0].fixed
+        assert model.fs.unit.specific_energy_coeff[0].value == data["specific_energy_coeff"]["value"]
+        assert model.fs.unit.oxidant_dose[0].fixed
+        assert model.fs.unit.oxidant_dose[0].value == data["oxidant_dose"]["value"]
+
+
+    @pytest.mark.component
+    def test_degrees_of_freedom(self, model):
+        assert degrees_of_freedom(model.fs.unit) == 0
+
+    @pytest.mark.component
+    def test_unit_consistency(self, model):
+        assert_units_consistent(model.fs.unit)
+
+    @pytest.mark.component
+    def test_initialize(self, model):
+        initialization_tester(model)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, model):
+        results = solver.solve(model)
+
+        # Check for optimal solution
+        assert check_optimal_termination(results)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, model):
+        assert (pytest.approx(0.102089, rel=1e-5) ==
+                value(model.fs.unit.properties_treated[0].flow_vol))
+        assert (pytest.approx(2.661333, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["toc"]))
+        assert (pytest.approx(9.795299, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["tss"]))
+        assert (pytest.approx(0.103497, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["eeq"]))
+        assert (pytest.approx(9921.863324, rel=1e-5) ==
+                value(model.fs.unit.ozone_flow_mass[0]))
+        assert (pytest.approx(49609.316620, rel=1e-5) ==
+                value(model.fs.unit.ozone_generation_power[0]))
+        assert (pytest.approx(0.000535, rel=1e-5) ==
+                value(model.fs.unit.chemical_flow_mass[0]))
+
+    @pytest.mark.component
+    def test_report(self, model):
+        stream = StringIO()
+
+        model.fs.unit.report(ostream=stream)
+
+        output = """
+====================================================================================
+Unit : fs.unit                                                             Time: 0.0
+------------------------------------------------------------------------------------
+    Unit Performance
+
+    Variables: 
+
+    Key                                          : Value      : Fixed : Bounds
+                           Oxidant Dosage (mg/L) :     5.0000 :  True : (None, None)
+                             Oxidant Flow (kg/s) : 0.00053500 : False : (0, None)
+                     Ozone CT Value (mg/(L*min)) :     1.0000 :  True : (None, None)
+                        Ozone Contact Time (min) :     1.0000 :  True : (None, None)
+                         Ozone Mass Flow (lb/hr) :     9921.9 : False : (0, None)
+                  Ozone Mass Transfer Efficiency :    0.80000 :  True : (None, None)
+                    Ozone Unit Power Demand (kW) :     49609. : False : (0, None)
+                Solute Removal [cryptosporidium] :    0.29479 :  True : (0, None)
+                            Solute Removal [eeq] :    0.98943 :  True : (0, None)
+                Solute Removal [giardia_lamblia] :    0.90324 :  True : (0, None)
+                            Solute Removal [toc] :    0.72830 :  True : (0, None)
+    Solute Removal [total_coliforms_fecal_ecoli] :    0.99723 :  True : (0, None)
+                            Solute Removal [tss] :     0.0000 :  True : (0, None)
+                Solute Removal [viruses_enteric] :    0.99723 :  True : (0, None)
+
+------------------------------------------------------------------------------------
+    Stream Table
+                                                     Inlet  Treated
+    Volumetric Flowrate                            0.10700  0.10209
+    Mass Concentration H2O                          934.58   979.53
+    Mass Concentration cryptosporidium              9.3458   6.9078
+    Mass Concentration toc                          9.3458   2.6613
+    Mass Concentration giardia_lamblia              9.3458  0.94780
+    Mass Concentration eeq                          9.3458  0.10350
+    Mass Concentration total_coliforms_fecal_ecoli  9.3458 0.027182
+    Mass Concentration viruses_enteric              9.3458 0.027182
+    Mass Concentration tss                          9.3458   9.7953
+====================================================================================
+"""
+
+        assert output in stream.getvalue()
+
+
+class TestOzoneZO_w_o_default_removal:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = ConcreteModel()
+        m.db = Database()
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+        m.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", 
+                                                                    "toc", 
+                                                                    "giardia_lamblia",
+                                                                    "eeq", 
+                                                                    "total_coliforms_fecal_ecoli", 
+                                                                    "viruses_enteric"
+                                                                    ]})
+
+        m.fs.unit = OzoneAOPZO(default={ "property_package": m.fs.params,
+                                            "database": m.db})
+
+        m.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(100)
+        m.fs.unit.inlet.flow_mass_comp[0, "cryptosporidium"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "toc"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "giardia_lamblia"].fix(2)
+        m.fs.unit.inlet.flow_mass_comp[0, "eeq"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "total_coliforms_fecal_ecoli"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "viruses_enteric"].fix(1)
+
+        return m
+
+    def test_toc_in_solute_list(self):
+        model = ConcreteModel()
+        model.db = Database()
+
+        model.fs = FlowsheetBlock(default={"dynamic": False})
+        model.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", "viruses_enteric"]})
+        with pytest.raises(ConfigurationError,
+                            match="TOC must be in solute list for Ozonation or Ozone/AOP"):
+
+
+            model.fs.unit = OzoneAOPZO(default={ "property_package": model.fs.params,
+                                            "database": model.db})
+
+    @pytest.mark.unit
+    def test_build(self, model):
+        assert model.fs.unit.config.database == model.db
+        assert model.fs.unit._tech_type == "ozone_aop"
+        assert isinstance(model.fs.unit.contact_time, Var)
+        assert isinstance(model.fs.unit.concentration_time, Var)
+        assert isinstance(model.fs.unit.mass_transfer_efficiency, Var)
+        assert isinstance(model.fs.unit.ozone_flow_mass, Var)
+        assert isinstance(model.fs.unit.ozone_consumption, Var)
+        assert isinstance(model.fs.unit.ozone_generation_power, Var)
+        assert isinstance(model.fs.unit.specific_energy_coeff, Var)
+        assert isinstance(model.fs.unit.oxidant_dose, Var)
+        assert isinstance(model.fs.unit.chemical_flow_mass, Var)
+        assert isinstance(model.fs.unit.ozone_consumption_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_flow_mass_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_generation_power_constraint, Constraint)
+        assert isinstance(model.fs.unit.chemical_flow_mass_constraint, Constraint)
+
+    @pytest.mark.component
+    def test_load_parameters(self, model):
+        data = model.db.get_unit_operation_parameters("ozone_aop")
+        model.fs.unit.load_parameters_from_database(use_default_removal=True)
+        assert model.fs.unit.recovery_frac_mass_H2O[0].fixed
+        assert model.fs.unit.recovery_frac_mass_H2O[0].value == 1
+
+        for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
+            assert v.fixed
+            if j not in data["removal_frac_mass_solute"]:
+                assert v.value == data["default_removal_frac_mass_solute"]["value"]
+            else:
+                assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+        assert model.fs.unit.contact_time[0].fixed
+        assert model.fs.unit.contact_time[0].value == data["contact_time"]["value"]
+        assert model.fs.unit.concentration_time[0].fixed
+        assert model.fs.unit.concentration_time[0].value == data["concentration_time"]["value"]
+        assert model.fs.unit.mass_transfer_efficiency[0].fixed
+        assert model.fs.unit.mass_transfer_efficiency[0].value == data["mass_transfer_efficiency"]["value"]
+        assert model.fs.unit.specific_energy_coeff[0].fixed
+        assert model.fs.unit.specific_energy_coeff[0].value == data["specific_energy_coeff"]["value"]
+        assert model.fs.unit.oxidant_dose[0].fixed
+        assert model.fs.unit.oxidant_dose[0].value == data["oxidant_dose"]["value"]
+
+    @pytest.mark.component
+    def test_degrees_of_freedom(self, model):
+        assert degrees_of_freedom(model.fs.unit) == 0
+
+    @pytest.mark.component
+    def test_unit_consistency(self, model):
+        assert_units_consistent(model.fs.unit)
+
+    @pytest.mark.component
+    def test_initialize(self, model):
+        initialization_tester(model)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, model):
+        results = solver.solve(model)
+
+        # Check for optimal solution
+        assert check_optimal_termination(results)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, model):
+        assert (pytest.approx(0.101186, rel=1e-5) ==
+                value(model.fs.unit.properties_treated[0].flow_vol))
+        assert (pytest.approx(2.685090, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["toc"]))
+        assert (pytest.approx(1.912526, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["giardia_lamblia"]))
+        assert (pytest.approx(0.104420, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["eeq"]))
+        assert (pytest.approx(9921.863324, rel=1e-5) ==
+                value(model.fs.unit.ozone_flow_mass[0]))
+        assert (pytest.approx(49609.316620, rel=1e-5) ==
+                value(model.fs.unit.ozone_generation_power[0]))
+        assert (pytest.approx(0.000535, rel=1e-5) ==
+                value(model.fs.unit.chemical_flow_mass[0]))
+
+    @pytest.mark.component
+    def test_report(self, model):
+        stream = StringIO()
+
+        model.fs.unit.report(ostream=stream)
+
+        output = """
+====================================================================================
+Unit : fs.unit                                                             Time: 0.0
+------------------------------------------------------------------------------------
+    Unit Performance
+
+    Variables: 
+
+    Key                                          : Value      : Fixed : Bounds
+                           Oxidant Dosage (mg/L) :     5.0000 :  True : (None, None)
+                             Oxidant Flow (kg/s) : 0.00053500 : False : (0, None)
+                     Ozone CT Value (mg/(L*min)) :     1.0000 :  True : (None, None)
+                        Ozone Contact Time (min) :     1.0000 :  True : (None, None)
+                         Ozone Mass Flow (lb/hr) :     9921.9 : False : (0, None)
+                  Ozone Mass Transfer Efficiency :    0.80000 :  True : (None, None)
+                    Ozone Unit Power Demand (kW) :     49609. : False : (0, None)
+                Solute Removal [cryptosporidium] :    0.29479 :  True : (0, None)
+                            Solute Removal [eeq] :    0.98943 :  True : (0, None)
+                Solute Removal [giardia_lamblia] :    0.90324 :  True : (0, None)
+                            Solute Removal [toc] :    0.72830 :  True : (0, None)
+    Solute Removal [total_coliforms_fecal_ecoli] :    0.99723 :  True : (0, None)
+                Solute Removal [viruses_enteric] :    0.99723 :  True : (0, None)
+
+------------------------------------------------------------------------------------
+    Stream Table
+                                                     Inlet  Treated
+    Volumetric Flowrate                            0.10700  0.10119
+    Mass Concentration H2O                          934.58   988.27
+    Mass Concentration cryptosporidium              9.3458   6.9694
+    Mass Concentration toc                          9.3458   2.6851
+    Mass Concentration giardia_lamblia              18.692   1.9125
+    Mass Concentration eeq                          9.3458  0.10442
+    Mass Concentration total_coliforms_fecal_ecoli  9.3458 0.027425
+    Mass Concentration viruses_enteric              9.3458 0.027425
+====================================================================================
+"""
+
+        assert output in stream.getvalue()

--- a/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
@@ -73,15 +73,13 @@ class TestOzoneZO_with_default_removal:
                                                                         "eeq"]})
         with pytest.raises(ConfigurationError,
                             match="TOC must be in solute list for Ozonation or Ozone/AOP"):
-
-
             model.fs.unit = OzoneAOPZO(default={ "property_package": model.fs.params,
                                                 "database": model.db})
 
 
     @pytest.mark.unit
     def test_build(self, model):
-        assert model.fs.unit.config.database == model.db
+        assert model.fs.unit.config.database is model.db
         assert model.fs.unit._tech_type == "ozone_aop"
         assert isinstance(model.fs.unit.contact_time, Var)
         assert isinstance(model.fs.unit.concentration_time, Var)
@@ -255,7 +253,7 @@ class TestOzoneZO_w_o_default_removal:
 
     @pytest.mark.unit
     def test_build(self, model):
-        assert model.fs.unit.config.database == model.db
+        assert model.fs.unit.config.database is model.db
         assert model.fs.unit._tech_type == "ozone_aop"
         assert isinstance(model.fs.unit.contact_time, Var)
         assert isinstance(model.fs.unit.concentration_time, Var)

--- a/watertap/unit_models/zero_order/tests/test_ozone_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_zo.py
@@ -1,0 +1,368 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+"""
+Tests for zero-order Ozonation model
+"""
+import pytest
+from io import StringIO
+
+from pyomo.environ import (
+    check_optimal_termination, ConcreteModel, Constraint, value, Var)
+from pyomo.util.check_units import assert_units_consistent
+
+from idaes.core import FlowsheetBlock
+from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util import get_solver
+from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.testing import initialization_tester
+
+from watertap.unit_models.zero_order import OzoneZO
+from watertap.core.wt_database import Database
+from watertap.core.zero_order_properties import WaterParameterBlock
+
+solver = get_solver()
+
+
+class TestOzoneZO_with_default_removal:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = ConcreteModel()
+        m.db = Database()
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+        m.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", 
+                                                                    "toc", 
+                                                                    "giardia_lamblia",
+                                                                    "eeq", 
+                                                                    "total_coliforms_fecal_ecoli", 
+                                                                    "viruses_enteric",
+                                                                    "tss"]})
+
+        m.fs.unit = OzoneZO(default={ "property_package": m.fs.params,
+                                            "database": m.db})
+
+        m.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(100)
+        m.fs.unit.inlet.flow_mass_comp[0, "cryptosporidium"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "toc"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "giardia_lamblia"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "eeq"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "total_coliforms_fecal_ecoli"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "viruses_enteric"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "tss"].fix(1)
+
+
+        return m
+
+    @pytest.mark.unit
+    def test_toc_in_solute_list(self):
+        model = ConcreteModel()
+        model.db = Database()
+
+        model.fs = FlowsheetBlock(default={"dynamic": False})
+        model.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", 
+                                                                        "giardia_lamblia",
+                                                                        "eeq"]})
+        with pytest.raises(ConfigurationError,
+                            match="TOC must be in solute list for Ozonation or Ozone/AOP"):
+
+
+            model.fs.unit = OzoneZO(default={ "property_package": model.fs.params,
+                                            "database": model.db})
+
+        
+        
+
+
+    @pytest.mark.unit
+    def test_build(self, model):
+        assert model.fs.unit.config.database == model.db
+        assert model.fs.unit._tech_type == "ozonation"
+        assert isinstance(model.fs.unit.contact_time, Var)
+        assert isinstance(model.fs.unit.concentration_time, Var)
+        assert isinstance(model.fs.unit.mass_transfer_efficiency, Var)
+        assert isinstance(model.fs.unit.ozone_flow_mass, Var)
+        assert isinstance(model.fs.unit.ozone_consumption, Var)
+        assert isinstance(model.fs.unit.ozone_generation_power, Var)
+        assert isinstance(model.fs.unit.specific_energy_coeff, Var)
+        assert isinstance(model.fs.unit.ozone_consumption_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_flow_mass_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_generation_power_constraint, Constraint)
+        
+
+
+    @pytest.mark.component
+    def test_load_parameters(self, model):
+        data = model.db.get_unit_operation_parameters("ozonation")
+        model.fs.unit.load_parameters_from_database(use_default_removal=True)
+        assert model.fs.unit.recovery_frac_mass_H2O[0].fixed
+        assert model.fs.unit.recovery_frac_mass_H2O[0].value == 1
+
+        for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
+            assert v.fixed
+            if j not in data["removal_frac_mass_solute"]:
+                assert v.value == data["default_removal_frac_mass_solute"]["value"]
+            else:
+                assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+        assert model.fs.unit.contact_time[0].fixed
+        assert model.fs.unit.contact_time[0].value == data["contact_time"]["value"]
+        assert model.fs.unit.concentration_time[0].fixed
+        assert model.fs.unit.concentration_time[0].value == data["concentration_time"]["value"]
+        assert model.fs.unit.mass_transfer_efficiency[0].fixed
+        assert model.fs.unit.mass_transfer_efficiency[0].value == data["mass_transfer_efficiency"]["value"]
+        assert model.fs.unit.specific_energy_coeff[0].fixed
+        assert model.fs.unit.specific_energy_coeff[0].value == data["specific_energy_coeff"]["value"]
+
+
+    @pytest.mark.component
+    def test_degrees_of_freedom(self, model):
+        assert degrees_of_freedom(model.fs.unit) == 0
+
+    @pytest.mark.component
+    def test_unit_consistency(self, model):
+        assert_units_consistent(model.fs.unit)
+
+    @pytest.mark.component
+    def test_initialize(self, model):
+        initialization_tester(model)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, model):
+        results = solver.solve(model)
+
+        # Check for optimal solution
+        assert check_optimal_termination(results)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, model):
+        assert (pytest.approx(0.102089, rel=1e-5) ==
+                value(model.fs.unit.properties_treated[0].flow_vol))
+        assert (pytest.approx(2.661333, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["toc"]))
+        assert (pytest.approx(9.795299, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["tss"]))
+        assert (pytest.approx(0.103497, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["eeq"]))
+        assert (pytest.approx(9921.863324, rel=1e-5) ==
+                value(model.fs.unit.ozone_flow_mass[0]))
+        assert (pytest.approx(49609.316620, rel=1e-5) ==
+                value(model.fs.unit.ozone_generation_power[0]))
+
+    @pytest.mark.component
+    def test_report(self, model):
+        stream = StringIO()
+
+        model.fs.unit.report(ostream=stream)
+
+        output = """
+====================================================================================
+Unit : fs.unit                                                             Time: 0.0
+------------------------------------------------------------------------------------
+    Unit Performance
+
+    Variables: 
+
+    Key                                          : Value   : Fixed : Bounds
+                     Ozone CT Value (mg/(L*min)) :  1.0000 :  True : (None, None)
+                        Ozone Contact Time (min) :  1.0000 :  True : (None, None)
+                         Ozone Mass Flow (lb/hr) :  9921.9 : False : (0, None)
+                  Ozone Mass Transfer Efficiency : 0.80000 :  True : (None, None)
+                    Ozone Unit Power Demand (kW) :  49609. : False : (0, None)
+                Solute Removal [cryptosporidium] : 0.29479 :  True : (0, None)
+                            Solute Removal [eeq] : 0.98943 :  True : (0, None)
+                Solute Removal [giardia_lamblia] : 0.90324 :  True : (0, None)
+                            Solute Removal [toc] : 0.72830 :  True : (0, None)
+    Solute Removal [total_coliforms_fecal_ecoli] : 0.99723 :  True : (0, None)
+                            Solute Removal [tss] :  0.0000 :  True : (0, None)
+                Solute Removal [viruses_enteric] : 0.99723 :  True : (0, None)
+
+------------------------------------------------------------------------------------
+    Stream Table
+                                                     Inlet  Treated
+    Volumetric Flowrate                            0.10700  0.10209
+    Mass Concentration H2O                          934.58   979.53
+    Mass Concentration cryptosporidium              9.3458   6.9078
+    Mass Concentration toc                          9.3458   2.6613
+    Mass Concentration giardia_lamblia              9.3458  0.94780
+    Mass Concentration eeq                          9.3458  0.10350
+    Mass Concentration total_coliforms_fecal_ecoli  9.3458 0.027182
+    Mass Concentration viruses_enteric              9.3458 0.027182
+    Mass Concentration tss                          9.3458   9.7953
+====================================================================================
+"""
+
+        assert output in stream.getvalue()
+
+
+class TestOzoneZO_w_o_default_removal:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = ConcreteModel()
+        m.db = Database()
+
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+        m.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", 
+                                            "toc", 
+                                            "giardia_lamblia",
+                                            "eeq", 
+                                            "total_coliforms_fecal_ecoli", 
+                                            "viruses_enteric"
+                                            ]})
+
+        m.fs.unit = OzoneZO(default={ "property_package": m.fs.params,
+                                            "database": m.db})
+
+        m.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(100)
+        m.fs.unit.inlet.flow_mass_comp[0, "cryptosporidium"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "toc"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "giardia_lamblia"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "eeq"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "total_coliforms_fecal_ecoli"].fix(1)
+        m.fs.unit.inlet.flow_mass_comp[0, "viruses_enteric"].fix(1)
+
+        return m
+
+    def test_toc_in_solute_list(self):
+        model = ConcreteModel()
+        model.db = Database()
+
+        model.fs = FlowsheetBlock(default={"dynamic": False})
+        model.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", "viruses_enteric"]})
+        with pytest.raises(ConfigurationError,
+                            match="TOC must be in solute list for Ozonation or Ozone/AOP"):
+
+
+            model.fs.unit = OzoneZO(default={ "property_package": model.fs.params,
+                                            "database": model.db})
+
+    @pytest.mark.unit
+    def test_build(self, model):
+        assert model.fs.unit.config.database == model.db
+        assert model.fs.unit._tech_type == "ozonation"
+        assert isinstance(model.fs.unit.contact_time, Var)
+        assert isinstance(model.fs.unit.concentration_time, Var)
+        assert isinstance(model.fs.unit.mass_transfer_efficiency, Var)
+        assert isinstance(model.fs.unit.ozone_flow_mass, Var)
+        assert isinstance(model.fs.unit.ozone_consumption, Var)
+        assert isinstance(model.fs.unit.ozone_generation_power, Var)
+        assert isinstance(model.fs.unit.specific_energy_coeff, Var)
+        assert isinstance(model.fs.unit.ozone_consumption_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_flow_mass_constraint, Constraint)
+        assert isinstance(model.fs.unit.ozone_generation_power_constraint, Constraint)
+
+    @pytest.mark.component
+    def test_load_parameters(self, model):
+        data = model.db.get_unit_operation_parameters("ozonation")
+        model.fs.unit.load_parameters_from_database()
+        assert model.fs.unit.recovery_frac_mass_H2O[0].value == 1
+
+        for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
+            assert v.fixed
+            if j not in data["removal_frac_mass_solute"]:
+                assert v.value == data["default_removal_frac_mass_solute"]["value"]
+            else:
+                assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+        assert model.fs.unit.contact_time[0].fixed
+        assert model.fs.unit.contact_time[0].value == data["contact_time"]["value"]
+        assert model.fs.unit.concentration_time[0].fixed
+        assert model.fs.unit.concentration_time[0].value == data["concentration_time"]["value"]
+        assert model.fs.unit.mass_transfer_efficiency[0].fixed
+        assert model.fs.unit.mass_transfer_efficiency[0].value == data["mass_transfer_efficiency"]["value"]
+        assert model.fs.unit.specific_energy_coeff[0].fixed
+        assert model.fs.unit.specific_energy_coeff[0].value == data["specific_energy_coeff"]["value"]
+
+    @pytest.mark.component
+    def test_degrees_of_freedom(self, model):
+        assert degrees_of_freedom(model.fs.unit) == 0
+
+    @pytest.mark.component
+    def test_unit_consistency(self, model):
+        assert_units_consistent(model.fs.unit)
+
+    @pytest.mark.component
+    def test_initialize(self, model):
+        initialization_tester(model)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, model):
+        results = solver.solve(model)
+
+        # Check for optimal solution
+        assert check_optimal_termination(results)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, model):
+        assert (pytest.approx(0.101089, rel=1e-5) ==
+                value(model.fs.unit.properties_treated[0].flow_vol))
+        assert (pytest.approx(2.687660, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["toc"]))
+        assert (pytest.approx(0.957178, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["giardia_lamblia"]))
+        assert (pytest.approx(0.104520, rel=1e-5) == value(
+            model.fs.unit.properties_treated[0].conc_mass_comp["eeq"]))
+        assert (pytest.approx(9921.85340, rel=1e-5) ==
+                value(model.fs.unit.ozone_flow_mass[0]))
+        assert (pytest.approx(49609.267016, rel=1e-5) ==
+                value(model.fs.unit.ozone_generation_power[0]))
+
+    @pytest.mark.component
+    def test_report(self, model):
+        stream = StringIO()
+
+        model.fs.unit.report(ostream=stream)
+
+        output = """
+====================================================================================
+Unit : fs.unit                                                             Time: 0.0
+------------------------------------------------------------------------------------
+    Unit Performance
+
+    Variables: 
+
+    Key                                          : Value   : Fixed : Bounds
+                     Ozone CT Value (mg/(L*min)) :  1.0000 :  True : (None, None)
+                        Ozone Contact Time (min) :  1.0000 :  True : (None, None)
+                         Ozone Mass Flow (lb/hr) :  9921.9 : False : (0, None)
+                  Ozone Mass Transfer Efficiency : 0.80000 :  True : (None, None)
+                    Ozone Unit Power Demand (kW) :  49609. : False : (0, None)
+                Solute Removal [cryptosporidium] : 0.29479 :  True : (0, None)
+                            Solute Removal [eeq] : 0.98943 :  True : (0, None)
+                Solute Removal [giardia_lamblia] : 0.90324 :  True : (0, None)
+                            Solute Removal [toc] : 0.72830 :  True : (0, None)
+    Solute Removal [total_coliforms_fecal_ecoli] : 0.99723 :  True : (0, None)
+                Solute Removal [viruses_enteric] : 0.99723 :  True : (0, None)
+
+------------------------------------------------------------------------------------
+    Stream Table
+                                                     Inlet  Treated
+    Volumetric Flowrate                            0.10600  0.10109
+    Mass Concentration H2O                          943.40   989.22
+    Mass Concentration cryptosporidium              9.4340   6.9761
+    Mass Concentration toc                          9.4340   2.6877
+    Mass Concentration giardia_lamblia              9.4340  0.95718
+    Mass Concentration eeq                          9.4340  0.10452
+    Mass Concentration total_coliforms_fecal_ecoli  9.4340 0.027451
+    Mass Concentration viruses_enteric              9.4340 0.027451
+====================================================================================
+"""
+
+        assert output in stream.getvalue()

--- a/watertap/unit_models/zero_order/tests/test_ozone_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_zo.py
@@ -74,14 +74,8 @@ class TestOzoneZO_with_default_removal:
                                                                         "eeq"]})
         with pytest.raises(ConfigurationError,
                             match="TOC must be in solute list for Ozonation or Ozone/AOP"):
-
-
             model.fs.unit = OzoneZO(default={ "property_package": model.fs.params,
                                             "database": model.db})
-
-        
-        
-
 
     @pytest.mark.unit
     def test_build(self, model):
@@ -97,7 +91,6 @@ class TestOzoneZO_with_default_removal:
         assert isinstance(model.fs.unit.ozone_consumption_constraint, Constraint)
         assert isinstance(model.fs.unit.ozone_flow_mass_constraint, Constraint)
         assert isinstance(model.fs.unit.ozone_generation_power_constraint, Constraint)
-        
 
 
     @pytest.mark.component
@@ -244,8 +237,6 @@ class TestOzoneZO_w_o_default_removal:
         model.fs.params = WaterParameterBlock(default={"solute_list": ["cryptosporidium", "viruses_enteric"]})
         with pytest.raises(ConfigurationError,
                             match="TOC must be in solute list for Ozonation or Ozone/AOP"):
-
-
             model.fs.unit = OzoneZO(default={ "property_package": model.fs.params,
                                             "database": model.db})
 


### PR DESCRIPTION
## Fixes/Addresses:



## Summary/Motivation:

Adding ozonation and ozone_aop models

## Changes proposed in this PR:
-add unit model for ozonation and corresponding test files
-add unit model for ozone_aop and corresponding test files
-update ozonation.yaml and ozone_aop.yaml files

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
