### PR TITLE
WT3: Adding costing for GAC units

### DIFF
--- a/watertap/core/tests/test_zero_order_costing.py
+++ b/watertap/core/tests/test_zero_order_costing.py
@@ -82,13 +82,16 @@ class TestGeneralMethods:
         assert model.frame.base_currency == pyunits.MUSD_2018
         assert model.frame.base_period == pyunits.year
 
-        assert len(model.frame.defined_flows) == 15
+        assert len(model.frame.defined_flows) == 20
         for f in model.frame.defined_flows:
             assert f in ["electricity",
+                         "acetic_acid",
                          "activated_carbon",
                          "alum",
                          "ammonia",
+                         "anthracite",
                          "anti-scalant",
+                         "cationic_polymer",
                          "caustic_soda",
                          "chlorine",
                          "ferric_chloride",
@@ -96,6 +99,8 @@ class TestGeneralMethods:
                          "hydrogen_peroxide",
                          "ion_exchange_resin",
                          "lime",
+                         "phosphoric_acid",
+                         "sand",
                          "sodium_bisulfite",
                          "sodium_chloride",
                          "sulfuric_acid"]

--- a/watertap/core/tests/test_zero_order_costing.py
+++ b/watertap/core/tests/test_zero_order_costing.py
@@ -82,9 +82,10 @@ class TestGeneralMethods:
         assert model.frame.base_currency == pyunits.MUSD_2018
         assert model.frame.base_period == pyunits.year
 
-        assert len(model.frame.defined_flows) == 14
+        assert len(model.frame.defined_flows) == 15
         for f in model.frame.defined_flows:
             assert f in ["electricity",
+                         "activated_carbon",
                          "alum",
                          "ammonia",
                          "anti-scalant",

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -30,6 +30,7 @@ from watertap.unit_models.zero_order import (
     ChemicalAdditionZO,
     ChlorinationZO,
     CoagulationFlocculationZO,
+    FixedBedZO,
     GACZO,
     LandfillZO,
     IonExchangeZO,
@@ -601,6 +602,18 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         blk.config.flowsheet_costing_block.cost_flow(
             blk.unit_model.electricity[t0], "electricity")
 
+    def cost_fixed_bed(blk):
+        """
+        General method for costing fixed bed units. This primarily calls the
+        cost_power_law_flow method.
+
+        This method also registers demand for a number of additional material
+        flows..
+        """
+        t0 = blk.flowsheet().time.first()
+
+        ZeroOrderCostingData.cost_power_law_flow(blk)
+
     def cost_gac(blk):
         """
         General method for costing granular activated carbon processes. Capital
@@ -1156,6 +1169,7 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
                     ChemicalAdditionZO: cost_chemical_addition,
                     ChlorinationZO: cost_chlorination,
                     CoagulationFlocculationZO: cost_coag_and_floc,
+                    FixedBedZO: cost_fixed_bed,
                     GACZO: cost_gac,
                     LandfillZO: cost_landfill,
                     IonExchangeZO: cost_ion_exchange,

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -30,6 +30,7 @@ from watertap.unit_models.zero_order import (
     ChemicalAdditionZO,
     ChlorinationZO,
     CoagulationFlocculationZO,
+    GACZO,
     LandfillZO,
     IonExchangeZO,
     OzoneZO,
@@ -600,6 +601,68 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         blk.config.flowsheet_costing_block.cost_flow(
             blk.unit_model.electricity[t0], "electricity")
 
+    def cost_gac(blk):
+        """
+        General method for costing granular activated carbon processes. Capital
+        cost is based on the inlet flow rate of liquid and the empty bed
+        contacting time.
+
+        This method also registers electricity and activated carbon consumption
+        as costed flows.
+        """
+        t0 = blk.flowsheet().time.first()
+
+        Q = blk.unit_model.properties_in[t0].flow_vol
+        T = blk.unit_model.empty_bed_contact_time
+
+        # Get parameter dict from database
+        parameter_dict = \
+            blk.unit_model.config.database.get_unit_operation_parameters(
+                blk.unit_model._tech_type,
+                subtype=blk.unit_model.config.process_subtype)
+
+        A, B, C = _get_tech_parameters(
+            blk,
+            parameter_dict,
+            blk.unit_model.config.process_subtype,
+            ["capital_a_parameter",
+             "capital_b_parameter",
+             "capital_c_parameter"])
+
+        # Determine if a costing factor is required
+        factor = parameter_dict["capital_cost"]["cost_factor"]
+
+        # Call general power law costing method
+        blk.capital_cost = pyo.Var(
+            initialize=1,
+            units=blk.config.flowsheet_costing_block.base_currency,
+            bounds=(0, None),
+            doc="Capital cost of unit operation")
+
+        expr = (pyo.units.convert(
+                    A * Q,
+                    to_units=blk.config.flowsheet_costing_block.base_currency) +
+                pyo.units.convert(
+                    B * T,
+                    to_units=blk.config.flowsheet_costing_block.base_currency) +
+                pyo.units.convert(
+                    C * Q * T,
+                    to_units=blk.config.flowsheet_costing_block.base_currency))
+
+        if factor == "TPEC":
+            expr *= blk.config.flowsheet_costing_block.TPEC
+        elif factor == "TIC":
+            expr *= blk.config.flowsheet_costing_block.TIC
+
+        blk.capital_cost_constraint = pyo.Constraint(
+            expr=blk.capital_cost == expr)
+
+        # Register flows
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.electricity[t0], "electricity")
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.activated_carbon_demand[t0], "activated_carbon")
+
     def cost_ion_exchange(blk):
         """
         General method for costing ion exchange units. Capital cost is based on
@@ -1093,6 +1156,7 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
                     ChemicalAdditionZO: cost_chemical_addition,
                     ChlorinationZO: cost_chlorination,
                     CoagulationFlocculationZO: cost_coag_and_floc,
+                    GACZO: cost_gac,
                     LandfillZO: cost_landfill,
                     IonExchangeZO: cost_ion_exchange,
                     OzoneZO: cost_ozonation,
@@ -1102,7 +1166,7 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
                     UVZO: cost_uv,
                     UVAOPZO: cost_uv_aop,
                     WellFieldZO: cost_well_field,
-                   }
+                    }
 
 
 def _get_tech_parameters(blk, parameter_dict, subtype, param_list):

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -621,6 +621,14 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.phosphoric_acid_demand[t0], "phosphoric_acid")
         blk.config.flowsheet_costing_block.cost_flow(
             blk.unit_model.ferric_chloride_demand[t0], "ferric_chloride")
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.activated_carbon_demand[t0], "activated_carbon")
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.sand_demand[t0], "sand")
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.anthracite_demand[t0], "anthracite")
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.cationic_polymer_demand[t0], "cationic_polymer")
 
     def cost_gac(blk):
         """

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -608,7 +608,7 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         cost_power_law_flow method.
 
         This method also registers demand for a number of additional material
-        flows..
+        flows.
         """
         t0 = blk.flowsheet().time.first()
 

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -614,6 +614,14 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
 
         ZeroOrderCostingData.cost_power_law_flow(blk)
 
