### PR TITLE
Updating all naming conventions in ion_prop_pack

### DIFF
--- a/watertap/property_models/ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/ion_DSPMDE_prop_pack.py
@@ -175,11 +175,11 @@ class DSPMDEParameterData(PhysicalParameterBlock):
         for j in self.config.solute_list:
             if j in self.config.charge:
                 if self.config.charge[j] > 0:
-                    # # TODO: Figure out why IDAES won't allow this 
-                    #self.add_component(str(j), Cation())
+                    # # TODO: Figure out why IDAES won't allow this
+                    # self.add_component(str(j), Cation())
                     self.add_component(str(j), Solute())
                 elif self.config.charge[j] < 0:
-                    #self.add_component(str(j), Anion())
+                    # self.add_component(str(j), Anion())
                     self.add_component(str(j), Solute())
                 else:
                     self.add_component(str(j), Solute())

--- a/watertap/property_models/ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/ion_DSPMDE_prop_pack.py
@@ -49,8 +49,8 @@ from idaes.core import (
     StateBlock,
     MaterialBalanceType,
 )
-from idaes.core.components import Component, Solute, Solvent
-from idaes.core.phases import LiquidPhase
+from idaes.core.components import Component, Solute, Solvent, Cation, Anion
+from idaes.core.phases import LiquidPhase, AqueousPhase
 from idaes.core.util.constants import Constants
 from idaes.core.util.initialization import (
     fix_state_vars,
@@ -166,14 +166,25 @@ class DSPMDEParameterData(PhysicalParameterBlock):
 
         self._state_block_class = DSPMDEStateBlock
 
+        # phases
+        self.Liq = AqueousPhase()
+
         # components
         self.H2O = Solvent()
 
         for j in self.config.solute_list:
-            self.add_component(str(j), Solute())
-
-        # phases
-        self.Liq = LiquidPhase()
+            if j in self.config.charge:
+                if self.config.charge[j] > 0:
+                    # # TODO: Figure out why IDAES won't allow this 
+                    #self.add_component(str(j), Cation())
+                    self.add_component(str(j), Solute())
+                elif self.config.charge[j] < 0:
+                    #self.add_component(str(j), Anion())
+                    self.add_component(str(j), Solute())
+                else:
+                    self.add_component(str(j), Solute())
+            else:
+                self.add_component(str(j), Solute())
 
         # reference
         # Todo: enter any relevant references

--- a/watertap/property_models/ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/ion_DSPMDE_prop_pack.py
@@ -186,13 +186,25 @@ class DSPMDEParameterData(PhysicalParameterBlock):
             if j in self.config.charge:
                 if self.config.charge[j] > 0:
                     self.add_component(
-                        str(j), Cation(default={"charge": 1, "_electrolyte": True})
+                        str(j),
+                        Cation(
+                            default={
+                                "charge": self.config.charge[j],
+                                "_electrolyte": True,
+                            }
+                        ),
                     )
                     self.component_list.add(str(j))
                     self.ion_set.add(str(j))
                 elif self.config.charge[j] < 0:
                     self.add_component(
-                        str(j), Anion(default={"charge": -1, "_electrolyte": True})
+                        str(j),
+                        Anion(
+                            default={
+                                "charge": self.config.charge[j],
+                                "_electrolyte": True,
+                            }
+                        ),
                     )
                     self.component_list.add(str(j))
                     self.ion_set.add(str(j))

--- a/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
@@ -25,6 +25,7 @@ from idaes.core import (
     FlowsheetBlock,
     MaterialFlowBasis,
     MaterialBalanceType,
+    AqueousPhase,
 )
 from idaes.core.util.scaling import calculate_scaling_factors, get_scaling_factor
 
@@ -44,6 +45,20 @@ from idaes.core.util.scaling import (
 )
 from watertap.property_models.tests.property_test_harness import PropertyAttributeError
 from idaes.core.util import get_solver
+
+# Imports from idaes core
+from idaes.core.components import Solvent, Solute, Cation, Anion
+from idaes.core.phases import PhaseType as PT
+
+# Imports from idaes generic models
+from idaes.generic_models.properties.core.pure.ConstantProperties import Constant
+from idaes.generic_models.properties.core.state_definitions import FpcTP
+from idaes.generic_models.properties.core.eos.ideal import Ideal
+
+# Import the idaes objects for Generic Properties
+from idaes.generic_models.properties.core.generic.generic_property import (
+    GenericParameterBlock,
+)
 
 solver = get_solver()
 # -----------------------------------------------------------------------------
@@ -832,3 +847,239 @@ def test_assert_electroneutrality_get_property():
         stream[0].assert_electroneutrality(
             defined_state=False, adjust_by_ion="Cl_-", tol=1e-18
         )
+
+
+@pytest.fixture(scope="module")
+def model4():
+    m4 = ConcreteModel()
+
+    m4.fs = FlowsheetBlock(default={"dynamic": False})
+    m4.fs.properties = DSPMDEParameterBlock(
+        default={
+            "solute_list": ["A", "B", "C", "D", "E"],
+            "diffusivity_data": {
+                ("Liq", "A"): 1e-9,
+                ("Liq", "B"): 1e-10,
+                ("Liq", "C"): 1e-7,
+                ("Liq", "D"): 1e-11,
+                ("Liq", "E"): 1e-11,
+            },
+            "mw_data": {
+                "H2O": 18e-3,
+                "A": 10e-3,
+                "B": 25e-3,
+                "C": 100e-3,
+                "D": 25e-3,
+                "E": 25e-3,
+            },
+            "stokes_radius_data": {
+                "A": 1e-9,
+                "B": 1e-9,
+                "C": 1e-9,
+                "D": 1e-10,
+                "E": 1e-10,
+            },
+            "charge": {"A": 1, "B": -2, "C": 2, "D": -1, "E": 0},
+        }
+    )
+
+    # config
+    thermo_config = {
+        "components": {
+            "H2O": {
+                "type": Solvent,
+                "valid_phase_types": PT.aqueousPhase,
+                "dens_mol_liq_comp": Constant,
+                "enth_mol_liq_comp": Constant,
+                "cp_mol_liq_comp": Constant,
+                "entr_mol_liq_comp": Constant,
+                # Parameter data is always associated with the methods defined above
+                "parameter_data": {
+                    "mw": (18.0153, pyunits.g / pyunits.mol),
+                    "dens_mol_liq_comp_coeff": (55.2, pyunits.kmol * pyunits.m**-3),
+                    "cp_mol_liq_comp_coeff": (
+                        75.312,
+                        pyunits.J / pyunits.mol / pyunits.K,
+                    ),
+                    "enth_mol_form_liq_comp_ref": (0, pyunits.kJ / pyunits.mol),
+                    "entr_mol_form_liq_comp_ref": (
+                        0,
+                        pyunits.J / pyunits.K / pyunits.mol,
+                    ),
+                },
+                # End parameter_data
+            },
+            "A": {
+                "type": Cation,
+                "charge": 1,
+                "dens_mol_liq_comp": Constant,
+                "enth_mol_liq_comp": Constant,
+                "cp_mol_liq_comp": Constant,
+                "entr_mol_liq_comp": Constant,
+                "parameter_data": {
+                    "mw": (10, pyunits.g / pyunits.mol),
+                    "dens_mol_liq_comp_coeff": (55.2, pyunits.kmol * pyunits.m**-3),
+                    "cp_mol_liq_comp_coeff": (
+                        75.312,
+                        pyunits.J / pyunits.mol / pyunits.K,
+                    ),
+                    "enth_mol_form_liq_comp_ref": (0, pyunits.kJ / pyunits.mol),
+                    "entr_mol_form_liq_comp_ref": (
+                        0,
+                        pyunits.J / pyunits.K / pyunits.mol,
+                    ),
+                },
+            },
+            "B": {
+                "type": Anion,
+                "charge": -2,
+                "dens_mol_liq_comp": Constant,
+                "enth_mol_liq_comp": Constant,
+                "cp_mol_liq_comp": Constant,
+                "entr_mol_liq_comp": Constant,
+                "parameter_data": {
+                    "mw": (25, pyunits.g / pyunits.mol),
+                    "dens_mol_liq_comp_coeff": (55.2, pyunits.kmol * pyunits.m**-3),
+                    "cp_mol_liq_comp_coeff": (
+                        75.312,
+                        pyunits.J / pyunits.mol / pyunits.K,
+                    ),
+                    "enth_mol_form_liq_comp_ref": (0, pyunits.kJ / pyunits.mol),
+                    "entr_mol_form_liq_comp_ref": (
+                        0,
+                        pyunits.J / pyunits.K / pyunits.mol,
+                    ),
+                },
+            },
+            "C": {
+                "type": Cation,
+                "charge": 2,
+                "dens_mol_liq_comp": Constant,
+                "enth_mol_liq_comp": Constant,
+                "cp_mol_liq_comp": Constant,
+                "entr_mol_liq_comp": Constant,
+                "parameter_data": {
+                    "mw": (100, pyunits.g / pyunits.mol),
+                    "dens_mol_liq_comp_coeff": (55.2, pyunits.kmol * pyunits.m**-3),
+                    "cp_mol_liq_comp_coeff": (
+                        75.312,
+                        pyunits.J / pyunits.mol / pyunits.K,
+                    ),
+                    "enth_mol_form_liq_comp_ref": (0, pyunits.kJ / pyunits.mol),
+                    "entr_mol_form_liq_comp_ref": (
+                        0,
+                        pyunits.J / pyunits.K / pyunits.mol,
+                    ),
+                },
+            },
+            "D": {
+                "type": Anion,
+                "charge": -1,
+                "dens_mol_liq_comp": Constant,
+                "enth_mol_liq_comp": Constant,
+                "cp_mol_liq_comp": Constant,
+                "entr_mol_liq_comp": Constant,
+                "parameter_data": {
+                    "mw": (25, pyunits.g / pyunits.mol),
+                    "dens_mol_liq_comp_coeff": (55.2, pyunits.kmol * pyunits.m**-3),
+                    "cp_mol_liq_comp_coeff": (
+                        75.312,
+                        pyunits.J / pyunits.mol / pyunits.K,
+                    ),
+                    "enth_mol_form_liq_comp_ref": (0, pyunits.kJ / pyunits.mol),
+                    "entr_mol_form_liq_comp_ref": (
+                        0,
+                        pyunits.J / pyunits.K / pyunits.mol,
+                    ),
+                },
+            },
+            "E": {
+                "type": Solute,
+                "valid_phase_types": PT.aqueousPhase,
+                "dens_mol_liq_comp": Constant,
+                "enth_mol_liq_comp": Constant,
+                "cp_mol_liq_comp": Constant,
+                "entr_mol_liq_comp": Constant,
+                "parameter_data": {
+                    "mw": (25, pyunits.g / pyunits.mol),
+                    "dens_mol_liq_comp_coeff": (55.2, pyunits.kmol * pyunits.m**-3),
+                    "cp_mol_liq_comp_coeff": (
+                        75.312,
+                        pyunits.J / pyunits.mol / pyunits.K,
+                    ),
+                    "enth_mol_form_liq_comp_ref": (0, pyunits.kJ / pyunits.mol),
+                    "entr_mol_form_liq_comp_ref": (
+                        0,
+                        pyunits.J / pyunits.K / pyunits.mol,
+                    ),
+                },
+            },
+        },
+        # End Component list
+        "phases": {
+            "Liq": {"type": AqueousPhase, "equation_of_state": Ideal},
+        },
+        "state_definition": FpcTP,
+        "state_bounds": {
+            "temperature": (273.15, 300, 650),
+            "pressure": (5e4, 1e5, 1e6),
+        },
+        "pressure_ref": 1e5,
+        "temperature_ref": 300,
+        "base_units": {
+            "time": pyunits.s,
+            "length": pyunits.m,
+            "mass": pyunits.kg,
+            "amount": pyunits.mol,
+            "temperature": pyunits.K,
+        },
+    }
+    # End thermo_config definition
+
+    m5 = ConcreteModel()
+    m5.fs = FlowsheetBlock(default={"dynamic": False})
+    m5.fs.properties = GenericParameterBlock(default=thermo_config)
+
+    return (m4, m5)
+
+
+@pytest.mark.unit
+def test_parameter_block_comparison(model4):
+    m_ion = model4[0]
+    m_generic = model4[1]
+
+    assert isinstance(m_ion.fs.properties.component_list, Set)
+    assert isinstance(m_generic.fs.properties.component_list, Set)
+    assert len(m_ion.fs.properties.component_list) == len(
+        m_generic.fs.properties.component_list
+    )
+    for j in m_ion.fs.properties.component_list:
+        assert j in ["H2O", "A", "B", "C", "D", "E"]
+
+    assert isinstance(m_ion.fs.properties.cation_set, Set)
+    assert isinstance(m_generic.fs.properties.cation_set, Set)
+    assert len(m_ion.fs.properties.cation_set) == len(
+        m_generic.fs.properties.cation_set
+    )
+    for j in m_ion.fs.properties.cation_set:
+        assert j in ["A", "C"]
+
+    assert isinstance(m_ion.fs.properties.anion_set, Set)
+    assert isinstance(m_generic.fs.properties.anion_set, Set)
+    assert len(m_ion.fs.properties.anion_set) == len(m_generic.fs.properties.anion_set)
+    for j in m_ion.fs.properties.anion_set:
+        assert j in ["B", "D"]
+
+    assert isinstance(m_ion.fs.properties.ion_set, Set)
+    assert isinstance(m_generic.fs.properties.ion_set, Set)
+    assert len(m_ion.fs.properties.ion_set) == len(m_generic.fs.properties.ion_set)
+    for j in m_ion.fs.properties.ion_set:
+        assert j in ["A", "B", "C", "D"]
+
+    assert isinstance(m_ion.fs.properties.solute_set, Set)
+    assert isinstance(m_generic.fs.properties.solute_set, Set)
+    assert len(m_ion.fs.properties.solute_set) == len(
+        m_generic.fs.properties.solute_set
+    )
+    for j in m_ion.fs.properties.solute_set:
+        assert j in ["E"]

--- a/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
@@ -134,7 +134,7 @@ def test_property_ions(model):
     m.fs.stream[0].flow_mass_phase_comp
 
     m.fs.stream[0].molality_comp
-    m.fs.stream[0].pressure_osm
+    m.fs.stream[0].pressure_osm_phase
     m.fs.stream[0].dens_mass_phase
     m.fs.stream[0].conc_mol_phase_comp
     m.fs.stream[0].act_coeff_phase_comp
@@ -161,7 +161,7 @@ def test_property_ions(model):
         2.2829e-2, rel=1e-3
     )
 
