### PR TITLE
account for TPEC and TIC factor in surface discharge costing

### DIFF
--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -1068,6 +1068,9 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.config.process_subtype,
             ["capital_a_parameter", "capital_b_parameter", "pipe_cost_basis", "reference_state"])
 
+        # Determine if a costing factor is required
+        factor = parameter_dict["capital_cost"]["cost_factor"]
+
         # Add cost variable and constraint
         blk.capital_cost = pyo.Var(
             initialize=1,
@@ -1082,6 +1085,11 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             pyo.units.convert(
                 pipe_cost_basis * blk.unit_model.pipe_distance[t0] * blk.unit_model.pipe_diameter[t0],
                 to_units=blk.config.flowsheet_costing_block.base_currency))
+
+        if factor == "TPEC":
+            expr *= blk.config.flowsheet_costing_block.TPEC
+        elif factor == "TIC":
+            expr *= blk.config.flowsheet_costing_block.TIC
 
         blk.capital_cost_constraint = pyo.Constraint(
             expr=blk.capital_cost == expr)


### PR DESCRIPTION
## Fixes/Addresses:

I did not account for a TPEC or TIC factor in costing the surface discharge ZO model that I created in PR 459. Andrew told me that it should be included, which is the purpose of this PR.

## Changes proposed in this PR:
- Update `cost_surface_discharge` method to account for TPEC and TIC factors.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