+        # Register flows - electricity already done by cost_power_law_flow
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.acetic_acid_demand[t0], "acetic_acid")
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.phosphoric_acid_demand[t0], "phosphoric_acid")
+        blk.config.flowsheet_costing_block.cost_flow(
+            blk.unit_model.ferric_chloride_demand[t0], "ferric_chloride")
+
     def cost_gac(blk):
         """
         General method for costing granular activated carbon processes. Capital
@@ -989,7 +997,6 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         blk.config.flowsheet_costing_block.cost_flow(
             blk.unit_model.chemical_flow_mass[t0], "hydrogen_peroxide")
 
-
     def cost_landfill(blk):
         """
         General method for costing landfill. Capital cost is based on the total mass and
@@ -1074,7 +1081,6 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         # Register flows
         blk.config.flowsheet_costing_block.cost_flow(
             blk.unit_model.electricity[t0], "electricity")
-
 
     def _get_ozone_capital_cost(blk, A, B, C, D):
         """

--- a/watertap/data/techno_economic/default_case_study.yaml
+++ b/watertap/data/techno_economic/default_case_study.yaml
@@ -4,6 +4,10 @@ defined_flows:
   electricity:
     value: 0.0595
     units: USD_2019/kWh
+  activated_carbon:
+    value: 3.63759
+    units: USD_2020/kg
+    purity: 1
   alum:
     value: 0.69
     units: USD_2020/kg

--- a/watertap/data/techno_economic/default_case_study.yaml
+++ b/watertap/data/techno_economic/default_case_study.yaml
@@ -20,11 +20,19 @@ defined_flows:
     value: 0.79
     units: USD_2020/kg
     purity: 1
+  anthracite:
+    value: 1.124346
+    units: USD_2020/kg
+    purity: 1
   anti-scalant:
     # Hydrazine
     value: 3.49
     units: USD_2020/kg
     purity: 0.85
+  cationic_polymer:
+    value: 0.79
+    units: USD_2017/kg
+    purity: 1
   caustic_soda:
     value: 0.11
     units: USD_2020/kg
@@ -55,6 +63,10 @@ defined_flows:
     purity: 1
   phosphoric_acid:
     value: 0.97
+    units: USD_2020/kg
+    purity: 1
+  sand:
+    value: 0.510219804
     units: USD_2020/kg
     purity: 1
   sodium_bisulfite:

--- a/watertap/data/techno_economic/default_case_study.yaml
+++ b/watertap/data/techno_economic/default_case_study.yaml
@@ -4,6 +4,10 @@ defined_flows:
   electricity:
     value: 0.0595
     units: USD_2019/kWh
+  acetic_acid:
+    value: 1.1
+    units: USD_2020/kg
+    purity: 1
   activated_carbon:
     value: 3.63759
     units: USD_2020/kg
@@ -47,6 +51,10 @@ defined_flows:
     purity: 1
   lime:
     value: 0.15
+    units: USD_2020/kg
+    purity: 1
+  phosphoric_acid:
+    value: 0.97
     units: USD_2020/kg
     purity: 1
   sodium_bisulfite:

--- a/watertap/data/techno_economic/fixed_bed.yaml
+++ b/watertap/data/techno_economic/fixed_bed.yaml
@@ -23,6 +23,15 @@ default: # TODO: confirm any differentiation in removal across subtypes
     capital_b_parameter:
       value: 0.734002
       units: dimensionless
+  acetic_acid_dose:
+    value: 0.0499676
+    units: kg/m^3
+  phosphoric_acid_dose:
+    value: 0.00422660
+    units: kg/m^3
+  ferric_chloride_dose:
+    value: 0.00999352
+    units: kg/m^3
 gravity_basin:
   energy_electric_flow_vol_inlet:
     value: 0.078498
@@ -47,6 +56,15 @@ gravity_basin:
     capital_b_parameter:
       value: 0.638873
       units: dimensionless
+  acetic_acid_dose:
+    value: 0.0499676
+    units: kg/m^3
+  phosphoric_acid_dose:
+    value: 0.00422660
+    units: kg/m^3
+  ferric_chloride_dose:
+    value: 0.00999352
+    units: kg/m^3
 fixed bed:
   energy_electric_flow_vol_inlet:
     value: 0.085618
@@ -71,3 +89,12 @@ fixed bed:
     capital_b_parameter:
       value: 0.734002
       units: dimensionless
+  acetic_acid_dose:
+    value: 0.0499676
+    units: kg/m^3
+  phosphoric_acid_dose:
+    value: 0.00422660
+    units: kg/m^3
+  ferric_chloride_dose:
+    value: 0.00999352
+    units: kg/m^3

--- a/watertap/data/techno_economic/fixed_bed.yaml
+++ b/watertap/data/techno_economic/fixed_bed.yaml
@@ -1,4 +1,7 @@
 default: # TODO: confirm any differentiation in removal across subtypes
+  energy_electric_flow_vol_inlet:
+    value: 0.085618
+    units: kWh/m^3
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless
@@ -8,7 +11,22 @@ default: # TODO: confirm any differentiation in removal across subtypes
       value: 0.90  # adding this arbitrary default since no removal data provided
       units: dimensionless
       constituent_longform: "Biological Oxygen Demand"
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
+      value: 1
+      units: m^3/hr
+    capital_a_parameter:
+      value: 37568.4
+      units: USD_2017
+    capital_b_parameter:
+      value: 0.734002
+      units: dimensionless
 gravity_basin:
+  energy_electric_flow_vol_inlet:
+    value: 0.078498
+    units: kWh/m^3
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless
@@ -17,7 +35,22 @@ gravity_basin:
       value: 0.90  # adding this arbitrary default since no removal data provided
       units: dimensionless
       constituent_longform: "Biological Oxygen Demand"
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
+      value: 1
+      units: m^3/hr
+    capital_a_parameter:
+      value: 81276.6
+      units: USD_2017
+    capital_b_parameter:
+      value: 0.638873
+      units: dimensionless
 fixed bed:
+  energy_electric_flow_vol_inlet:
+    value: 0.085618
+    units: kWh/m^3
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless
@@ -26,3 +59,15 @@ fixed bed:
       value: 0.90  # adding this arbitrary default since no removal data provided
       units: dimensionless
       constituent_longform: "Biological Oxygen Demand"
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
+      value: 1
+      units: m^3/hr
+    capital_a_parameter:
+      value: 37568.4
+      units: USD_2017
+    capital_b_parameter:
+      value: 0.734002
+      units: dimensionless

--- a/watertap/data/techno_economic/fixed_bed.yaml
+++ b/watertap/data/techno_economic/fixed_bed.yaml
@@ -32,6 +32,30 @@ default: # TODO: confirm any differentiation in removal across subtypes
   ferric_chloride_dose:
     value: 0.00999352
     units: kg/m^3
+  activated_carbon_parameter_a:
+    value: 0.00405395
+    units: kg/m^3
+  activated_carbon_parameter_b:
+    value: -0.087230845
+    units: dimensionless
+  sand_parameter_a:
+    value: 0.00450127
+    units: kg/m^3
+  sand_parameter_b:
+    value: -0.087230845
+    units: dimensionless
+  anthracite_parameter_a:
+    value: 0.00450127
+    units: kg/m^3
+  anthracite_parameter_b:
+    value: -0.0884862
+    units: dimensionless
+  cationic_polymer_parameter_a:
+    value: 0.0106589
+    units: kg/m^3
+  cationic_polymer_parameter_b:
+    value: -0.196068
+    units: dimensionless
 gravity_basin:
   energy_electric_flow_vol_inlet:
     value: 0.078498
@@ -65,6 +89,30 @@ gravity_basin:
   ferric_chloride_dose:
     value: 0.00999352
     units: kg/m^3
+  activated_carbon_parameter_a:
+    value: 0.00405395
+    units: kg/m^3
+  activated_carbon_parameter_b:
+    value: -0.087230845
+    units: dimensionless
+  sand_parameter_a:
+    value: 0.00450127
+    units: kg/m^3
+  sand_parameter_b:
+    value: -0.087230845
+    units: dimensionless
+  anthracite_parameter_a:
+    value: 0.00450127
+    units: kg/m^3
+  anthracite_parameter_b:
+    value: -0.0884862
+    units: dimensionless
+  cationic_polymer_parameter_a:
+    value: 0.0273543
+    units: kg/m^3
+  cationic_polymer_parameter_b:
+    value: -0.241725
+    units: dimensionless
 fixed bed:
   energy_electric_flow_vol_inlet:
     value: 0.085618
@@ -98,3 +146,27 @@ fixed bed:
   ferric_chloride_dose:
     value: 0.00999352
     units: kg/m^3
+  activated_carbon_parameter_a:
+    value: 0.00405395
+    units: kg/m^3
+  activated_carbon_parameter_b:
+    value: -0.087230845
+    units: dimensionless
+  sand_parameter_a:
+    value: 0.00450127
+    units: kg/m^3
+  sand_parameter_b:
+    value: -0.087230845
+    units: dimensionless
+  anthracite_parameter_a:
+    value: 0.00450127
+    units: kg/m^3
+  anthracite_parameter_b:
+    value: -0.0884862
+    units: dimensionless
+  cationic_polymer_parameter_a:
+    value: 0.0106589
+    units: kg/m^3
+  cationic_polymer_parameter_b:
+    value: -0.196068
+    units: dimensionless

--- a/watertap/data/techno_economic/gac.yaml
+++ b/watertap/data/techno_economic/gac.yaml
@@ -1,4 +1,7 @@
 default: # TODO: confirm any differentiation in removal across subtypes
+  volumetric_electricity_intensity:
+    value: 0.106310
+    units: kW/m^3
   recovery_frac_mass_H2O:
     value: 0.96
     units: dimensionless
@@ -15,10 +18,27 @@ default: # TODO: confirm any differentiation in removal across subtypes
       value: 0.97
       units: dimensionless
       constituent_longform: Total Suspended Solids (TSS)
-  empty_bed_contact_time:   #TODO: used in EPA cost curves for later
+  empty_bed_contact_time:
     value: 10
     units: min
+  activated_carbon_replacement:
+    value: 0.0550884
+    units: kg/m^3
+  capital_cost:
+    cost_factor: None
+    capital_a_parameter:
+      value: 436.445
+      units: USD_2017/(m^3/hr)
+    capital_b_parameter:
+      value: 4049210
+      units: USD_2017/hr
+    capital_c_parameter:
+      value: 5971.57
+      units: USD_2017/m^3
 pressure_vessel:
+  volumetric_electricity_intensity:
+    value: 0.0521749
+    units: kW/m^3
   recovery_frac_mass_H2O:
     value: 0.96
     units: dimensionless
@@ -35,10 +55,27 @@ pressure_vessel:
       value: 0.97
       units: dimensionless
       constituent_longform: Total Suspended Solids (TSS)
-  empty_bed_contact_time: #TODO: used in EPA cost curves for later
+  empty_bed_contact_time:
     value: 10
     units: min
+  activated_carbon_replacement:
+    value: 0.0550884
+    units: kg/m^3
+  capital_cost:
+    cost_factor: None
+    capital_a_parameter:
+      value: 144.259
+      units: USD_2017/(m^3/hr)
+    capital_b_parameter:
+      value: 1873400
+      units: USD_2017/hr
+    capital_c_parameter:
+      value: 8427.78
+      units: USD_2017/m^3
 gravity:
+  volumetric_electricity_intensity:
+    value: 0.106310
+    units: kW/m^3
   recovery_frac_mass_H2O:
     value: 0.96
     units: dimensionless
@@ -55,6 +92,20 @@ gravity:
       value: 0.97
       units: dimensionless
       constituent_longform: Total Suspended Solids (TSS)
-  empty_bed_contact_time: #TODO: used in EPA cost curves for later
+  empty_bed_contact_time:
     value: 10
     units: min
+  activated_carbon_replacement:
+    value: 0.0550884
+    units: kg/m^3
+  capital_cost:
+    cost_factor: None
+    capital_a_parameter:
+      value: 436.445
+      units: USD_2017/(m^3/hr)
+    capital_b_parameter:
+      value: 4049210
+      units: USD_2017/hr
+    capital_c_parameter:
+      value: 5971.57
+      units: USD_2017/m^3

--- a/watertap/data/techno_economic/gac.yaml
+++ b/watertap/data/techno_economic/gac.yaml
@@ -1,5 +1,5 @@
 default: # TODO: confirm any differentiation in removal across subtypes
-  volumetric_electricity_intensity:
+  electricity_intensity_parameter:
     value: 0.106310
     units: kW/m^3
   recovery_frac_mass_H2O:
@@ -36,7 +36,7 @@ default: # TODO: confirm any differentiation in removal across subtypes
       value: 5971.57
       units: USD_2017/m^3
 pressure_vessel:
-  volumetric_electricity_intensity:
+  electricity_intensity_parameter:
     value: 0.0521749
     units: kW/m^3
   recovery_frac_mass_H2O:
@@ -73,7 +73,7 @@ pressure_vessel:
       value: 8427.78
       units: USD_2017/m^3
 gravity:
-  volumetric_electricity_intensity:
+  electricity_intensity_parameter:
     value: 0.106310
     units: kW/m^3
   recovery_frac_mass_H2O:

--- a/watertap/unit_models/zero_order/fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/fixed_bed_zo.py
@@ -102,3 +102,131 @@ class FixedBedZOData(ZeroOrderBaseData):
                     pyunits.convert(
                         b.ferric_chloride_dose*b.properties_in[t].flow_vol,
                         to_units=pyunits.kg/pyunits.hr))
+
+        # Activated Carbon demand
+        self.activated_carbon_demand = Var(
+            self.flowsheet().time,
+            units=pyunits.kg/pyunits.hr,
+            bounds=(0, None),
+            doc="Replacement rate for activated carbon")
+        self.activated_carbon_parameter_a = Var(
+            units=pyunits.kg/pyunits.m**3,
+            bounds=(0, None),
+            doc="Pre-exponential factor for activated carbon demand")
+        self.activated_carbon_parameter_b = Var(
+            units=pyunits.dimensionless,
+            bounds=(0, None),
+            doc="Exponential factor for activated carbon demand")
+        self._fixed_perf_vars.append(self.activated_carbon_parameter_a)
+        self._fixed_perf_vars.append(self.activated_carbon_parameter_b)
+        self._perf_var_dict["Activated Carbon Demand"] = \
+            self.activated_carbon_demand
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Activated carbon demand constraint")
+        def activated_carbon_demand_equation(b, t):
+            return (b.activated_carbon_demand[t] ==
+                    pyunits.convert(
+                        b.activated_carbon_parameter_a *
+                        pyunits.convert(b.properties_in[t].flow_vol /
+                                        (pyunits.m**3/pyunits.hour),
+                                        to_units=pyunits.dimensionless) **
+                        b.activated_carbon_parameter_b *
+                        b.properties_in[t].flow_vol,
+                        to_units=pyunits.kg/pyunits.hr))
+
+        # Sand demand
+        self.sand_demand = Var(
+            self.flowsheet().time,
+            units=pyunits.kg/pyunits.hr,
+            bounds=(0, None),
+            doc="Replacement rate for sand")
+        self.sand_parameter_a = Var(
+            units=pyunits.kg/pyunits.m**3,
+            bounds=(0, None),
+            doc="Pre-exponential factor for sand demand")
+        self.sand_parameter_b = Var(
+            units=pyunits.dimensionless,
+            bounds=(0, None),
+            doc="Exponential factor for sand demand")
+        self._fixed_perf_vars.append(self.sand_parameter_a)
+        self._fixed_perf_vars.append(self.sand_parameter_b)
+        self._perf_var_dict["Sand Demand"] = \
+            self.sand_demand
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Sand demand constraint")
+        def sand_demand_equation(b, t):
+            return (b.sand_demand[t] ==
+                    pyunits.convert(
+                        b.sand_parameter_a *
+                        pyunits.convert(b.properties_in[t].flow_vol /
+                                        (pyunits.m**3/pyunits.hour),
+                                        to_units=pyunits.dimensionless) **
+                        b.sand_parameter_b *
+                        b.properties_in[t].flow_vol,
+                        to_units=pyunits.kg/pyunits.hr))
+
+        # Anthracite demand
+        self.anthracite_demand = Var(
+            self.flowsheet().time,
+            units=pyunits.kg/pyunits.hr,
+            bounds=(0, None),
+            doc="Replacement rate for anthracite")
+        self.anthracite_parameter_a = Var(
+            units=pyunits.kg/pyunits.m**3,
+            bounds=(0, None),
+            doc="Pre-exponential factor for anthracite demand")
+        self.anthracite_parameter_b = Var(
+            units=pyunits.dimensionless,
+            bounds=(0, None),
+            doc="Exponential factor for anthracite demand")
+        self._fixed_perf_vars.append(self.anthracite_parameter_a)
+        self._fixed_perf_vars.append(self.anthracite_parameter_b)
+        self._perf_var_dict["Anthracite Demand"] = \
+            self.anthracite_demand
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Anthracite demand constraint")
+        def anthracite_demand_equation(b, t):
+            return (b.anthracite_demand[t] ==
+                    pyunits.convert(
+                        b.anthracite_parameter_a *
+                        pyunits.convert(b.properties_in[t].flow_vol /
+                                        (pyunits.m**3/pyunits.hour),
+                                        to_units=pyunits.dimensionless) **
+                        b.anthracite_parameter_b *
+                        b.properties_in[t].flow_vol,
+                        to_units=pyunits.kg/pyunits.hr))
+
+        # Cationic polymer demand
+        self.cationic_polymer_demand = Var(
+            self.flowsheet().time,
+            units=pyunits.kg/pyunits.hr,
+            bounds=(0, None),
+            doc="Replacement rate for cationic polymer")
+        self.cationic_polymer_parameter_a = Var(
+            units=pyunits.kg/pyunits.m**3,
+            bounds=(0, None),
+            doc="Pre-exponential factor for cationic polymer demand")
+        self.cationic_polymer_parameter_b = Var(
+            units=pyunits.dimensionless,
+            bounds=(0, None),
+            doc="Exponential factor for cationic polymer demand")
+        self._fixed_perf_vars.append(self.cationic_polymer_parameter_a)
+        self._fixed_perf_vars.append(self.cationic_polymer_parameter_b)
+        self._perf_var_dict["Cationic Polymer Demand"] = \
+            self.cationic_polymer_demand
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Cationic Polymer demand constraint")
+        def cationic_polymer_demand_equation(b, t):
+            return (b.cationic_polymer_demand[t] ==
+                    pyunits.convert(
+                        b.cationic_polymer_parameter_a *
+                        pyunits.convert(b.properties_in[t].flow_vol /
+                                        (pyunits.m**3/pyunits.hour),
+                                        to_units=pyunits.dimensionless) **
+                        b.cationic_polymer_parameter_b *
+                        b.properties_in[t].flow_vol,
+                        to_units=pyunits.kg/pyunits.hr))

--- a/watertap/unit_models/zero_order/fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/fixed_bed_zo.py
@@ -17,7 +17,7 @@ operation.
 
 from pyomo.environ import Reference, units as pyunits
 from idaes.core import declare_process_block_class
-from watertap.core import build_siso, pump_electricity, ZeroOrderBaseData
+from watertap.core import build_siso, constant_intensity, ZeroOrderBaseData
 
 # Some more information about this module
 __author__ = "Adam Atia"
@@ -37,8 +37,5 @@ class FixedBedZOData(ZeroOrderBaseData):
         self._tech_type = "fixed_bed"
 
         build_siso(self)
-        self._Q = Reference(self.properties_in[:].flow_vol)
-        # TODO: incorporate a*Q**b relationship for electricity consumption based on EPA data fitting;
-        # apply pump electricity consumption in the meantime
-        pump_electricity(self, self._Q)
+        constant_intensity(self)
         self.recovery_frac_mass_H2O.fix(1)

--- a/watertap/unit_models/zero_order/gac_zo.py
+++ b/watertap/unit_models/zero_order/gac_zo.py
@@ -15,9 +15,9 @@ This module contains a zero-order representation of a granular activated carbon 
 operation.
 """
 
