### PR TITLE
First WT3 costing examples

### DIFF
--- a/watertap/data/techno_economic/aeration_basin.yaml
+++ b/watertap/data/techno_economic/aeration_basin.yaml
@@ -2,25 +2,18 @@ default:
   energy_electric_flow_vol_inlet:
     value: 0.41226735  # 0.5 in previous "aeration_tank" yaml file. This was the only disparity
     units: kWh/m^3
-  specific_capital_cost_flow_vol_inlet:
-    flow_basis_par:
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
       value: 4731.764235
       units: m^3/hr
-    cap_basis_par:
-      value: 5.5
-      units: M$
-    cap_exp_par:
+    capital_a_parameter:
+      value: 5.5e6
+      units: USD_2014
+    capital_b_parameter:
       value: 0.586
       units: dimensionless
-    vol units:
-      value: m^3/hr
-    capital cost units:
-      value: M$
-    year:
-      value: 2014
-    cost_function_form:
-      function f(flow_vol_in): cap_basis_par*(flow_vol_in/flow_basis_par)^cap_exp
-      units: $
   recovery_frac_mass_H2O:
     value: 1
     units: dimensionless

--- a/watertap/data/techno_economic/air_flotation.yaml
+++ b/watertap/data/techno_economic/air_flotation.yaml
@@ -2,25 +2,18 @@ default:
   energy_electric_flow_vol_inlet:
     value: 0.3
     units: kWh/m^3
-  specific_capital_cost_flow_vol_inlet:
-    flow_basis_par:
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
       value: 15772.5491
       units: m^3/hr
-    cap_basis_par:
-      value: 4.488923561
-      units: M$
-    cap_exp_par:
+    capital_a_parameter:
+      value: 4.488923561e6
+      units: USD_2015
+    capital_b_parameter:
       value: 0.8671
       units: dimensionless
-    vol units:
-      value: m^3/hr
-    capital cost units:
-      value: M$
-    year:
-      value: 2015
-    cost_function_form:
-      function f(flow_vol_in): cap_basis_par*(flow_vol_in/flow_basis_par)^cap_exp
-      units: $
   recovery_frac_mass_H2O:
     value: 0.9999
     units: dimensionless

--- a/watertap/data/techno_economic/anaerobic_digestion_oxidation.yaml
+++ b/watertap/data/techno_economic/anaerobic_digestion_oxidation.yaml
@@ -2,25 +2,18 @@ default:
   energy_electric_flow_vol_inlet:
     value: 0.15
     units: kWh/m^3
-  specific_capital_cost_flow_vol_inlet:
-    flow_basis_par:
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
       value: 911.054
       units: m^3/hr
-    cap_basis_par:
-      value: 19.3552312
-      units: M$
-    cap_exp_par:
+    capital_a_parameter:
+      value: 19.3552312e6
+      units: USD_2012
+    capital_b_parameter:
       value: 0.6
       units: dimensionless
-    vol units:
-      value: m^3/hr
-    capital cost units:
-      value: M$
-    year:
-      value: 2012
-    cost_function_form:
-      function f(flow_vol_in): cap_basis_par*(flow_vol_in/flow_basis_par)^cap_exp
-      units: $
   recovery_frac_mass_H2O:
     value: 0.9999
     units: dimensionless

--- a/watertap/data/techno_economic/backwash_solids_handling.yaml
+++ b/watertap/data/techno_economic/backwash_solids_handling.yaml
@@ -19,3 +19,15 @@ default:
       value: 0.95
       units: dimensionless
       constituent_longform: Total Suspended Solids (TSS))
+  capital_cost:
+    basis: flow_mass
+    cost_factor: TPEC
+    reference_state:
+      value: 1577255
+      units: kg/hr
+    capital_a_parameter:
+      value: 9.76e6
+      units: USD_2007
+    capital_b_parameter:
+      value: 0.918
+      units: dimensionless

--- a/watertap/data/techno_economic/bioreactor.yaml
+++ b/watertap/data/techno_economic/bioreactor.yaml
@@ -2,25 +2,18 @@ default:
   energy_electric_flow_vol_inlet:
     value: 0.0
     units: kWh/m^3
-  specific_capital_cost_flow_vol_inlet:
-    flow_basis_par:
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
       value: 45.0
       units: m^3/hr
