### PR TITLE
add build_mass_conc function and modify generic prop config dict for …

### DIFF
--- a/watertap/examples/flowsheets/full_treatment_train/analysis/oli_case_generation.py
+++ b/watertap/examples/flowsheets/full_treatment_train/analysis/oli_case_generation.py
@@ -20,6 +20,20 @@ def build_mass_frac(blk, state_blk):
 
     blk.mass_frac_comp = Expression(mw_comp.keys(), rule=mass_frac_calc)
 
+def build_mass_conc(blk, state_blk):
+    mw_comp = {'H2O': 18.015e-3,
+               'Na_+': 22.990e-3,
+               'Ca_2+': 40.078e-3,
+               'Mg_2+': 24.305e-3,
+               'SO4_2-': 96.06e-3,
+               'Cl_-': 35.453e-3}
+
+    def mass_conc_calc(blk, j):
+        return (state_blk.conc_mol_phase_comp['Liq', j] * mw_comp[j])
+
+    blk.mass_conc_comp = Expression(mw_comp.keys(), rule=mass_conc_calc)
+
+
 def run_analysis(case_num, nx, RO_type, interp_nan_outputs=True):
 
     desal_kwargs = {'has_desal_feed': False, 'is_twostage': True, 'has_ERD': True,
@@ -40,10 +54,10 @@ def run_analysis(case_num, nx, RO_type, interp_nan_outputs=True):
         m.fs.eq_max_saturation_index_desal.deactivate()
 
         build_mass_frac(m.fs, m.fs.desal_saturation.properties[0])
-
+        build_mass_conc(m.fs, m.fs.desal_saturation.properties[0])
         sweep_params['System Recovery'] = LinearSample(m.fs.system_recovery_target, 0.3, 0.85, nx)
 
-        for (j, v) in m.fs.mass_frac_comp.items():
+        for (j, v) in m.fs.mass_conc_comp.items():
             outputs[j] = v
         outputs['LCOW'] = m.fs.costing.LCOW
 

--- a/watertap/examples/flowsheets/full_treatment_train/model_components/eNRTL/entrl_config_FpcTP.py
+++ b/watertap/examples/flowsheets/full_treatment_train/model_components/eNRTL/entrl_config_FpcTP.py
@@ -39,7 +39,7 @@ from idaes.generic_models.properties.core.pure.electrolyte import \
     relative_permittivity_constant
 
 
-class ConstantVolMol():
+class VolMolH2O():
     def build_parameters(b):
         b.vol_mol_pure = Param(initialize=18e-6,
                                units=pyunits.m**3/pyunits.mol,
@@ -48,38 +48,131 @@ class ConstantVolMol():
     def return_expression(b, cobj, T):
         return cobj.vol_mol_pure
 
+class VolMolNaCl():
+    def build_parameters(b):
+        b.vol_mol_pure = Param(initialize=58.44e-6,
+                               units=pyunits.m**3/pyunits.mol,
+                               mutable=True)
+
+    def return_expression(b, cobj, T):
+        return cobj.vol_mol_pure
+
+class VolMolNa2SO4():
+    def build_parameters(b):
+        b.vol_mol_pure = Param(initialize=142.04e-6,
+                               units=pyunits.m**3/pyunits.mol,
+                               mutable=True)
+
+    def return_expression(b, cobj, T):
+        return cobj.vol_mol_pure
+
+
+class VolMolCaCl2():
+    def build_parameters(b):
+        b.vol_mol_pure = Param(initialize=110.98e-6,
+                               units=pyunits.m**3/pyunits.mol,
+                               mutable=True)
+
+    def return_expression(b, cobj, T):
+        return cobj.vol_mol_pure
+
+class VolMolCaSO4():
+    def build_parameters(b):
+        b.vol_mol_pure = Param(initialize=136.14e-6,
+                               units=pyunits.m**3/pyunits.mol,
+                               mutable=True)
+
+    def return_expression(b, cobj, T):
+        return cobj.vol_mol_pure
+
+class VolMolMgCl2():
+    def build_parameters(b):
+        b.vol_mol_pure = Param(initialize=95.21e-6,
+                               units=pyunits.m**3/pyunits.mol,
+                               mutable=True)
+
+    def return_expression(b, cobj, T):
+        return cobj.vol_mol_pure
+
+class VolMolMgSO4():
+    def build_parameters(b):
+        b.vol_mol_pure = Param(initialize=120.37e-6,
+                               units=pyunits.m**3/pyunits.mol,
+                               mutable=True)
+
+    def return_expression(b, cobj, T):
+        return cobj.vol_mol_pure
 
 configuration = {
     "components": {
         "H2O": {"type": Solvent,
-                "vol_mol_liq_comp": ConstantVolMol,
+                "vol_mol_liq_comp": VolMolH2O,
                 "relative_permittivity_liq_comp":
                     relative_permittivity_constant,
                 "parameter_data": {
                     "mw": (18E-3, pyunits.kg/pyunits.mol),
                     "relative_permittivity_liq_comp": 78.54}},
         "NaCl": {"type": Apparent,
-                 "dissociation_species": {"Na_+": 1, "Cl_-": 1}},
+                 "dissociation_species": {"Na_+": 1, "Cl_-": 1},
+                 "vol_mol_liq_comp": VolMolNaCl,
+                 "parameter_data": {
+                     "mw": (58.44E-3, pyunits.kg / pyunits.mol)
+                 }},
         "Na2SO4": {"type": Apparent,
-                   "dissociation_species": {"Na_+": 2, "SO4_2-": 1}},
+                   "dissociation_species": {"Na_+": 2, "SO4_2-": 1},
+                   "vol_mol_liq_comp": VolMolNa2SO4,
+                   "parameter_data": {
+                       "mw": (142.04E-3, pyunits.kg / pyunits.mol)
+                   }},
         "CaCl2": {"type": Apparent,
-                  "dissociation_species": {"Ca_2+": 1, "Cl_-": 2}},
+                  "dissociation_species": {"Ca_2+": 1, "Cl_-": 2},
+                  "vol_mol_liq_comp": VolMolCaCl2,
+                  "parameter_data": {
+                      "mw": (110.98E-3, pyunits.kg / pyunits.mol)
+                  }},
         "CaSO4": {"type": Apparent,
-                  "dissociation_species": {"Ca_2+": 1, "SO4_2-": 1}},
+                  "dissociation_species": {"Ca_2+": 1, "SO4_2-": 1},
+                  "vol_mol_liq_comp": VolMolCaSO4,
+                  "parameter_data": {
+                      "mw": (136.14E-3, pyunits.kg / pyunits.mol)
+                  }},
         "MgCl2": {"type": Apparent,
-                  "dissociation_species": {"Mg_2+": 1, "Cl_-": 2}},
+                  "dissociation_species": {"Mg_2+": 1, "Cl_-": 2},
+                  "vol_mol_liq_comp": VolMolMgCl2,
+                  "parameter_data": {
+                      "mw": (95.21E-3, pyunits.kg / pyunits.mol)
+                  }},
         "MgSO4": {"type": Apparent,
-                  "dissociation_species": {"Mg_2+": 1, "SO4_2-": 1}},
+                  "dissociation_species": {"Mg_2+": 1, "SO4_2-": 1},
+                  "vol_mol_liq_comp": VolMolMgSO4,
+                  "parameter_data": {
+                      "mw": (120.37E-3, pyunits.kg / pyunits.mol)
+                  }},
         "Na_+": {"type": Cation,
-                 "charge": +1},
+                 "charge": +1,
+                 "parameter_data":{
+                     "mw": 23e-3
+                 }},
         "Ca_2+": {"type": Cation,
-                  "charge": +2},
+                  "charge": +2,
+                  "parameter_data": {
+                      "mw": 40e-3
+                  }},
         "Mg_2+": {"type": Cation,
-                  "charge": +2},
+                  "charge": +2,
+                  "parameter_data":{
+                      "mw": 24.3e-3
+                  }},
         "Cl_-": {"type": Anion,
-                 "charge": -1},
+                 "charge": -1,
+                 "parameter_data": {
+                     "mw": 35.45e-3
+                 }},
         "SO4_2-": {"type": Anion,
-                   "charge": -2}},
+                   "charge": -2,
+                   "parameter_data": {
+                       "mw": 96.06e-3
+                   }}},
     "phases": {
         "Liq": {"type": AqueousPhase,
                 "equation_of_state": ENRTL,


### PR DESCRIPTION
## Fixes/Addresses:

Enable computation of mass concentration on eNRTL stateblock.

## Summary/Motivation:
Modify `eNRTL_config_FpcTP.py` to compute mass concentration in oli_case_generation and output results in terms of mass concentration for supplying to the OLI API.

## Changes proposed in this PR:
- add molar volume methods for each component in enrtl config dict
- add build_mass_conc and replace output of mass_frac_comp with mass_conc_comp in case 1 output in ol_case_generation.py

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