-from pyomo.environ import Reference, units as pyunits
+from pyomo.environ import units as pyunits, Var
 from idaes.core import declare_process_block_class
-from watertap.core import build_sido, pump_electricity, ZeroOrderBaseData
+from watertap.core import build_sido, ZeroOrderBaseData
 
 # Some more information about this module
 __author__ = "Adam Atia"
@@ -37,7 +37,74 @@ class GACZOData(ZeroOrderBaseData):
         self._tech_type = "gac"
 
         build_sido(self)
-        self._Q = Reference(self.properties_in[:].flow_vol)
-        # TODO: incorporate a*Q**b relationship for electricity consumption based on EPA data fitting;
-        # apply pump electricity consumption in the meantime
-        pump_electricity(self, self._Q)
+
+        # Empty Bed Contact Time
+        self.empty_bed_contact_time = Var(
+            units=pyunits.hour,
+            bounds=(0, None),
+            doc="Empty bed contact time of unit")
+
+        self._fixed_perf_vars.append(self.empty_bed_contact_time)
+        self._perf_var_dict["Empty Bed Contact Time"] = \
+            self.empty_bed_contact_time
+
+        # Electricity Demand
+        self.electricity = Var(self.flowsheet().time,
+                               units=pyunits.kW,
+                               bounds=(0, None),
+                               doc="Electricity consumption of unit")
+
+        self.volumetric_electricity_intensity = Var(
+            units=pyunits.kW/pyunits.m**3,
+            doc="Electricity intensity with respect to inlet flowrate of unit")
+
+        self.energy_electric_flow_vol_inlet = Var(
+            units=pyunits.kWh/pyunits.m**3,
+            doc="Electricity intensity with respect to inlet flowrate of unit")
+
+        @self.Constraint(
+            doc='Electricity intensity based on empty bed contact time.')
+        def electricity_intensity_constraint(b):
+            return (b.energy_electric_flow_vol_inlet ==
+                    b.volumetric_electricity_intensity *
+                    b.empty_bed_contact_time)
+
+        @self.Constraint(self.flowsheet().time,
+                         doc='Constraint for electricity consumption based on '
+                         'feed flowrate.')
+        def electricity_consumption(b, t):
+            return b.electricity[t] == (
+                b.energy_electric_flow_vol_inlet *
+                pyunits.convert(b.get_inlet_flow(t),
+                                to_units=pyunits.m**3/pyunits.hour))
+
+        self._fixed_perf_vars.append(self.volumetric_electricity_intensity)
+
+        self._perf_var_dict["Electricity Demand"] = self.electricity
+        self._perf_var_dict["Electricity Intensity"] = \
+            self.energy_electric_flow_vol_inlet
+
+        # Demand for activated carbon
+        self.activated_carbon_replacement = Var(
+            units=pyunits.kg/pyunits.m**3,
+            bounds=(0, None),
+            doc="Replacement rate of activated carbon")
+
+        self.activated_carbon_demand = Var(
+            self.flowsheet().time,
+            units=pyunits.kg/pyunits.hour,
+            bounds=(0, None),
+            doc="Demand for activated carbon")
+
+        @self.Constraint(self.flowsheet().time,
+                         doc='Constraint for activated carbon consumption.')
+        def activated_carbon_equation(b, t):
+            return b.activated_carbon_demand[t] == (
+                b.activated_carbon_replacement *
+                pyunits.convert(b.get_inlet_flow(t),
+                                to_units=pyunits.m**3/pyunits.hour))
+
+        self._fixed_perf_vars.append(self.activated_carbon_replacement)
+
+        self._perf_var_dict["Activated Carbon Demand"] = \
+            self.activated_carbon_demand