-    cap_basis_par:
-      value: 1.25216
-      units: M$
-    cap_exp_par:
+    capital_a_parameter:
+      value: 1.25216e6
+      units: USD_2018
+    capital_b_parameter:
       value: 1.0
       units: dimensionless
-    vol units:
-      value: m^3/hr
-    capital cost units:
-      value: M$
-    year:
-      value: 2018
-    cost_function_form:
-      function f(flow_vol_in): cap_basis_par*(flow_vol_in/flow_basis_par)^cap_exp
-      units: $
   recovery_frac_mass_H2O:
     value: 0.97
     units: dimensionless

--- a/watertap/unit_models/zero_order/aeration_basin_zo.py
+++ b/watertap/unit_models/zero_order/aeration_basin_zo.py
@@ -15,7 +15,6 @@ This module contains a zero-order representation of an aeration basin unit.
 operation.
 """
 
-from pyomo.environ import Constraint, units as pyunits, Var
 from idaes.core import declare_process_block_class
 
 from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData

--- a/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
@@ -17,19 +17,22 @@ import pytest
 
 from io import StringIO
 from pyomo.environ import (
-    ConcreteModel, Constraint, value, Var, assert_optimal_termination)
+    Block, ConcreteModel, Constraint, value, Var, assert_optimal_termination)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import AerationBasinZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
+
 
 class TestAerationBasinZO_no_default:
     @pytest.fixture(scope="class")
@@ -343,3 +346,46 @@ class Test_AerationBasin_ZOsubtype:
         for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
             assert v.fixed
             assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+
+def test_costing():
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = AerationBasinZO(default={
+        "property_package": m.fs.params,
+        "database": m.db})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.aeration_basin, Block)
+    assert isinstance(m.fs.costing.aeration_basin.capital_a_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.aeration_basin.capital_b_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.aeration_basin.reference_state, Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]

--- a/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
@@ -17,19 +17,22 @@ import pytest
 
 from io import StringIO
 from pyomo.environ import (
-    ConcreteModel, Constraint, value, Var, assert_optimal_termination)
+    Block, ConcreteModel, Constraint, value, Var, assert_optimal_termination)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import AirFlotationZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
+
 
 class TestAirFloatationZO:
     @pytest.fixture(scope="class")
@@ -294,3 +297,46 @@ Unit : fs.unit                                                             Time:
 """
 
         assert output in stream.getvalue()
+
+
+def test_costing():
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = AirFlotationZO(default={
+        "property_package": m.fs.params,
+        "database": m.db})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.air_flotation, Block)
+    assert isinstance(m.fs.costing.air_flotation.capital_a_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.air_flotation.capital_b_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.air_flotation.reference_state, Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
@@ -17,19 +17,22 @@ import pytest
 
 from io import StringIO
 from pyomo.environ import (
-    ConcreteModel, Constraint, value, Var, assert_optimal_termination)
+    Block, ConcreteModel, Constraint, value, Var, assert_optimal_termination)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import AnaerobicDigestionOxidationZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
+
 
 class TestAnaerobicDigestionOxidationZO:
     @pytest.fixture(scope="class")
@@ -312,3 +315,49 @@ Unit : fs.unit                                                             Time:
 """
 
         assert output in stream.getvalue()
+
+
+def test_costing():
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = AnaerobicDigestionOxidationZO(default={
+        "property_package": m.fs.params,
+        "database": m.db})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.anaerobic_digestion_oxidation, Block)
+    assert isinstance(
+        m.fs.costing.anaerobic_digestion_oxidation.capital_a_parameter,
+        Var)
+    assert isinstance(
+        m.fs.costing.anaerobic_digestion_oxidation.capital_b_parameter,
+        Var)
+    assert isinstance(
+        m.fs.costing.anaerobic_digestion_oxidation.reference_state, Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]

--- a/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
@@ -17,17 +17,19 @@ import pytest
 from io import StringIO
 
 from pyomo.environ import (
-    check_optimal_termination, ConcreteModel, Constraint, value, Var, Param)
+    Block, check_optimal_termination, ConcreteModel, Constraint, value, Var, Param)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import BackwashSolidsHandlingZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
 
@@ -197,3 +199,47 @@ class TestIXZOsubtype:
         for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
             assert v.fixed
             assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+
+def test_costing():
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = BackwashSolidsHandlingZO(default={
+        "property_package": m.fs.params,
+        "database": m.db})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.backwash_solids_handling, Block)
+    assert isinstance(
+        m.fs.costing.backwash_solids_handling.capital_a_parameter, Var)
+    assert isinstance(
+        m.fs.costing.backwash_solids_handling.capital_b_parameter, Var)
+    assert isinstance(m.fs.costing.backwash_solids_handling.reference_state,
+                      Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]

--- a/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
@@ -17,17 +17,19 @@ import pytest
 from io import StringIO
 
 from pyomo.environ import (
-    check_optimal_termination, ConcreteModel, Constraint, value, Var, Param)
+    Block, check_optimal_termination, ConcreteModel, Constraint, value, Var, Param)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import BioreactorZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
 
@@ -147,3 +149,45 @@ Unit : fs.unit                                                             Time:
 """
         assert output in stream.getvalue()
 
