### PR TITLE
Adding check for no active constraints in zero-order PT initialization

### DIFF
--- a/watertap/core/zero_order_diso.py
+++ b/watertap/core/zero_order_diso.py
@@ -19,8 +19,10 @@ outlet where composition changes, such as a generic bioreactor).
 import idaes.logger as idaeslog
 from idaes.core.util import get_solver
 import idaes.core.util.scaling as iscale
+from idaes.core.util.exceptions import InitializationError
 
-from pyomo.environ import NonNegativeReals, Var, units as pyunits
+from pyomo.environ import (
+    check_optimal_termination, NonNegativeReals, Var, units as pyunits)
 
 # Some more information about this module
 __author__ = "Adam Atia"
@@ -205,6 +207,11 @@ def initialize_diso(blk, state_args=None, outlvl=idaeslog.NOTSET,
     init_log.info_high(
         "Initialization Step 2 {}.".format(idaeslog.condition(results))
     )
+
+    if not check_optimal_termination(results):
+        raise InitializationError(
+            f"{blk.name} failed to initialize successfully. Please check "
+            f"the output logs for more information.")
 
     # ---------------------------------------------------------------------
     # Release Inlet state

--- a/watertap/core/zero_order_properties.py
+++ b/watertap/core/zero_order_properties.py
@@ -195,7 +195,7 @@ class _WaterStateBlock(StateBlock):
             If hold_states is True, returns a dict containing flags for
             which states were fixed during initialization.
         '''
-        # For now, there are no ocnstraints in the property package, so only
+        # For now, there are no constraints in the property package, so only
         # fix state variables if required
         init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
 

--- a/watertap/core/zero_order_pt.py
+++ b/watertap/core/zero_order_pt.py
@@ -124,11 +124,6 @@ def initialize_pt(blk, state_args=None, outlvl=idaeslog.NOTSET,
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
             results = solver_obj.solve(blk, tee=slc.tee)
 
-        if not check_optimal_termination(results):
-            raise InitializationError(
-                f"{blk.name} failed to initialize successfully. Please check "
-                f"the output logs for more information.")
-
         init_log.info_high(
             "Initialization Step 2 {}.".format(idaeslog.condition(results))
         )
@@ -139,6 +134,12 @@ def initialize_pt(blk, state_args=None, outlvl=idaeslog.NOTSET,
 
     init_log.info('Initialization Complete: {}'
                   .format(idaeslog.condition(results)))
+
+    if (number_activated_constraints(blk) > 0 and
+            not check_optimal_termination(results)):
+        raise InitializationError(
+            f"{blk.name} failed to initialize successfully. Please check "
+            f"the output logs for more information.")
 
 
 def calculate_scaling_factors_pt(self):

--- a/watertap/core/zero_order_pt.py
+++ b/watertap/core/zero_order_pt.py
@@ -15,10 +15,12 @@ This module contains the methods for constructing the material balances for
 zero-order pass-through unit models (i.e. units with a single inlet and single
 outlet where flow and composition do not change, such as pumps).
 """
-from pyomo.environ import Var, units as pyunits
+from pyomo.environ import check_optimal_termination
 
 import idaes.logger as idaeslog
 from idaes.core.util import get_solver
+from idaes.core.util.model_statistics import number_activated_constraints
+from idaes.core.util.exceptions import InitializationError
 
 # Some more inforation about this module
 __author__ = "Andrew Lee"
@@ -118,12 +120,18 @@ def initialize_pt(blk, state_args=None, outlvl=idaeslog.NOTSET,
 
     # ---------------------------------------------------------------------
     # Solve unit
-    with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-        results = solver_obj.solve(blk, tee=slc.tee)
+    if number_activated_constraints(blk) > 0:
+        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+            results = solver_obj.solve(blk, tee=slc.tee)
 
-    init_log.info_high(
-        "Initialization Step 2 {}.".format(idaeslog.condition(results))
-    )
+        if not check_optimal_termination(results):
+            raise InitializationError(
+                f"{blk.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
+
+        init_log.info_high(
+            "Initialization Step 2 {}.".format(idaeslog.condition(results))
+        )
 
     # ---------------------------------------------------------------------
     # Release Inlet state

--- a/watertap/core/zero_order_sido.py
+++ b/watertap/core/zero_order_sido.py
@@ -18,8 +18,10 @@ zero-order single inlet-double outlet (SIDO) unit models.
 import idaes.logger as idaeslog
 from idaes.core.util import get_solver
 import idaes.core.util.scaling as iscale
+from idaes.core.util.exceptions import InitializationError
 
-from pyomo.environ import NonNegativeReals, Var, units as pyunits
+from pyomo.environ import (
+    check_optimal_termination, NonNegativeReals, Var, units as pyunits)
 
 # Some more inforation about this module
 __author__ = "Andrew Lee"
@@ -234,6 +236,11 @@ def initialize_sido(blk, state_args=None, outlvl=idaeslog.NOTSET,
 
     init_log.info('Initialization Complete: {}'
                   .format(idaeslog.condition(results)))
+
+    if not check_optimal_termination(results):
+        raise InitializationError(
+            f"{blk.name} failed to initialize successfully. Please check "
+            f"the output logs for more information.")
 
 
 def calculate_scaling_factors_sido(self):

--- a/watertap/core/zero_order_sido_reactive.py
+++ b/watertap/core/zero_order_sido_reactive.py
@@ -19,8 +19,10 @@ reactions.
 import idaes.logger as idaeslog
 from idaes.core.util import get_solver
 import idaes.core.util.scaling as iscale
+from idaes.core.util.exceptions import InitializationError
 
-from pyomo.environ import NonNegativeReals, Param, Set, Var, units as pyunits
+from pyomo.environ import (
+    check_optimal_termination, NonNegativeReals, Param, Set, Var, units as pyunits)
 
 # Some more inforation about this module
 __author__ = "Andrew Lee"
@@ -374,6 +376,11 @@ def initialize_sidor(blk, state_args=None, outlvl=idaeslog.NOTSET,
 
     init_log.info('Initialization Complete: {}'
                   .format(idaeslog.condition(results)))
+
+    if not check_optimal_termination(results):
+        raise InitializationError(
+            f"{blk.name} failed to initialize successfully. Please check "
+            f"the output logs for more information.")
 
 
 def calculate_scaling_factors_sidor(self):

--- a/watertap/core/zero_order_siso.py
+++ b/watertap/core/zero_order_siso.py
@@ -19,8 +19,10 @@ outlet where composition changes, such as a generic bioreactor).
 import idaes.logger as idaeslog
 from idaes.core.util import get_solver
 import idaes.core.util.scaling as iscale
+from idaes.core.util.exceptions import InitializationError
 
-from pyomo.environ import NonNegativeReals, Var, units as pyunits
+from pyomo.environ import (
+    check_optimal_termination, NonNegativeReals, Var, units as pyunits)
 
 # Some more information about this module
 __author__ = "Adam Atia"
@@ -201,6 +203,11 @@ def initialize_siso(blk, state_args=None, outlvl=idaeslog.NOTSET,
 
     init_log.info('Initialization Complete: {}'
                   .format(idaeslog.condition(results)))
+
+    if not check_optimal_termination(results):
+        raise InitializationError(
+            f"{blk.name} failed to initialize successfully. Please check "
+            f"the output logs for more information.")
 
 
 def calculate_scaling_factors_siso(self):


### PR DESCRIPTION
## Related to: #470 

## Summary/Motivation:
As part of trying to tack down the cause of #470, it was noted that there was the possibility of a pass-through unit having no active constraints which would cause a solver error when run.

Additionally, it was noted that none of the zero-order initialization methods raised `InitializationErrors` on a failed solve.

## Changes proposed in this PR:
- Add check for zero active constraints in pass-through initialization and skip final solve if this is the case.
- Add check for status of final solve in all zero-order initialization methods and raise `InitializationErrors` if not optimal.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