--- a/watertap/unit_models/zero_order/gac_zo.py
+++ b/watertap/unit_models/zero_order/gac_zo.py
@@ -54,9 +54,10 @@ class GACZOData(ZeroOrderBaseData):
                                bounds=(0, None),
                                doc="Electricity consumption of unit")
 
-        self.volumetric_electricity_intensity = Var(
+        self.electricity_intensity_parameter = Var(
             units=pyunits.kW/pyunits.m**3,
-            doc="Electricity intensity with respect to inlet flowrate of unit")
+            doc="Parameter for calculating electricity base on empty bed "
+            "contacting time")
 
         self.energy_electric_flow_vol_inlet = Var(
             units=pyunits.kWh/pyunits.m**3,
@@ -66,7 +67,7 @@ class GACZOData(ZeroOrderBaseData):
             doc='Electricity intensity based on empty bed contact time.')
         def electricity_intensity_constraint(b):
             return (b.energy_electric_flow_vol_inlet ==
-                    b.volumetric_electricity_intensity *
+                    b.electricity_intensity_parameter *
                     b.empty_bed_contact_time)
 
         @self.Constraint(self.flowsheet().time,
@@ -78,7 +79,7 @@ class GACZOData(ZeroOrderBaseData):
                 pyunits.convert(b.get_inlet_flow(t),
                                 to_units=pyunits.m**3/pyunits.hour))
 
