### PR TITLE
fix parameter sweep issue in write_to_csv

### DIFF
--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -553,7 +553,6 @@ def _write_to_csv(
     global_results_arr,
     rank,
     write_csv,
-    dirname,
     fname,
     interpolate_nan_outputs,
 ):
@@ -568,7 +567,7 @@ def _write_to_csv(
 
         if write_csv and fname is not None:
             # Write the CSV
-            csv_results_file = os.path.join(str(dirname), fname + ".csv")
+            csv_results_file = fname + ".csv"
             np.savetxt(
                 csv_results_file,
                 global_save_data,
@@ -922,7 +921,6 @@ def _save_results(
         global_results_arr,
         rank,
         write_csv,
-        dirname,
         fname_no_ext,
         interpolate_nan_outputs,
     )


### PR DESCRIPTION
## Fixes/Addresses:
## Summary/Motivation:
Running multisweep for the full treatment train example no longer works, and the issue was an obstacle during efforts to bring in our AMO use case. A subtle mod is made in this PR to resolve the issue for the time being.

## Changes proposed in this PR:
- edit _write_to_csv in parameter_sweep to avoid conflict when directory name is in filename path provided

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
