### PR TITLE
Remove Cl2 recovery from .yaml and put in module

### DIFF
--- a/watertap/data/techno_economic/chlorination.yaml
+++ b/watertap/data/techno_economic/chlorination.yaml
@@ -21,11 +21,6 @@ default:
     cost_function_form:
       function f(flow_vol_in): cap_basis_par*(flow_vol_in/flow_basis_par)^cap_exp
       units: $
-  recovery_frac_mass_H2O:
-    value: 1
-    units: dimensionless
-    reference: Based on costs for Chlorine Storage and Feed from Cost Estimating Manual
-      for Water Treatment Facilities (McGivney/Kawamura)
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless

--- a/watertap/data/techno_economic/tests/test_unit_parameter_files.py
+++ b/watertap/data/techno_economic/tests/test_unit_parameter_files.py
@@ -53,7 +53,7 @@ def test_unit_parameter_files(tech):
                     "storage_tank",
                     ]
 
-    siso_full_recovery = ["uv_aop", "uv", "ion_exchange", "fixed_bed", "decarbonator"]
+    siso_full_recovery = ["uv_aop", "uv", "ion_exchange", "fixed_bed", "decarbonator", "chlorination"]
 
     no_energy_electric_flow_vol_inlet = ["energy_recovery",
                                          "mbr_denitrification",

--- a/watertap/unit_models/zero_order/chlorination_zo.py
+++ b/watertap/unit_models/zero_order/chlorination_zo.py
@@ -52,7 +52,8 @@ class ChlorinationZOData(ZeroOrderBaseData):
         self.chlorine_decay_rate = Var(self.flowsheet().time,
                                        units=pyunits.mg/(pyunits.L*pyunits.hour),
                                        doc="Chlorine decay rate")
-
+        
+        self.recovery_frac_mass_H2O.fix(1)
         self._fixed_perf_vars.append(self.initial_chlorine_demand)
         self._fixed_perf_vars.append(self.contact_time)
         self._fixed_perf_vars.append(self.concentration_time)


### PR DESCRIPTION
## Fixes/Addresses:

Fix `recovery_frac_mass_H2O` in chlorination module rather than have it in the .yaml to match convention of other SISO models.

## Summary/Motivation:

Maintain consistency in how `recovery_frac_mass_H2O` is fixed for SISO models.

## Changes proposed in this PR:
- remove `recovery_frac_mass_H2O` from chlorination.yaml
- fix `recovery_frac_mass_H2O` in chlorination_zo module
- add chlorination to list of `siso_full_recovery` units in `test_unit_parameter_files.py`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