-        self._fixed_perf_vars.append(self.volumetric_electricity_intensity)
+        self._fixed_perf_vars.append(self.electricity_intensity_parameter)
 
         self._perf_var_dict["Electricity Demand"] = self.electricity
         self._perf_var_dict["Electricity Intensity"] = \

--- a/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
@@ -79,6 +79,30 @@ class TestFixedBedZO_w_o_default_removal:
         assert isinstance(model.fs.unit.ferric_chloride_demand_equation,
                           Constraint)
 
+        assert isinstance(model.fs.unit.activated_carbon_parameter_a, Var)
+        assert isinstance(model.fs.unit.activated_carbon_parameter_b, Var)
+        assert isinstance(model.fs.unit.activated_carbon_demand, Var)
+        assert isinstance(model.fs.unit.activated_carbon_demand_equation,
+                          Constraint)
+
+        assert isinstance(model.fs.unit.sand_parameter_a, Var)
+        assert isinstance(model.fs.unit.sand_parameter_b, Var)
+        assert isinstance(model.fs.unit.sand_demand, Var)
+        assert isinstance(model.fs.unit.sand_demand_equation,
+                          Constraint)
+
+        assert isinstance(model.fs.unit.anthracite_parameter_a, Var)
+        assert isinstance(model.fs.unit.anthracite_parameter_b, Var)
+        assert isinstance(model.fs.unit.anthracite_demand, Var)
+        assert isinstance(model.fs.unit.anthracite_demand_equation,
+                          Constraint)
+
+        assert isinstance(model.fs.unit.cationic_polymer_parameter_a, Var)
+        assert isinstance(model.fs.unit.cationic_polymer_parameter_b, Var)
+        assert isinstance(model.fs.unit.cationic_polymer_demand, Var)
+        assert isinstance(model.fs.unit.cationic_polymer_demand_equation,
+                          Constraint)
+
     @pytest.mark.component
     def test_load_parameters(self, model):
         data = model.db.get_unit_operation_parameters("fixed_bed")
@@ -96,6 +120,44 @@ class TestFixedBedZO_w_o_default_removal:
         assert model.fs.unit.energy_electric_flow_vol_inlet.fixed
         assert model.fs.unit.energy_electric_flow_vol_inlet.value == data[
             "energy_electric_flow_vol_inlet"]["value"]