+
+def test_costing():
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = BioreactorZO(default={
+        "property_package": m.fs.params,
+        "database": m.db})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.bioreactor, Block)
+    assert isinstance(m.fs.costing.bioreactor.capital_a_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.bioreactor.capital_b_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.bioreactor.reference_state, Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]

--- a/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
@@ -16,7 +16,7 @@ Tests for zero-order chemical addition model
 import pytest
 from io import StringIO
 
-from pyomo.environ import ConcreteModel, Constraint, Param, value, Var
+from pyomo.environ import Block, ConcreteModel, Constraint, Param, value, Var
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -24,10 +24,12 @@ from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core.util.exceptions import ConfigurationError
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import ChemicalAdditionZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
 
@@ -178,7 +180,7 @@ class TestPumpZOsubtype:
 
         return m
 
-    @pytest.mark.parametrize("subtype", [params.keys()])
+    @pytest.mark.parametrize("subtype", [k for k in params.keys()])
     @pytest.mark.component
     def test_load_parameters(self, model, subtype):
         model.fs.unit = ChemicalAdditionZO(default={
@@ -203,3 +205,54 @@ class TestPumpZOsubtype:
         assert model.fs.unit.ratio_in_solution.fixed
         assert model.fs.unit.ratio_in_solution.value == data[
             "ratio_in_solution"]["value"]
+
+
+@pytest.mark.parametrize("subtype", [k for k in params.keys()
+                                     if k != "default"])
+def test_costing(subtype):
+    print(subtype)
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = ChemicalAdditionZO(default={
+        "property_package": m.fs.params,
+        "database": m.db,
+        "process_subtype": subtype})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.chemical_addition, Block)
+    assert isinstance(m.fs.costing.chemical_addition.capital_a_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.chemical_addition.capital_b_parameter,
+                      Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]
+
+    assert str(m.fs.unit1.chemical_dosage[0] *
+               m.fs.unit1.properties[0].flow_vol /
+               m.fs.unit1.ratio_in_solution) == str(
+                   m.fs.costing._registered_flows[subtype][0])

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -17,17 +17,19 @@ import pytest
 from io import StringIO
 
 from pyomo.environ import (
-    check_optimal_termination, ConcreteModel, Constraint, value, Var)
+    Block, check_optimal_termination, ConcreteModel, Constraint, value, Var)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import NanofiltrationZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
 
@@ -285,3 +287,46 @@ Unit : fs.unit                                                             Time:
 """
 
         assert output in stream.getvalue()
+
+
+def test_costing():
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = NanofiltrationZO(default={
+        "property_package": m.fs.params,
+        "database": m.db})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.nanofiltration, Block)
+    assert isinstance(m.fs.costing.nanofiltration.capital_a_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.nanofiltration.capital_b_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.nanofiltration.reference_state, Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]


### PR DESCRIPTION
## Fixes/Addresses:

Adds example costing and tests for aeration basis and air flotation (plus NF and chemical addition) units.

## Things to Note:
- These examples should work for any basic unit (I hope).
- Make sure to check the year used for the costing, and update if necessary.
- Note also the units for the A parameter - the old YAML format generally uses M$
- Cost factor line is for TPEC or TIC (if required)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
