### PR TITLE
Use user-provided output name when applicable

### DIFF
--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -384,7 +384,7 @@ def _create_component_output_skeleton(component, num_samples):
 
 # ================================================================
 
-def _update_local_output_dict(model, sweep_params, case_number, sweep_vals, run_successful, output_dict):
+def _update_local_output_dict(model, sweep_params, case_number, sweep_vals, run_successful, output_dict, outputs):
 
     # Get the inputs
     op_ps_dict = output_dict["sweep_params"]
@@ -394,14 +394,12 @@ def _update_local_output_dict(model, sweep_params, case_number, sweep_vals, run_
 
     # Get the outputs from model
     if run_successful:
-        for key in output_dict['outputs'].keys():
-            outcome = model.find_component(key)
-            output_dict["outputs"][key]["value"][case_number] = pyo.value(outcome)
+        for label, pyo_obj in outputs.items():
+            output_dict["outputs"][label]["value"][case_number] = pyo.value(pyo_obj)
 
     else:
-        for key in output_dict['outputs'].keys():
-            outcome = model.find_component(key)
-            output_dict["outputs"][key]["value"][case_number] = np.nan
+        for label in outputs.keys():
+            output_dict["outputs"][label]["value"][case_number] = np.nan
 
 # ================================================================
 
@@ -609,7 +607,7 @@ def _do_param_sweep(model, sweep_params, outputs, local_values, optimize_functio
                 run_successful = True
 
         # Update the loop based on the reinitialization
-        _update_local_output_dict(model, sweep_params, k, local_values[k, :], run_successful, local_output_dict)
+        _update_local_output_dict(model, sweep_params, k, local_values[k, :], run_successful, local_output_dict, outputs)
 
         local_solve_successful_list.append(run_successful)
 

--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -358,8 +358,8 @@ def _create_local_output_skeleton(model, sweep_params, outputs, num_samples):
                 output_dict["outputs"][pyo_obj.name] = _create_component_output_skeleton(pyo_obj, num_samples)
     else:
         # Save only the outputs specified in the outputs dictionary
-        for pyo_obj in outputs.values():
-            output_dict["outputs"][pyo_obj.name] = _create_component_output_skeleton(pyo_obj, num_samples)
+        for short_name, pyo_obj in outputs.items():
+            output_dict["outputs"][short_name] = _create_component_output_skeleton(pyo_obj, num_samples)
 
     return output_dict
 

--- a/watertap/tools/tests/test_parameter_sweep.py
+++ b/watertap/tools/tests/test_parameter_sweep.py
@@ -494,15 +494,15 @@ class TestParallelManager():
 
         # Check for the h5 output
         if rank == 0:
-            truth_dict = {'outputs': {'fs.output[c]': {'lower bound': 0,
+            truth_dict = {'outputs': {'output_c': {'lower bound': 0,
                                                        'units': 'None',
                                                        'upper bound': 0,
                                                        'value': np.array([0.2, 0.2, np.nan, 1., 1., np.nan, np.nan, np.nan, np.nan])},
-                                      'fs.output[d]': {'lower bound': 0,
+                                      'output_d': {'lower bound': 0,
                                                        'units': 'None',
                                                        'upper bound': 0,
                                                        'value': np.array([0.  , 0.75,  np.nan, 0., 0.75,  np.nan, np.nan, np.nan, np.nan])},
-                                      'fs.performance': {'value': np.array([0.2 , 0.95,  np.nan, 1., 1.75,  np.nan, np.nan,  np.nan, np.nan])}},
+                                      'performance': {'value': np.array([0.2 , 0.95,  np.nan, 1., 1.75,  np.nan, np.nan,  np.nan, np.nan])}},
                           'solve_successful': [True,
                                                True,
                                                False,
@@ -529,7 +529,7 @@ class TestParallelManager():
             # Check if there is a text file created
             import ast
 
-            truth_txt_dict = {'outputs': ['fs.output[c]', 'fs.output[d]', 'fs.performance'],
+            truth_txt_dict = {'outputs': ['output_c', 'output_d', 'performance'],
                               'sweep_params': ['fs.input[a]', 'fs.input[b]']}
 
             txt_fpath = os.path.join(tmp_path, '{0}.txt'.format(h5_fname))
@@ -592,15 +592,15 @@ class TestParallelManager():
         # Check the h5
         if rank == 0:
 
-            truth_dict = {'outputs': {'fs.output[c]': {'lower bound': 0,
+            truth_dict = {'outputs': {'output_c': {'lower bound': 0,
                                                        'units': 'None',
                                                        'upper bound': 0,
                                                        'value': np.array([0.2, 0.2, 0.2, 1., 1., 1., 1., 1., 1.])},
-                                      'fs.output[d]': {'lower bound': 0,
+                                      'output_d': {'lower bound': 0,
                                                        'units': 'None',
                                                        'upper bound': 0,
                                                        'value': np.array([9.98580690e-09, 0.75, 1., 9.99872731e-09, 0.75, 1., 9.99860382e-09, 0.75, 1.])},
-                                      'fs.performance': {'value': np.array([0.2, 0.95, 1.2, 1., 1.75, 2., 1., 1.75, 2.])},
+                                      'performance': {'value': np.array([0.2, 0.95, 1.2, 1., 1.75, 2., 1., 1.75, 2.])},
                                       'objective': {'value': np.array([ 0.2,  9.50000020e-01, -4.98799990e+02,  1.,  1.75, -4.97999990e+02, -7.98999990e+02, -7.98249990e+02, 2.0 - 1000.*((2.*0.9 - 1.) + (3.*0.5 - 1.))])}},
                           'solve_successful': [True]*9,
                           'sweep_params': {'fs.input[a]': {'lower bound': 0,

--- a/watertap/tools/tests/test_parameter_sweep.py
+++ b/watertap/tools/tests/test_parameter_sweep.py
@@ -360,7 +360,7 @@ class TestParallelManager():
         sweep_params, sampling_type = _process_sweep_params(sweep_params)
         values = _build_combinations(sweep_params, sampling_type, None, comm, rank, num_procs)
         num_cases = np.shape(values)[0]
-        output_dict = _create_local_output_skeleton(model, sweep_params, None, num_cases)
+        output_dict, outputs = _create_local_output_skeleton(model, sweep_params, None, num_cases)
 
         truth_dict = {'outputs': {'fs.output[c]': {'lower bound': 0,
                                                    'units': 'None',
@@ -414,7 +414,7 @@ class TestParallelManager():
         local_num_cases = np.shape(local_values)[0]
 
 
-        local_output_dict = _create_local_output_skeleton(model, sweep_params, None, local_num_cases)
+        local_output_dict, outputs = _create_local_output_skeleton(model, sweep_params, None, local_num_cases)
 
         # Manually update the values in the numpy array
         for key, value in local_output_dict.items():


### PR DESCRIPTION
## Fixes/Addresses:

This change ensures that the user-provided name of the output, e.g., `Ca` in `outputs['Ca'] = m.fs.mass_frac_comp['Ca']` is used as the column header instead of the long name of the Pyomo object.

## Summary/Motivation:

This change cleans up the formatting in the saved file and allows the more human readable name to be printed.

## Changes proposed in this PR:
- Small change to use the user-provided key vs `pyo_obj.name` in `parameter_sweep`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