+
+        assert model.fs.unit.acetic_acid_dose.fixed
+        assert model.fs.unit.acetic_acid_dose.value == data[
+            "acetic_acid_dose"]["value"]
+        assert model.fs.unit.phosphoric_acid_dose.fixed
+        assert model.fs.unit.phosphoric_acid_dose.value == data[
+            "phosphoric_acid_dose"]["value"]
+        assert model.fs.unit.ferric_chloride_dose.fixed
+        assert model.fs.unit.ferric_chloride_dose.value == data[
+            "ferric_chloride_dose"]["value"]
+
+        assert model.fs.unit.activated_carbon_parameter_a.fixed
+        assert model.fs.unit.activated_carbon_parameter_a.value == data[
+            "activated_carbon_parameter_a"]["value"]
+        assert model.fs.unit.activated_carbon_parameter_b.fixed
+        assert model.fs.unit.activated_carbon_parameter_b.value == data[
+            "activated_carbon_parameter_b"]["value"]
+
+        assert model.fs.unit.sand_parameter_a.fixed
+        assert model.fs.unit.sand_parameter_a.value == data[
+            "sand_parameter_a"]["value"]
+        assert model.fs.unit.sand_parameter_b.fixed
+        assert model.fs.unit.sand_parameter_b.value == data[
+            "sand_parameter_b"]["value"]
+
+        assert model.fs.unit.anthracite_parameter_a.fixed
+        assert model.fs.unit.anthracite_parameter_a.value == data[
+            "anthracite_parameter_a"]["value"]
+        assert model.fs.unit.anthracite_parameter_b.fixed
+        assert model.fs.unit.anthracite_parameter_b.value == data[
+            "anthracite_parameter_b"]["value"]
+
+        assert model.fs.unit.cationic_polymer_parameter_a.fixed
+        assert model.fs.unit.cationic_polymer_parameter_a.value == data[
+            "cationic_polymer_parameter_a"]["value"]
+        assert model.fs.unit.cationic_polymer_parameter_b.fixed
+        assert model.fs.unit.cationic_polymer_parameter_b.value == data[
+            "cationic_polymer_parameter_b"]["value"]
 
     @pytest.mark.component
     def test_degrees_of_freedom(self, model):
@@ -145,9 +207,17 @@ Unit : fs.unit                                                             Time:
 
     Variables: 
 
-    Key                  : Value   : Fixed : Bounds
-      Electricity Demand :  3685.2 : False : (0, None)
-    Solute Removal [bod] : 0.90000 :  True : (0, None)
+    Key                     : Value    : Fixed : Bounds
+         Acetic Acid Demand :   1799.0 : False : (0, None)
+    Activated Carbon Demand :   58.448 : False : (0, None)
+          Anthracite Demand :   64.048 : False : (0, None)
+    Cationic Polymer Demand :   49.057 : False : (0, None)
+         Electricity Demand :   3082.6 : False : (0, None)
+      Electricity Intensity : 0.085618 :  True : (None, None)
+    Ferric Chlorided Demand :   359.80 : False : (0, None)
+     Phosphoric Acid Demand :   152.17 : False : (0, None)
+                Sand Demand :   64.897 : False : (0, None)
+       Solute Removal [bod] :  0.90000 :  True : (0, None)
 
 ------------------------------------------------------------------------------------
     Stream Table
