### PR TITLE
Zero-order NF subtype for dye rejection

### DIFF
--- a/watertap/core/tests/test_zero_order_costing.py
+++ b/watertap/core/tests/test_zero_order_costing.py
@@ -188,7 +188,7 @@ class TestGeneralMethods:
 
     @pytest.mark.unit
     def test_get_tech_parameters_second_call(self, model):
-        # Use differnt parameter values- thes eshould be ignored
+        # Use different parameter values- these should be ignored
         parameters = {
             "capital_cost": {
                 "capital_a_parameter": {

--- a/watertap/core/wt_database.py
+++ b/watertap/core/wt_database.py
@@ -153,7 +153,7 @@ class Database:
             # Assume subtype is list-like and raise an exception if not
             try:
                 for s in subtype:
-                    # Iterate throguh provided subtypes and update parameters
+                    # Iterate through provided subtypes and update parameters
                     # Note that this will overwrite previous parameters if
                     # there is overlap, so we might need to be careful in use.
                     try:

--- a/watertap/core/zero_order_base.py
+++ b/watertap/core/zero_order_base.py
@@ -273,7 +273,7 @@ class ZeroOrderBaseData(UnitModelBlockData):
         var_dict = {}
 
         for k, v in self._perf_var_dict.items():
-            if k in ["Solute Removal", "Reaction Extent"]:
+            if k in ["Solute Removal", "Reaction Extent", "Rejection"]:
                 for j, vd in v[time_point, :].wildcard_items():
                     var_dict[f"{k} [{j}]"] = vd
             elif v.is_indexed():

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -25,7 +25,6 @@ from idaes.generic_models.costing.costing_base import (
     FlowsheetCostingBlockData, register_idaes_currency_units)
 
 from watertap.core.zero_order_base import ZeroOrderBase
-from watertap.costing.watertap_costing_package import cost_membrane
 from watertap.unit_models.zero_order import (
     BrineConcentratorZO,
     ChemicalAdditionZO,

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -1555,7 +1555,7 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             bounds=(0, None),
             doc="Capital cost of unit operation")
 
-        blk.fixed_operating_cost = pyo.Var(
+        blk.variable_operating_cost = pyo.Var(
             initialize=1,
             units=blk.config.flowsheet_costing_block.base_currency,
             bounds=(0, None),
@@ -1575,8 +1575,8 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         blk.capital_cost_constraint = \
             pyo.Constraint(expr=blk.capital_cost == capex_expr)
 
-        blk.fixed_operating_cost_constraint = \
-            pyo.Constraint(expr=blk.fixed_operating_cost ==
+        blk.variable_operating_cost_constraint = \
+            pyo.Constraint(expr=blk.variable_operating_cost ==
                                 pyo.units.convert(rep_rate
                                                   * mem_cost
                                                   * pyo.units.convert(
@@ -1778,8 +1778,8 @@ def _get_unit_cost_method(blk):
             subtype=blk.unit_model.config.process_subtype)
 
     if "cost_method" not in parameter_dict['capital_cost']:
-        raise KeyError("Add a cost_method as a sub-key under capital_cost "
-                        "in the unit YAML file.")
+        raise KeyError(f"Costing for {blk.unit_model._tech_type} requires a cost_method argument, however "
+                       f"this was not defined for process sub-type {blk.unit_model.config.process_subtype}.")
 
     return parameter_dict['capital_cost']['cost_method']
 

--- a/watertap/data/techno_economic/component_list.yaml
+++ b/watertap/data/techno_economic/component_list.yaml
@@ -30,6 +30,8 @@ cryptosporidium:
   constituent_longform: Cryptosporidium
 cyanide_as_free:
   constituent_longform: cyanide_as_free
+dye:
+  constituent_longform: Dye
 eeq:
   constituent_longform: Estradiol Equivalency (EEQ)
 electrical_conductivity:

--- a/watertap/data/techno_economic/nanofiltration.yaml
+++ b/watertap/data/techno_economic/nanofiltration.yaml
@@ -103,17 +103,8 @@ rHGO_dye_rejection:
   capital_cost:
     basis: flow_vol
     cost_factor: None
-    reference_state:
-      value: 4731.764235
-      units: m^3/hr
-    capital_a_parameter:
-      value: 75.0e6
-      units: USD_2014
-    capital_b_parameter:
-      value: 1.0
-      units: dimensionless
   recovery_frac_mass_H2O:
-    value: 0.85
+    value: 0.75
     units: dimensionless
   default_removal_frac_mass_solute:
     value: 0

--- a/watertap/data/techno_economic/nanofiltration.yaml
+++ b/watertap/data/techno_economic/nanofiltration.yaml
@@ -100,9 +100,17 @@ default:
       constituent_longform: Potassium
 
 rHGO_dye_rejection:
+  energy_electric_flow_vol_inlet:  # placeholder to pass test_unit_parameter_files, but not necessary for use
+    value: 0.231344952
+    units: kWh/m^3
   capital_cost:
-    basis: flow_vol
     cost_factor: None
+    membrane_cost:
+      value: 15
+      units: USD_2018/m^2
+    membrane_replacement_rate:
+      value: 0.15
+      units: dimensionless
   recovery_frac_mass_H2O:
     value: 0.75
     units: dimensionless

--- a/watertap/data/techno_economic/nanofiltration.yaml
+++ b/watertap/data/techno_economic/nanofiltration.yaml
@@ -98,3 +98,38 @@ default:
       value: 0.99
       units: dimensionless
       constituent_longform: Potassium
+
+rHGO_dye_rejection:
+  capital_cost:
+    basis: flow_vol
+    cost_factor: None
+    reference_state:
+      value: 4731.764235
+      units: m^3/hr
+    capital_a_parameter:
+      value: 75.0e6
+      units: USD_2014
+    capital_b_parameter:
+      value: 1.0
+      units: dimensionless
+  recovery_frac_mass_H2O:
+    value: 0.85
+    units: dimensionless
+  default_removal_frac_mass_solute:
+    value: 0
+    units: dimensionless
+  removal_frac_mass_solute:
+    dye:
+      value: 0.9839
+      units: dimensionless
+      constituent_longform: Dye
+    tds:
+      value: 0.2655
+      units: dimensionless
+      constituent_longform: Total Suspended Solids (TSS)
+  applied_pressure:
+    value: 6.895   # corresponds to default of 100 psi
+    units: bar
+  water_permeability_coefficient:
+    value: 100
+    units: liters/m^2/hour/bar

--- a/watertap/data/techno_economic/nanofiltration.yaml
+++ b/watertap/data/techno_economic/nanofiltration.yaml
@@ -3,6 +3,7 @@ default:
     value: 0.231344952
     units: kWh/m^3
   capital_cost:
+    cost_method: cost_power_law_flow
     basis: flow_vol
     cost_factor: None
     reference_state:
@@ -104,6 +105,7 @@ rHGO_dye_rejection:
     value: 0.231344952
     units: kWh/m^3
   capital_cost:
+    cost_method: cost_membrane
     cost_factor: None
     membrane_cost:
       value: 15

--- a/watertap/unit_models/zero_order/nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/nanofiltration_zo.py
@@ -16,11 +16,11 @@ operation.
 """
 
 from idaes.core import declare_process_block_class
-
-from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData
+from pyomo.environ  import Var, Constraint, units as pyunits
+from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData, pump_electricity
 
 # Some more information about this module
-__author__ = "Andrew Lee"
+__author__ = "Andrew Lee, Adam Atia"
 
 
 @declare_process_block_class("NanofiltrationZO")
@@ -37,4 +37,45 @@ class NanofiltrationZOData(ZeroOrderBaseData):
         self._tech_type = "nanofiltration"
 
         build_sido(self)
-        constant_intensity(self)
+
+        if self.config.process_subtype != "default":
+            constant_intensity(self)
+        else:
+            self.rejection_comp = Var(self.flowsheet().time,
+                                      self.config.property_package.config.solute_list,
+                                      units=pyunits.dimensionless,
+                                      doc="Component rejection")
+
+            self.water_permeability_coefficient = Var(self.flowsheet().time,
+                                                      units=pyunits.L/pyunits.m**2/pyunits.hour/pyunits.bar,
+                                                      doc="Membrane water permeability coefficient, A")
+
+            self.applied_pressure = Var(self.flowsheet().time,
+                                        units=pyunits.bar,
+                                        doc="Net driving pressure across membrane")
+
+            self.area = Var(units=pyunits.m**2,
+                            doc="Membrane area")
+
+            self._fixed_perf_vars.append(self.uv_reduced_equivalent_dose)
+            self._fixed_perf_vars.append(self.uv_transmittance_in)
+
+
+            @self.Constraint(self.flowsheet().time,
+                             doc="Water permeance constraint")
+            def water_permeance_constraint(b, t):
+                return (b.properties_treated.flow_vol[t] ==
+                        pyunits.convert(b.water_permeability_coefficient * b.area * b.applied_pressure[t],
+                                        to_units=pyunits.m**3/pyunits.s))
+
+            @self.Constraint(self.flowsheet().time,
+                             self.config.property_package.config.solute_list,
+                             doc="Solute [observed] rejection constraint")
+            def rejection_constraint(b, t, j):
+                return (b.rejection_comp[t, j] ==
+                        1 - b.properties_treated[t].conc_mass_comp[j] / b.properties_in[t].conc_mass_comp[j])
+
+            self._perf_var_dict["Membrane Area (m^2)"] = self.area
+            self._perf_var_dict["Net Driving Pressure (bar)"] = self.applied_pressure
+            self._perf_var_dict["Water Permeability Coefficient (LMH/bar)"] = self.water_permeability_coefficient
+            self._perf_var_dict[f"Rejection (-)"] = self.rejection_comp

--- a/watertap/unit_models/zero_order/nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/nanofiltration_zo.py
@@ -17,7 +17,7 @@ operation.
 
 from idaes.core import declare_process_block_class
 from pyomo.environ  import Var, Constraint, units as pyunits
-from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData, pump_electricity
+from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData
 
 # Some more information about this module
 __author__ = "Andrew Lee, Adam Atia"

--- a/watertap/unit_models/zero_order/nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/nanofiltration_zo.py
@@ -38,7 +38,7 @@ class NanofiltrationZOData(ZeroOrderBaseData):
 
         build_sido(self)
 
-        if self.config.process_subtype != "default":
+        if self.config.process_subtype == "default" or self.config.process_subtype is None:
             constant_intensity(self)
         else:
             self.rejection_comp = Var(self.flowsheet().time,
@@ -57,15 +57,15 @@ class NanofiltrationZOData(ZeroOrderBaseData):
             self.area = Var(units=pyunits.m**2,
                             doc="Membrane area")
 
-            self._fixed_perf_vars.append(self.uv_reduced_equivalent_dose)
-            self._fixed_perf_vars.append(self.uv_transmittance_in)
+            self._fixed_perf_vars.append(self.applied_pressure)
+            self._fixed_perf_vars.append(self.water_permeability_coefficient)
 
 
             @self.Constraint(self.flowsheet().time,
                              doc="Water permeance constraint")
             def water_permeance_constraint(b, t):
-                return (b.properties_treated.flow_vol[t] ==
-                        pyunits.convert(b.water_permeability_coefficient * b.area * b.applied_pressure[t],
+                return (b.properties_treated[t].flow_vol ==
+                        pyunits.convert(b.water_permeability_coefficient[t] * b.area * b.applied_pressure[t],
                                         to_units=pyunits.m**3/pyunits.s))
 
             @self.Constraint(self.flowsheet().time,
@@ -78,4 +78,4 @@ class NanofiltrationZOData(ZeroOrderBaseData):
             self._perf_var_dict["Membrane Area (m^2)"] = self.area
             self._perf_var_dict["Net Driving Pressure (bar)"] = self.applied_pressure
             self._perf_var_dict["Water Permeability Coefficient (LMH/bar)"] = self.water_permeability_coefficient
-            self._perf_var_dict[f"Rejection (-)"] = self.rejection_comp
+            self._perf_var_dict[f"Rejection"] = self.rejection_comp

--- a/watertap/unit_models/zero_order/pump_electricity_zo.py
+++ b/watertap/unit_models/zero_order/pump_electricity_zo.py
@@ -54,6 +54,12 @@ class PumpElectricityZOData(ZeroOrderBaseData):
             bounds=(0, None),
             doc="Electricity for low pressure pump")
 
+        self.applied_pressure = Var(
+            self.flowsheet().config.time,
+            units=pyunits.bar,
+            bounds=(0, None),
+            doc="Applied pressure")
+
         self._fixed_perf_vars.append(self.lift_height)
         self._fixed_perf_vars.append(self.eta_pump)
         self._fixed_perf_vars.append(self.eta_motor)
@@ -67,4 +73,13 @@ class PumpElectricityZOData(ZeroOrderBaseData):
                 Constants.acceleration_gravity / (b.eta_pump * b.eta_motor),
                 to_units=pyunits.kW)
 
+        @self.Constraint(self.flowsheet().time,
+                         doc='Constraint for pump applied pressure')
+        def applied_pressure_constraint(b, t):
+            return b.applied_pressure[t] == pyunits.convert(
+                b.lift_height * b.properties[t].dens_mass *
+                Constants.acceleration_gravity,
+                to_units=pyunits.bar)
+
         self._perf_var_dict["Electricity (kW)"] = self.electricity
+        self._perf_var_dict["Applied Pressure (bar)"] = self.applied_pressure

--- a/watertap/unit_models/zero_order/pump_zo.py
+++ b/watertap/unit_models/zero_order/pump_zo.py
@@ -19,7 +19,7 @@ from idaes.core import declare_process_block_class
 
 from watertap.core import build_pt, constant_intensity, ZeroOrderBaseData
 
-# Some more inforation about this module
+# Some more information about this module
 __author__ = "Andrew Lee"
 
 

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -511,6 +511,9 @@ def test_costing_non_default_subtype():
     assert isinstance(m.fs.unit1.costing.capital_cost_constraint,
                       Constraint)
     assert isinstance(m.fs.costing.nanofiltration, Block)
+    assert isinstance(m.fs.unit1.costing.fixed_operating_cost, Var)
+    assert isinstance(m.fs.unit1.costing.fixed_operating_cost_constraint,
+                      Constraint)
 
     assert_units_consistent(m.fs)
     assert degrees_of_freedom(m.fs.unit1) == 0

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -30,7 +30,6 @@ from watertap.unit_models.zero_order import NanofiltrationZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
 from watertap.core.zero_order_costing import ZeroOrderCosting
-from watertap.costing.watertap_costing_package import cost_membrane
 
 solver = get_solver()
 

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -508,8 +508,8 @@ def test_costing_non_default_subtype():
     assert isinstance(m.fs.unit.costing.capital_cost_constraint,
                       Constraint)
     assert isinstance(m.fs.costing.nanofiltration, Block)
-    assert isinstance(m.fs.unit.costing.fixed_operating_cost, Var)
-    assert isinstance(m.fs.unit.costing.fixed_operating_cost_constraint,
+    assert isinstance(m.fs.unit.costing.variable_operating_cost, Var)
+    assert isinstance(m.fs.unit.costing.variable_operating_cost_constraint,
                       Constraint)
 
     assert_units_consistent(m.fs)
@@ -524,4 +524,4 @@ def test_costing_non_default_subtype():
 
     assert pytest.approx(39162.813807, rel=1e-5) == value(m.fs.unit.area)
     assert pytest.approx(0.58744, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
-    assert pytest.approx(0.088116, rel=1e-5) == value(m.fs.unit.costing.fixed_operating_cost)
+    assert pytest.approx(0.088116, rel=1e-5) == value(m.fs.unit.costing.variable_operating_cost)

--- a/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
@@ -61,8 +61,10 @@ class TestPumpElectricityZO:
         assert isinstance(model.fs.unit.electricity, Var)
         assert isinstance(model.fs.unit.electricity_consumption, Constraint)
         assert isinstance(model.fs.unit.lift_height, Var)
+        assert isinstance(model.fs.unit.applied_pressure, Var)
         assert isinstance(model.fs.unit.eta_pump, Var)
         assert isinstance(model.fs.unit.eta_motor, Var)
+        assert isinstance(model.fs.unit.applied_pressure_constraint, Constraint)
 
     @pytest.mark.component
     def test_load_parameters(self, model):
@@ -130,8 +132,9 @@ Unit : fs.unit                                                             Time:
 
     Variables: 
 
-    Key              : Value  : Fixed : Bounds
-    Electricity (kW) : 22.134 : False : (0, None)
+    Key                    : Value  : Fixed : Bounds
+    Applied Pressure (bar) : 2.9881 : False : (0, None)
+          Electricity (kW) : 22.134 : False : (0, None)
 
 ------------------------------------------------------------------------------------
     Stream Table


### PR DESCRIPTION
## Fixes/Addresses:
## Summary/Motivation:
This NF subtype incorporates the water flux equation to compute membrane area, as well as rejection rates of solutes.

## Changes proposed in this PR:
- add NF subtype with costing
- add tests
- add variable to pump_electricity for applied pressure, matching the var name in the NF subtype

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
