### PR TITLE
Warnings in pytest: remove ignore flag, fix deprecations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
-addopts = -W ignore
-          --durations=100
+addopts = --durations=100
           --cov=watertap
           --cov-config=.coveragerc
 testpaths = watertap

--- a/watertap/conftest.py
+++ b/watertap/conftest.py
@@ -14,6 +14,7 @@ class MarkerSpec(enum.Enum):
     component = "Quick tests that may require a solver"
     integration = "Long duration tests"
     build = "FIXME for building stuff?"
+    solver = "Tests that require a solver"
     requires_idaes_solver = "Tests that require a solver from the IDEAS extensions to pass"
 
     @property

--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -372,7 +372,7 @@ def _create_local_output_skeleton(model, sweep_params, outputs, num_samples):
 def _create_component_output_skeleton(component, num_samples):
 
     comp_dict = {}
-    comp_dict["value"] = np.zeros(num_samples, dtype=np.float)
+    comp_dict["value"] = np.zeros(num_samples, dtype=np.float64)
     if hasattr(component, 'lb'):
         comp_dict["lower bound"] = component.lb
     if hasattr(component, 'ub'):
@@ -428,7 +428,7 @@ def _create_global_output(local_output_dict, req_num_samples, comm, rank, num_pr
             for key, item in global_output_dict.items():
                 if key != "solve_successful":
                     for subkey, subitem in item.items():
-                        subitem['value'] = np.zeros(num_total_samples, dtype=np.float)
+                        subitem['value'] = np.zeros(num_total_samples, dtype=np.float64)
 
         else:
             global_output_dict = local_output_dict

--- a/watertap/tools/parameter_sweep_input_parser.py
+++ b/watertap/tools/parameter_sweep_input_parser.py
@@ -165,10 +165,10 @@ def set_defaults_from_yaml(m, yaml_filename, verbose=False):
             if component.mutable:
                 _set_value(component, key, default_value)
             else:
-                _log.warn(f"Cannot set value of non-mutable Param {component}")
+                _log.warning(f"Cannot set value of non-mutable Param {component}")
                 fail_count += 1
         else:
-            _log.warn(f"Cannot set value of component {component}")
+            _log.warning(f"Cannot set value of component {component}")
             fail_count += 1
 
     number_defaults = len(input_dict)

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -373,7 +373,7 @@ class ReverseOsmosisData(_ReverseOsmosisBaseData):
             res = opt.solve(blk, tee=slc.tee)
             # occasionally it might be worth retrying a solve
             if not check_optimal_termination(res):
-                init_log.warn("Trouble solving ReverseOsmosis0D unit model, trying one more time")
+                init_log.warning("Trouble solving ReverseOsmosis0D unit model, trying one more time")
                 res = opt.solve(blk, tee=slc.tee)
         check_solve(res, checkpoint='Initialization Step 3', logger=init_log, fail_flag=fail_on_warning)
         # ---------------------------------------------------------------------

--- a/watertap/unit_models/reverse_osmosis_1D.py
+++ b/watertap/unit_models/reverse_osmosis_1D.py
@@ -418,7 +418,7 @@ class ReverseOsmosis1DData(_ReverseOsmosisBaseData):
             res = opt.solve(blk, tee=slc.tee)
             # occasionally it might be worth retrying a solve
             if not check_optimal_termination(res):
-                init_log.warn("Trouble solving ReverseOsmosis1D unit model, trying one more time")
+                init_log.warning("Trouble solving ReverseOsmosis1D unit model, trying one more time")
                 res = opt.solve(blk, tee=slc.tee)
         check_solve(res, logger=init_log, fail_flag=fail_on_warning, checkpoint='Initialization Step 3')
         # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary/Motivation:

- We want to be aware if/when new warnings appear

## Changes proposed in this PR:
- Remove `-W ignore` flag in `pytest.ini`
- Apply some easy fixes to remove deprecation warnings:
  - `Logger.warn()` -> `Logger.warning()`
  - `np.float` -> `np.float64`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