@@ -159,6 +229,7 @@ Unit : fs.unit                                                             Time:
 """
 
         assert output in stream.getvalue()
+
 
 class TestFixedBedZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -210,6 +281,44 @@ class TestFixedBedZO_w_default_removal:
         assert model.fs.unit.energy_electric_flow_vol_inlet.value == data[
             "energy_electric_flow_vol_inlet"]["value"]
 
+        assert model.fs.unit.acetic_acid_dose.fixed
+        assert model.fs.unit.acetic_acid_dose.value == data[
+            "acetic_acid_dose"]["value"]
+        assert model.fs.unit.phosphoric_acid_dose.fixed
+        assert model.fs.unit.phosphoric_acid_dose.value == data[
+            "phosphoric_acid_dose"]["value"]
+        assert model.fs.unit.ferric_chloride_dose.fixed
+        assert model.fs.unit.ferric_chloride_dose.value == data[
+            "ferric_chloride_dose"]["value"]
+
+        assert model.fs.unit.activated_carbon_parameter_a.fixed
+        assert model.fs.unit.activated_carbon_parameter_a.value == data[
+            "activated_carbon_parameter_a"]["value"]
+        assert model.fs.unit.activated_carbon_parameter_b.fixed
+        assert model.fs.unit.activated_carbon_parameter_b.value == data[
+            "activated_carbon_parameter_b"]["value"]
+
+        assert model.fs.unit.sand_parameter_a.fixed
+        assert model.fs.unit.sand_parameter_a.value == data[
+            "sand_parameter_a"]["value"]
+        assert model.fs.unit.sand_parameter_b.fixed
+        assert model.fs.unit.sand_parameter_b.value == data[
+            "sand_parameter_b"]["value"]
+
+        assert model.fs.unit.anthracite_parameter_a.fixed
+        assert model.fs.unit.anthracite_parameter_a.value == data[
+            "anthracite_parameter_a"]["value"]
+        assert model.fs.unit.anthracite_parameter_b.fixed
+        assert model.fs.unit.anthracite_parameter_b.value == data[
+            "anthracite_parameter_b"]["value"]
+
+        assert model.fs.unit.cationic_polymer_parameter_a.fixed
+        assert model.fs.unit.cationic_polymer_parameter_a.value == data[
+            "cationic_polymer_parameter_a"]["value"]
+        assert model.fs.unit.cationic_polymer_parameter_b.fixed
+        assert model.fs.unit.cationic_polymer_parameter_b.value == data[
+            "cationic_polymer_parameter_b"]["value"]
+
     @pytest.mark.component
     def test_degrees_of_freedom(self, model):
         assert degrees_of_freedom(model.fs.unit) == 0
@@ -260,10 +369,18 @@ Unit : fs.unit                                                             Time:
 
     Variables: 
 
-    Key                  : Value   : Fixed : Bounds
-      Electricity Demand :  3686.7 : False : (0, None)
-    Solute Removal [bod] : 0.90000 :  True : (0, None)
-    Solute Removal [foo] :  0.0000 :  True : (0, None)
+    Key                     : Value    : Fixed : Bounds
+         Acetic Acid Demand :   1799.7 : False : (0, None)
+    Activated Carbon Demand :   58.469 : False : (0, None)
+          Anthracite Demand :   64.072 : False : (0, None)
+    Cationic Polymer Demand :   49.073 : False : (0, None)
+         Electricity Demand :   3083.8 : False : (0, None)
+      Electricity Intensity : 0.085618 :  True : (None, None)
+    Ferric Chlorided Demand :   359.95 : False : (0, None)
+     Phosphoric Acid Demand :   152.23 : False : (0, None)
+                Sand Demand :   64.921 : False : (0, None)
+       Solute Removal [bod] :  0.90000 :  True : (0, None)
+       Solute Removal [foo] :   0.0000 :  True : (0, None)
 
 ------------------------------------------------------------------------------------
     Stream Table
@@ -357,3 +474,17 @@ def test_costing(subtype):
 
     assert m.fs.unit1.electricity[0] in \
         m.fs.costing._registered_flows["electricity"]
+    assert m.fs.unit1.acetic_acid_demand[0] in \
+        m.fs.costing._registered_flows["acetic_acid"]
+    assert m.fs.unit1.phosphoric_acid_demand[0] in \
+        m.fs.costing._registered_flows["phosphoric_acid"]
+    assert m.fs.unit1.ferric_chloride_demand[0] in \
+        m.fs.costing._registered_flows["ferric_chloride"]
+    assert m.fs.unit1.activated_carbon_demand[0] in \
+        m.fs.costing._registered_flows["activated_carbon"]
+    assert m.fs.unit1.sand_demand[0] in \
+        m.fs.costing._registered_flows["sand"]
+    assert m.fs.unit1.anthracite_demand[0] in \
+        m.fs.costing._registered_flows["anthracite"]
+    assert m.fs.unit1.cationic_polymer_demand[0] in \
+        m.fs.costing._registered_flows["cationic_polymer"]

--- a/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
@@ -64,6 +64,21 @@ class TestFixedBedZO_w_o_default_removal:
         assert isinstance(model.fs.unit.water_recovery_equation, Constraint)
         assert isinstance(model.fs.unit.solute_treated_equation, Constraint)
 
+        assert isinstance(model.fs.unit.acetic_acid_dose, Var)
+        assert isinstance(model.fs.unit.acetic_acid_demand, Var)
+        assert isinstance(model.fs.unit.acetic_acid_demand_equation,
+                          Constraint)
+
+        assert isinstance(model.fs.unit.phosphoric_acid_dose, Var)
+        assert isinstance(model.fs.unit.phosphoric_acid_demand, Var)
+        assert isinstance(model.fs.unit.acetic_acid_demand_equation,
+                          Constraint)
+
+        assert isinstance(model.fs.unit.ferric_chloride_dose, Var)
+        assert isinstance(model.fs.unit.ferric_chloride_demand, Var)
+        assert isinstance(model.fs.unit.ferric_chloride_demand_equation,
+                          Constraint)
+
     @pytest.mark.component
     def test_load_parameters(self, model):
         data = model.db.get_unit_operation_parameters("fixed_bed")
@@ -298,6 +313,7 @@ db = Database()
 params = db._get_technology("fixed_bed")
 
 
+@pytest.mark.component
 @pytest.mark.parametrize("subtype", [k for k in params.keys()])
 def test_costing(subtype):
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_gac_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_gac_zo.py
@@ -17,17 +17,19 @@ import pytest
 from io import StringIO
 
 from pyomo.environ import (
-    check_optimal_termination, ConcreteModel, Constraint, value, Var, Param)
+    Block, check_optimal_termination, ConcreteModel, Constraint, value, Var)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
+from idaes.generic_models.costing import UnitModelCostingBlock
 
 from watertap.unit_models.zero_order import GACZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
+from watertap.core.zero_order_costing import ZeroOrderCosting
 
 solver = get_solver()
 
@@ -56,13 +58,18 @@ class TestGACZO_w_o_default_removal:
     def test_build(self, model):
         assert model.fs.unit.config.database is model.db
 
-        assert isinstance(model.fs.unit.lift_height, Param)
-        assert isinstance(model.fs.unit.eta_pump, Param)
-        assert isinstance(model.fs.unit.eta_motor, Param)
+        assert isinstance(model.fs.unit.empty_bed_contact_time, Var)
+        assert isinstance(model.fs.unit.energy_electric_flow_vol_inlet, Var)
         assert isinstance(model.fs.unit.electricity, Var)
+        assert isinstance(model.fs.unit.activated_carbon_replacement, Var)
+        assert isinstance(model.fs.unit.activated_carbon_demand, Var)
+
         assert isinstance(model.fs.unit.electricity_consumption, Constraint)
+        assert isinstance(model.fs.unit.electricity_intensity_constraint,
+                          Constraint)
         assert isinstance(model.fs.unit.water_recovery_equation, Constraint)
         assert isinstance(model.fs.unit.solute_treated_equation, Constraint)
+        assert isinstance(model.fs.unit.activated_carbon_equation, Constraint)
 
     @pytest.mark.component
     def test_load_parameters(self, model):
@@ -76,6 +83,16 @@ class TestGACZO_w_o_default_removal:
         for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
             assert v.fixed
             assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+        assert model.fs.unit.empty_bed_contact_time.fixed
+        assert model.fs.unit.empty_bed_contact_time.value == \
+            data["empty_bed_contact_time"]["value"]/60  # min to hour
+        assert model.fs.unit.volumetric_electricity_intensity.fixed
+        assert model.fs.unit.volumetric_electricity_intensity.value == \
+            data["volumetric_electricity_intensity"]["value"]
+        assert model.fs.unit.activated_carbon_replacement.fixed
+        assert model.fs.unit.activated_carbon_replacement.value == \
+            data["activated_carbon_replacement"]["value"]
 
     @pytest.mark.component
     def test_degrees_of_freedom(self, model):
@@ -112,7 +129,7 @@ class TestGACZO_w_o_default_removal:
             model.fs.unit.properties_byproduct[0].conc_mass_comp["tss"]))
         assert (pytest.approx(0.49854, rel=1e-5) == value(
             model.fs.unit.properties_byproduct[0].conc_mass_comp["nonvolatile_toc"]))
-        assert (pytest.approx(3685.6, rel=1e-5) ==
+        assert (pytest.approx(637.988, rel=1e-5) ==
                 value(model.fs.unit.electricity[0]))
 
     @pytest.mark.solver
@@ -139,11 +156,14 @@ Unit : fs.unit                                                             Time:
 
     Variables: 
 
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  3685.6 : False : (0, None)
-    Solute Removal [nonvolatile_toc] : 0.20000 :  True : (0, None)
-                Solute Removal [tss] : 0.97000 :  True : (0, None)
-                      Water Recovery : 0.96000 :  True : (1e-08, 1.0000001)
+    Key                              : Value    : Fixed : Bounds
+             Activated Carbon Demand :   1983.6 : False : (0, None)
+                  Electricity Demand :   637.99 : False : (0, None)
+               Electricity Intensity : 0.017718 : False : (None, None)
+              Empty Bed Contact Time :  0.16667 :  True : (0, None)
+    Solute Removal [nonvolatile_toc] :  0.20000 :  True : (0, None)
+                Solute Removal [tss] :  0.97000 :  True : (0, None)
+                      Water Recovery :  0.96000 :  True : (1e-08, 1.0000001)
 
 ------------------------------------------------------------------------------------
     Stream Table
@@ -156,6 +176,7 @@ Unit : fs.unit                                                             Time:
 """
 
         assert output in stream.getvalue()
+
 
 class TestGACZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -182,27 +203,38 @@ class TestGACZO_w_default_removal:
     def test_build(self, model):
         assert model.fs.unit.config.database is model.db
 
-        assert isinstance(model.fs.unit.lift_height, Param)
-        assert isinstance(model.fs.unit.eta_pump, Param)
-        assert isinstance(model.fs.unit.eta_motor, Param)
+        assert isinstance(model.fs.unit.empty_bed_contact_time, Var)
+        assert isinstance(model.fs.unit.energy_electric_flow_vol_inlet, Var)
         assert isinstance(model.fs.unit.electricity, Var)
+
         assert isinstance(model.fs.unit.electricity_consumption, Constraint)
+        assert isinstance(model.fs.unit.electricity_intensity_constraint,
+                          Constraint)
         assert isinstance(model.fs.unit.water_recovery_equation, Constraint)
         assert isinstance(model.fs.unit.solute_treated_equation, Constraint)
 
     @pytest.mark.component
     def test_load_parameters(self, model):
         data = model.db.get_unit_operation_parameters("gac")