-    assert value(m.fs.stream[0].pressure_osm) == pytest.approx(60.546e5, rel=1e-3)
+    assert value(m.fs.stream[0].pressure_osm_phase["Liq"]) == pytest.approx(60.546e5, rel=1e-3)
 
     assert value(m.fs.stream[0].dens_mass_phase["Liq"]) == pytest.approx(
         1001.76, rel=1e-3
@@ -226,7 +226,7 @@ def test_property_ions(model2):
     stream[0].flow_mass_phase_comp
 
     stream[0].molality_comp
-    stream[0].pressure_osm
+    stream[0].pressure_osm_phase
     stream[0].dens_mass_phase
     stream[0].conc_mol_phase_comp
     stream[0].flow_vol
@@ -307,7 +307,7 @@ def test_build(model3):
         "flow_mass_phase_comp",
         "mole_frac_phase_comp",
         "molality_comp",
-        "pressure_osm",
+        "pressure_osm_phase",
         "act_coeff_phase_comp",
     ]
 
@@ -525,7 +525,7 @@ def test_seawater_data():
     )
 
     assert value(stream[0].dens_mass_phase["Liq"]) == pytest.approx(1023.816, rel=1e-3)
-    assert value(stream[0].pressure_osm) == pytest.approx(29.132e5, rel=1e-3)
+    assert value(stream[0].pressure_osm_phase["Liq"]) == pytest.approx(29.132e5, rel=1e-3)
     assert value(stream[0].flow_vol) == pytest.approx(9.767e-4, rel=1e-3)
 
     assert value(
@@ -687,16 +687,16 @@ def test_assert_electroneutrality_get_property():
     stream[0].temperature.fix(298.15)
     stream[0].pressure.fix(101325)
 
-    assert not stream[0].is_property_constructed("pressure_osm")
+    assert not stream[0].is_property_constructed("pressure_osm_phase")
     assert not stream[0].is_property_constructed("mass_frac_phase_comp")
 
     stream[0].assert_electroneutrality(
         defined_state=True,
         adjust_by_ion="Cl_-",
-        get_property=["mass_frac_phase_comp", "pressure_osm"],
+        get_property=["mass_frac_phase_comp", "pressure_osm_phase"],
     )
     assert stream[0].is_property_constructed("mass_frac_phase_comp")
-    assert stream[0].is_property_constructed("pressure_osm")
+    assert stream[0].is_property_constructed("pressure_osm_phase")
     assert not hasattr(stream, "charge_balance")
 
     assert not stream[0].is_property_constructed("flow_vol")
@@ -774,7 +774,7 @@ def test_assert_electroneutrality_get_property():
     stream[0].assert_electroneutrality(
         defined_state=True,
         adjust_by_ion="Cl_-",
-        get_property=("mass_frac_phase_comp", "pressure_osm"),
+        get_property=("mass_frac_phase_comp", "pressure_osm_phase"),
     )
     # check error when adjust_by_ion is not in solute list
     with pytest.raises(

--- a/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
@@ -161,7 +161,9 @@ def test_property_ions(model):
         2.2829e-2, rel=1e-3
     )
 
-    assert value(m.fs.stream[0].pressure_osm_phase["Liq"]) == pytest.approx(60.546e5, rel=1e-3)
+    assert value(m.fs.stream[0].pressure_osm_phase["Liq"]) == pytest.approx(
+        60.546e5, rel=1e-3
+    )
 
     assert value(m.fs.stream[0].dens_mass_phase["Liq"]) == pytest.approx(
         1001.76, rel=1e-3
@@ -525,7 +527,9 @@ def test_seawater_data():
     )
 
     assert value(stream[0].dens_mass_phase["Liq"]) == pytest.approx(1023.816, rel=1e-3)
-    assert value(stream[0].pressure_osm_phase["Liq"]) == pytest.approx(29.132e5, rel=1e-3)
+    assert value(stream[0].pressure_osm_phase["Liq"]) == pytest.approx(
+        29.132e5, rel=1e-3
+    )
     assert value(stream[0].flow_vol) == pytest.approx(9.767e-4, rel=1e-3)
 
     assert value(

--- a/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
@@ -80,8 +80,8 @@ def test_parameter_block(model):
     assert isinstance(model.fs.properties.solvent_set, Set)
     for j in model.fs.properties.solvent_set:
         assert j in ["H2O"]
-    assert isinstance(model.fs.properties.solute_set, Set)
-    for j in model.fs.properties.solute_set:
+    assert isinstance(model.fs.properties.ion_set, Set)
+    for j in model.fs.properties.ion_set | model.fs.properties.solute_set:
         assert j in ["A", "B", "C", "D"]
 
     assert isinstance(model.fs.properties.phase_list, Set)
@@ -534,12 +534,14 @@ def test_seawater_data():
 
     assert value(
         sum(
-            stream[0].conc_mass_phase_comp["Liq", j] for j in m.fs.properties.solute_set
+            stream[0].conc_mass_phase_comp["Liq", j]
+            for j in m.fs.properties.ion_set | m.fs.properties.solute_set
         )
     ) == pytest.approx(35.9744, rel=1e-3)
     assert value(
         sum(
-            stream[0].mass_frac_phase_comp["Liq", j] for j in m.fs.properties.solute_set
+            stream[0].mass_frac_phase_comp["Liq", j]
+            for j in m.fs.properties.ion_set | m.fs.properties.solute_set
         )
     ) == pytest.approx(0.035142, rel=1e-3)
     assert value(

--- a/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
+++ b/watertap/property_models/tests/test_ion_DSPMDE_prop_pack.py
@@ -1083,3 +1083,10 @@ def test_parameter_block_comparison(model4):
     )
     for j in m_ion.fs.properties.solute_set:
         assert j in ["E"]
+
+    assert m_ion.fs.properties.charge_comp["B"].value == -2
+    # NOTE: Below is how you grab charge from the generic package
+    assert (
+        m_ion.fs.properties.charge_comp["B"].value
+        == m_generic.fs.properties.get_component("B").config.charge
+    )

--- a/watertap/unit_models/nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/nanofiltration_DSPMDE_0D.py
@@ -1804,15 +1804,8 @@ class NanofiltrationData(UnitModelBlockData):
             self.config.property_package, "solute_set"
         ):
             solute_set = self.config.property_package.ion_set
-        elif hasattr(self.config.property_package, "solute_set") and not hasattr(
-            self.config.property_package, "ion_set"
-        ):
-            solute_set = self.config.property_package.solute_set
         else:
-            raise ConfigurationError(
-                "This NF model was expecting an "
-                "ion_set or solute_set and did not receive either."
-            )
+            solute_set = self.config.property_package.solute_set
 
         # setting scaling factors for variables
         if iscale.get_scaling_factor(self.radius_pore) is None:

--- a/watertap/unit_models/nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/nanofiltration_DSPMDE_0D.py
@@ -200,7 +200,7 @@ class NanofiltrationData(UnitModelBlockData):
             :header: "Configuration Options", "Description"
 
             "``MassTransferCoefficient.fixed``", "Specify an estimated value for the mass transfer coefficient in the feed channel"
-            "``MassTransferCoefficient.spiral_wound``", "Allow model to perform calculation of mass transfer coefficient based on 
+            "``MassTransferCoefficient.spiral_wound``", "Allow model to perform calculation of mass transfer coefficient based on
             spiral wound module correlation"
         """,
         ),
@@ -745,7 +745,7 @@ class NanofiltrationData(UnitModelBlockData):
             return b.flux_vol_water[t, x] == (
                 prop_feed.pressure
                 - prop_perm.pressure
-                - (prop_feed_inter.pressure_osm - prop_perm.pressure_osm)
+                - (prop_feed_inter.pressure_osm_phase["Liq"] - prop_perm.pressure_osm_phase["Liq"])
             ) * (b.radius_pore**2) / (
                 8 * prop_feed.visc_d_phase[p] * b.membrane_thickness_effective
             )
@@ -1558,17 +1558,17 @@ class NanofiltrationData(UnitModelBlockData):
             ] = self.mixed_permeate[time_point].conc_mol_phase_comp["Liq", j]
 
             if self.feed_side.properties_in[time_point].is_property_constructed(
-                "pressure_osm"
+                "pressure_osm_phase"
             ):
                 var_dict[
                     f"Osmotic Pressure @ Bulk Feed, Inlet (Pa)"
-                ] = self.feed_side.properties_in[time_point].pressure_osm
+                ] = self.feed_side.properties_in[time_point].pressure_osm_phase["Liq"]
             if self.feed_side.properties_out[time_point].is_property_constructed(
-                "pressure_osm"
+                "pressure_osm_phase"
             ):
                 var_dict[
                     f"Osmotic Pressure @ Bulk Feed, Outlet (Pa)"
-                ] = self.feed_side.properties_out[time_point].pressure_osm
+                ] = self.feed_side.properties_out[time_point].pressure_osm_phase["Liq"]
 
             for x in self.io_list:
                 if not x:
@@ -1597,17 +1597,17 @@ class NanofiltrationData(UnitModelBlockData):
 
                 var_dict[
                     f"Osmotic Pressure @ Membrane Interface, {io} (Pa)"
-                ] = self.feed_side.properties_interface[time_point, x].pressure_osm
+                ] = self.feed_side.properties_interface[time_point, x].pressure_osm_phase["Liq"]
 
                 var_dict[
                     f"Osmotic Pressure @ Permeate, {io} (Pa)"
-                ] = self.permeate_side[time_point, x].pressure_osm
+                ] = self.permeate_side[time_point, x].pressure_osm_phase["Liq"]
                 expr_dict[f"Net Driving Pressure, {io} (Pa)"] = (
                     prop_feed.pressure
                     - self.permeate_side[0, x].pressure
                     - (
-                        self.feed_side.properties_interface[0, x].pressure_osm
-                        - self.permeate_side[0, x].pressure_osm
+                        self.feed_side.properties_interface[0, x].pressure_osm_phase["Liq"]
+                        - self.permeate_side[0, x].pressure_osm_phase["Liq"]
                     )
                 )
                 var_dict[

--- a/watertap/unit_models/nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/nanofiltration_DSPMDE_0D.py
@@ -245,6 +245,8 @@ class NanofiltrationData(UnitModelBlockData):
 
         self.io_list = io_list = Set(initialize=[0, 1])  # inlet/outlet set
 
+        # These two sets should always be present
+        #   and their union is the full set of dissolved species
         if hasattr(self.config.property_package, "ion_set") and hasattr(
             self.config.property_package, "solute_set"
         ):
@@ -252,18 +254,10 @@ class NanofiltrationData(UnitModelBlockData):
                 self.config.property_package.ion_set
                 | self.config.property_package.solute_set
             )
-        elif hasattr(self.config.property_package, "ion_set") and not hasattr(
-            self.config.property_package, "solute_set"
-        ):
-            solute_set = self.config.property_package.ion_set
-        elif hasattr(self.config.property_package, "solute_set") and not hasattr(
-            self.config.property_package, "ion_set"
-        ):
-            solute_set = self.config.property_package.solute_set
         else:
             raise ConfigurationError(
                 "This NF model was expecting an "
-                "ion_set or solute_set and did not receive either."
+                "ion_set and solute_set and did not them."
             )
 
         solvent_set = self.config.property_package.solvent_set
@@ -1793,19 +1787,10 @@ class NanofiltrationData(UnitModelBlockData):
     def calculate_scaling_factors(self):
         super().calculate_scaling_factors()
 
-        if hasattr(self.config.property_package, "ion_set") and hasattr(
-            self.config.property_package, "solute_set"
-        ):
-            solute_set = (
-                self.config.property_package.ion_set
-                | self.config.property_package.solute_set
-            )
-        elif hasattr(self.config.property_package, "ion_set") and not hasattr(
-            self.config.property_package, "solute_set"
-        ):
-            solute_set = self.config.property_package.ion_set
-        else:
-            solute_set = self.config.property_package.solute_set
+        solute_set = (
+            self.config.property_package.ion_set
+            | self.config.property_package.solute_set
+        )
 
         # setting scaling factors for variables
         if iscale.get_scaling_factor(self.radius_pore) is None:

--- a/watertap/unit_models/nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/nanofiltration_DSPMDE_0D.py
@@ -745,7 +745,10 @@ class NanofiltrationData(UnitModelBlockData):
             return b.flux_vol_water[t, x] == (
                 prop_feed.pressure
                 - prop_perm.pressure
-                - (prop_feed_inter.pressure_osm_phase["Liq"] - prop_perm.pressure_osm_phase["Liq"])
+                - (
+                    prop_feed_inter.pressure_osm_phase["Liq"]
+                    - prop_perm.pressure_osm_phase["Liq"]
+                )
             ) * (b.radius_pore**2) / (
                 8 * prop_feed.visc_d_phase[p] * b.membrane_thickness_effective
             )
@@ -1597,7 +1600,11 @@ class NanofiltrationData(UnitModelBlockData):
 
                 var_dict[
                     f"Osmotic Pressure @ Membrane Interface, {io} (Pa)"
-                ] = self.feed_side.properties_interface[time_point, x].pressure_osm_phase["Liq"]
+                ] = self.feed_side.properties_interface[
+                    time_point, x
+                ].pressure_osm_phase[
+                    "Liq"
+                ]
 
                 var_dict[
                     f"Osmotic Pressure @ Permeate, {io} (Pa)"
@@ -1606,7 +1613,9 @@ class NanofiltrationData(UnitModelBlockData):
                     prop_feed.pressure
                     - self.permeate_side[0, x].pressure
                     - (
-                        self.feed_side.properties_interface[0, x].pressure_osm_phase["Liq"]
+                        self.feed_side.properties_interface[0, x].pressure_osm_phase[
+                            "Liq"
+                        ]
                         - self.permeate_side[0, x].pressure_osm_phase["Liq"]
                     )
                 )

--- a/watertap/unit_models/tests/test_nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/tests/test_nanofiltration_DSPMDE_0D.py
@@ -68,6 +68,8 @@ solver = get_solver()
 def test_config():
     m = ConcreteModel()
     m.fs = FlowsheetBlock(default={"dynamic": False})
+    # NOTE: Not giving actual charges in order to test construction of
+    #   both the ion_set and solute_set
     m.fs.properties = DSPMDEParameterBlock(
         default={"solute_list": ["Ca_2+", "SO4_2-", "Na_+", "Cl_-", "Mg_2+"]}
     )


### PR DESCRIPTION
## Fixes/Addresses:

Partially addresses items in #464. Focus is on improving standardization of naming between the generic property package and the ion property package. Each now has the same and equivalent species 'Sets' and has the same names for osmotic pressure properties. 

## Summary/Motivation:


## Changes proposed in this PR:
- Update names of variables to match generic package standards
- Update lists of solutes to differentiate ions 
- Sets now follow same standardized naming as generic properties 
- Added unit tests to compare sets generated between generic and ion prop pack

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
