### PR TITLE
Quick Revision of Ion Property Model for DSPM

### DIFF
--- a/watertap/property_models/ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/ion_DSPMDE_prop_pack.py
@@ -687,8 +687,8 @@ class DSPMDEStateBlockData(StateBlockData):
         for ind, v in self.diffus_phase_comp.items():
             if iscale.get_scaling_factor(v) is None:
                 iscale.set_scaling_factor(self.diffus_phase_comp[ind], 1e10)
-            else:
-                raise
+            # else:
+            #     raise
 
         for p, v in self.dens_mass_phase.items():
             if iscale.get_scaling_factor(v) is None:

--- a/watertap/property_models/ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/ion_DSPMDE_prop_pack.py
@@ -167,7 +167,6 @@ class DSPMDEParameterData(PhysicalParameterBlock):
         self.set_default_scaling('pressure', 1e-6)
         self.set_default_scaling('dens_mass_phase', 1e-3, index='Liq')
         self.set_default_scaling('visc_d_phase', 1e3, index='Liq')
-        self.set_default_scaling('diffus_phase_comp', 1e9, index='Liq')
 
 
     @classmethod
@@ -687,8 +686,6 @@ class DSPMDEStateBlockData(StateBlockData):
         for ind, v in self.diffus_phase_comp.items():
             if iscale.get_scaling_factor(v) is None:
                 iscale.set_scaling_factor(self.diffus_phase_comp[ind], 1e10)
-            # else:
-            #     raise
 
         for p, v in self.dens_mass_phase.items():
             if iscale.get_scaling_factor(v) is None:

--- a/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
@@ -316,8 +316,7 @@ def test_default_scaling(model3):
     default_scaling_var_dict = {('temperature', None): 1e-2,
                                 ('pressure', None): 1e-6,
                                 ('dens_mass_phase', 'Liq'): 1e-3,
-                                ('visc_d_phase', 'Liq'): 1e3,
-                                ('diffus_phase_comp', 'Liq'): 1e9}
+                                ('visc_d_phase', 'Liq'): 1e3}
     assert len(default_scaling_var_dict) == len(m.fs.properties.default_scaling_factor)
     for t, sf in default_scaling_var_dict.items():
         assert t in m.fs.properties.default_scaling_factor.keys()

--- a/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
@@ -148,16 +148,6 @@ def test_property_ions(model):
     results = solver.solve(m)
     assert_optimal_termination(results)
 
-    # assert value(m.fs.stream[0].mole_frac_phase_comp['Liq', 'A']) == pytest.approx(4.068e-4,  rel=1e-3)
-    # assert value(m.fs.stream[0].mole_frac_phase_comp['Liq', 'B']) == pytest.approx(1.047e-2,  rel=1e-3)
-    # assert value(m.fs.stream[0].mole_frac_phase_comp['Liq', 'C']) == pytest.approx(1.047e-2,  rel=1e-3)
-    # assert value(m.fs.stream[0].mole_frac_phase_comp['Liq', 'H2O']) == pytest.approx(9.786e-1,  rel=1e-3)
-    #
-    # assert value(m.fs.stream[0].flow_mass_phase_comp['Liq', 'A']) == pytest.approx(4.07e-6,  rel=1e-3)
-    # assert value(m.fs.stream[0].flow_mass_phase_comp['Liq', 'B']) == pytest.approx(2.6198e-4,  rel=1e-3)
-    # assert value(m.fs.stream[0].flow_mass_phase_comp['Liq', 'C']) == pytest.approx(1.048e-3,  rel=1e-3)
-    # assert value(m.fs.stream[0].flow_mass_phase_comp['Liq', 'H2O']) == pytest.approx(1.762e-2,  rel=1e-3)
-
     assert value(m.fs.stream[0].conc_mass_phase_comp['Liq','A']) == pytest.approx(2.1288e-1,  rel=1e-3)
 
     assert value(m.fs.stream[0].conc_mol_phase_comp['Liq','A']) == pytest.approx(21.288,  rel=1e-3)
@@ -247,7 +237,7 @@ def model3():
         "solute_list": ["Ca_2+", "SO4_2-", "Na_+", "Cl_-", "Mg_2+"]
         })
 
-    stream = m.fs.stream = m.fs.properties.build_state_block([0], default={'defined_state': True})
+    m.fs.stream = m.fs.properties.build_state_block([0], default={'defined_state': True})
 
     return m
 


### PR DESCRIPTION
## Fixes/Addresses:

## Summary/Motivation:
Removing code that was left in for debugging and removing default scaling factor for diffus_phase_comp. The scaling factor is set in calculate_scaling_factors if the user doesn't provide any.

## Changes proposed in this PR:
- remove raise exception that was left in for debugging
- remove default_scaling_factor for diffus_phase_comp
-  minor cleanup in test

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