+
         model.fs.unit.load_parameters_from_database(use_default_removal=True)
         assert model.fs.unit.recovery_frac_mass_H2O[0].fixed
         assert model.fs.unit.recovery_frac_mass_H2O[0].value == \
             data["recovery_frac_mass_H2O"]["value"]
+
         for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
             assert v.fixed
             if j == "foo":
-                assert v.value == data["default_removal_frac_mass_solute"]["value"]
+                assert v.value == 0
             else:
                 assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+        assert model.fs.unit.empty_bed_contact_time.fixed
+        assert model.fs.unit.empty_bed_contact_time.value == \
+            data["empty_bed_contact_time"]["value"]/60  # min to hour
+        assert model.fs.unit.volumetric_electricity_intensity.fixed
+        assert model.fs.unit.volumetric_electricity_intensity.value == \
+            data["volumetric_electricity_intensity"]["value"]
 
     @pytest.mark.component
     def test_degrees_of_freedom(self, model):
@@ -243,7 +275,7 @@ class TestGACZO_w_default_removal:
             model.fs.unit.properties_byproduct[0].conc_mass_comp["nonvolatile_toc"]))
         assert (pytest.approx(2.4927e-08, rel=1e-5) == value(
             model.fs.unit.properties_byproduct[0].conc_mass_comp["foo"]))
-        assert (pytest.approx(3686.0, rel=1e-5) ==
+        assert (pytest.approx(638.051, rel=1e-5) ==
                 value(model.fs.unit.electricity[0]))
 
     @pytest.mark.solver
@@ -270,12 +302,15 @@ Unit : fs.unit                                                             Time:
 
     Variables: 
 
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  3686.0 : False : (0, None)
-                Solute Removal [foo] :  0.0000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] : 0.20000 :  True : (0, None)
-                Solute Removal [tss] : 0.97000 :  True : (0, None)
-                      Water Recovery : 0.96000 :  True : (1e-08, 1.0000001)
+    Key                              : Value    : Fixed : Bounds
+             Activated Carbon Demand :   1983.8 : False : (0, None)
+                  Electricity Demand :   638.05 : False : (0, None)
+               Electricity Intensity : 0.017718 : False : (None, None)
+              Empty Bed Contact Time :  0.16667 :  True : (0, None)
+                Solute Removal [foo] :   0.0000 :  True : (0, None)
+    Solute Removal [nonvolatile_toc] :  0.20000 :  True : (0, None)
+                Solute Removal [tss] :  0.97000 :  True : (0, None)
+                      Water Recovery :  0.96000 :  True : (1e-08, 1.0000001)
 
 ------------------------------------------------------------------------------------
     Stream Table
@@ -320,3 +355,49 @@ class TestGACZOsubtype:
         for (t, j), v in model.fs.unit.removal_frac_mass_solute.items():
             assert v.fixed
             assert v.value == data["removal_frac_mass_solute"][j]["value"]
+
+
+def test_costing():
+    m = ConcreteModel()
+    m.db = Database()
+
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = WaterParameterBlock(
+        default={"solute_list": ["sulfur", "toc", "tss"]})
+
+    m.fs.costing = ZeroOrderCosting()
+
+    m.fs.unit1 = GACZO(default={
+        "property_package": m.fs.params,
+        "database": m.db})
+
+    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)
+    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit1.inlet.flow_mass_comp[0, "tss"].fix(3)
+    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    m.fs.unit1.costing = UnitModelCostingBlock(default={
+        "flowsheet_costing_block": m.fs.costing})
+
+    assert isinstance(m.fs.costing.gac, Block)
+    assert isinstance(m.fs.costing.gac.capital_a_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.gac.capital_b_parameter,
+                      Var)
+    assert isinstance(m.fs.costing.gac.capital_c_parameter,
+                      Var)
+
+    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
+                      Constraint)
+
+    assert_units_consistent(m.fs)
+    assert degrees_of_freedom(m.fs.unit1) == 0
+
+    assert m.fs.unit1.electricity[0] in \
+        m.fs.costing._registered_flows["electricity"]
+    assert m.fs.unit1.activated_carbon_demand[0] in \
+        m.fs.costing._registered_flows["activated_carbon"]

--- a/watertap/unit_models/zero_order/tests/test_gac_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_gac_zo.py
@@ -87,9 +87,9 @@ class TestGACZO_w_o_default_removal:
         assert model.fs.unit.empty_bed_contact_time.fixed
         assert model.fs.unit.empty_bed_contact_time.value == \
             data["empty_bed_contact_time"]["value"]/60  # min to hour
-        assert model.fs.unit.volumetric_electricity_intensity.fixed
-        assert model.fs.unit.volumetric_electricity_intensity.value == \
-            data["volumetric_electricity_intensity"]["value"]
+        assert model.fs.unit.electricity_intensity_parameter.fixed
+        assert model.fs.unit.electricity_intensity_parameter.value == \
+            data["electricity_intensity_parameter"]["value"]
         assert model.fs.unit.activated_carbon_replacement.fixed
         assert model.fs.unit.activated_carbon_replacement.value == \
             data["activated_carbon_replacement"]["value"]
@@ -232,9 +232,9 @@ class TestGACZO_w_default_removal:
         assert model.fs.unit.empty_bed_contact_time.fixed
         assert model.fs.unit.empty_bed_contact_time.value == \
             data["empty_bed_contact_time"]["value"]/60  # min to hour
-        assert model.fs.unit.volumetric_electricity_intensity.fixed
-        assert model.fs.unit.volumetric_electricity_intensity.value == \
-            data["volumetric_electricity_intensity"]["value"]
+        assert model.fs.unit.electricity_intensity_parameter.fixed
+        assert model.fs.unit.electricity_intensity_parameter.value == \
+            data["electricity_intensity_parameter"]["value"]
 
     @pytest.mark.component
     def test_degrees_of_freedom(self, model):

--- a/watertap/unit_models/zero_order/tests/test_gac_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_gac_zo.py
@@ -357,7 +357,13 @@ class TestGACZOsubtype:
             assert v.value == data["removal_frac_mass_solute"][j]["value"]
 
 
-def test_costing():
+db = Database()
+params = db._get_technology("gac")
+
+
+@pytest.mark.component
+@pytest.mark.parametrize("subtype", [k for k in params.keys()])
+def test_costing(subtype):
     m = ConcreteModel()
     m.db = Database()
 
@@ -370,7 +376,8 @@ def test_costing():
 
     m.fs.unit1 = GACZO(default={
         "property_package": m.fs.params,
-        "database": m.db})
+        "database": m.db,
+        "process_subtype": subtype})
 
     m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
     m.fs.unit1.inlet.flow_mass_comp[0, "sulfur"].fix(1)


### PR DESCRIPTION
## Part of WT3 merger

## Summary/Motivation:


## Changes proposed in this PR:
- Rework GAC and fixed bed models to include electricity intensity calculations regressed from EPA data
- Add correlations for chemical demands in GAC and fixed beds
- Add capital cost methods for GAC and fixed bed units

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
