### PR TITLE
Add tools for Black formatting: CI check for PRs, pre-commit hook

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,11 +20,11 @@ env:
   PYTEST_ADDOPTS: "--color=yes"
 
 jobs:
+
   code-formatting:
     name: Check code is formatted (Black)
     # OS and/or Python version don't make a difference, so we choose ubuntu and 3.8 as defaults
     runs-on: ubuntu-latest
-    if: 'false'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -39,7 +39,8 @@ jobs:
           pip --no-cache-dir install --progress-bar off "$black_requirement"
       - name: Run Black to verify that the committed code is formatted
         run: |
-          black --check
+          black --check .
+
   tests:
     name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,26 @@ env:
   PYTEST_ADDOPTS: "--color=yes"
 
 jobs:
+  code-formatting:
+    name: Check code is formatted (Black)
+    # OS and/or Python version don't make a difference, so we choose ubuntu and 3.8 as defaults
+    runs-on: ubuntu-latest
+    if: 'false'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install Black
+        # unlike the other jobs, we don't need to install WaterTAP and/or all the dev dependencies,
+        # but we still want to specify the Black version to use in requirements-dev.txt for local development
+        # so we extract the relevant line and pass it to a simple `pip install`
+        run: |
+          black_requirement="$(grep '^black==' requirements-dev.txt)"
+          pip --no-cache-dir install --progress-bar off "$black_requirement"
+      - name: Run Black to verify that the committed code is formatted
+        run: |
+          black --check
   tests:
     name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+      language_version: python3.8
+      types:
+        - python

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = "2021, NAWI"
 author = "NAWI"
 
 # The full version, including alpha/beta/rc tags
-release = "0.4.0dev"
+release = "0.5.0dev"
 # The short X.Y version
-version = "0.4.0dev"
+version = "0.5.0dev"
 # -- General configuration ---------------------------------------------------
 
 

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -224,6 +224,15 @@ If you plan to contribute to WaterTAP's codebase, choose this option.
 
 #. If needed, follow the steps described in the ":ref:`install-idaes-ext`" section above to install solvers distributed through IDAES Extensions.
 
+#. (Optional but recommended) `Pre-commit hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`_ are scripts that are automatically run by Git "client-side" (i.e. on a developer's local machine)
+   whenever `git commit` is run.
+   WaterTAP uses the `pre-commit <https://pre-commit.com/>`_ framework to manage a few hooks that are useful for WaterTAP developers.
+   To install the WaterTAP pre-commit hooks, run:
+
+   .. code-block:: shell
+
+       pre-commit install
+
 #. To verify that the installation was successful, try running the WaterTAP test suite using ``pytest``:
 
 	.. code-block:: shell

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
+black==22.3.0
 # Defer to setup.py contents
 -e .[dev]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==22.3.0
+pre-commit
 # Defer to setup.py contents
 -e .[dev]

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ SPECIAL_DEPENDENCIES_FOR_PRERELEASE = [
 setup(
     name="watertap",
     url="https://github.com/watertap-org/watertap",
-    version="0.4.0dev",
+    version="0.5.0dev",
     description="WaterTAP modeling library",
     long_description=long_description,
     long_description_content_type="text/plain",


### PR DESCRIPTION
## Summary/Motivation:

- Add tools to ensure code is properly formatted with Black before being merged into the repo

## Changes proposed in this PR:
- Add GHA job to run `black --check` that fails if the code would be changed by Black (which means that it hasn't been formatted with the right version of Black before being commited)
- Add `pre-commit` as a dev requirement to run Black automatically locally before committing

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
