### PR TITLE
Costing flows in the WaterTAP costing package methods

### DIFF
--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -105,12 +105,6 @@ def build():
     m.fs.disposal = Product(default={"property_package": m.fs.properties})
 
     # costing
-    m.fs.costing.cost_flow(
-        pyunits.convert(m.fs.P1.work_mechanical[0], to_units=pyunits.kW), "electricity"
-    )
-    m.fs.costing.cost_flow(
-        pyunits.convert(m.fs.P2.work_mechanical[0], to_units=pyunits.kW), "electricity"
-    )
     m.fs.P1.costing = UnitModelCostingBlock(
         default={"flowsheet_costing_block": m.fs.costing}
     )

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
@@ -635,7 +635,10 @@ def add_costing(m):
     # RO Train
     # RO equipment is costed using more detailed costing package
     desal.P1.costing = UnitModelCostingBlock(
-        default={"flowsheet_costing_block": m.fs.ro_costing}
+        default={
+            "flowsheet_costing_block": m.fs.ro_costing,
+            "costing_method_arguments": {"cost_electricity_flow": False},
+        }
     )
     desal.RO.costing = UnitModelCostingBlock(
         default={"flowsheet_costing_block": m.fs.ro_costing}
@@ -650,7 +653,10 @@ def add_costing(m):
             default={"flowsheet_costing_block": m.fs.ro_costing}
         )
         desal.P2.costing = UnitModelCostingBlock(
-            default={"flowsheet_costing_block": m.fs.ro_costing}
+            default={
+                "flowsheet_costing_block": m.fs.ro_costing,
+                "costing_method_arguments": {"cost_electricity_flow": False},
+            }
         )
     elif m.erd_type == "pump_as_turbine":
         pass

--- a/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/costing.py
+++ b/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/costing.py
@@ -86,10 +86,6 @@ def build_costing(m, costing_package=WaterTAPCosting, **kwargs):
                 "costing_method_arguments": {"pump_type": PumpType.low_pressure},
             }
         )
-        m.fs.costing.cost_flow(
-            pyunits.convert(m.fs.pump_NF.work_mechanical[0], to_units=pyunits.kW),
-            "electricity",
-        )
 
     # Reverse Osmosis
     if hasattr(m.fs, "RO"):
@@ -121,10 +117,6 @@ def build_costing(m, costing_package=WaterTAPCosting, **kwargs):
                 "costing_method_arguments": {"pump_type": PumpType.high_pressure},
             }
         )
-        m.fs.costing.cost_flow(
-            pyunits.convert(m.fs.pump_RO.work_mechanical[0], to_units=pyunits.kW),
-            "electricity",
-        )
 
     # Stage 2 pump
     if hasattr(m.fs, "pump_RO2"):
@@ -133,10 +125,6 @@ def build_costing(m, costing_package=WaterTAPCosting, **kwargs):
                 "flowsheet_costing_block": m.fs.costing,
                 "costing_method_arguments": {"pump_type": PumpType.high_pressure},
             }
-        )
-        m.fs.costing.cost_flow(
-            pyunits.convert(m.fs.pump_RO2.work_mechanical[0], to_units=pyunits.kW),
-            "electricity",
         )
 
     # ERD
@@ -148,10 +136,6 @@ def build_costing(m, costing_package=WaterTAPCosting, **kwargs):
                     "energy_recovery_device_type": EnergyRecoveryDeviceType.pressure_exchanger
                 },
             }
-        )
-        m.fs.costing.cost_flow(
-            pyunits.convert(m.fs.ERD.work_mechanical[0], to_units=pyunits.kW),
-            "electricity",
         )
 
     # Pretreatment

--- a/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/costing.py
+++ b/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/costing.py
@@ -143,12 +143,11 @@ def build_costing(m, costing_package=WaterTAPCosting, **kwargs):
         m.fs.stoich_softening_mixer_unit.costing = UnitModelCostingBlock(
             default={
                 "flowsheet_costing_block": m.fs.costing,
-                "costing_method_arguments": {"mixer_type": MixerType.CaOH2},
+                "costing_method_arguments": {
+                    "mixer_type": MixerType.CaOH2,
+                    "dosing_rate": m.fs.stoich_softening_mixer_unit.dosing_rate,
+                },
             }
-        )
-        m.fs.costing.cost_flow(
-            m.fs.stoich_softening_mixer_unit.dosing_rate,
-            "CaOH2",
         )
 
     # Post-treatment
@@ -157,12 +156,11 @@ def build_costing(m, costing_package=WaterTAPCosting, **kwargs):
         m.fs.ideal_naocl_mixer_unit.costing = UnitModelCostingBlock(
             default={
                 "flowsheet_costing_block": m.fs.costing,
-                "costing_method_arguments": {"mixer_type": MixerType.NaOCl},
+                "costing_method_arguments": {
+                    "mixer_type": MixerType.NaOCl,
+                    "dosing_rate": m.fs.ideal_naocl_mixer_unit.dosing_rate,
+                },
             }
-        )
-        m.fs.costing.cost_flow(
-            m.fs.ideal_naocl_mixer_unit.dosing_rate,
-            "NaOCl",
         )
 
     if hasattr(m.fs, "mixer_permeate"):

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -109,9 +109,6 @@ def build(number_of_stages=2):
         pump.costing = UnitModelCostingBlock(
             default={"flowsheet_costing_block": m.fs.costing}
         )
-        m.fs.costing.cost_flow(
-            pyunits.convert(pump.work_mechanical[0], to_units=pyunits.kW), "electricity"
-        )
 
     # Add the equalizer pumps
     m.fs.BoosterPumps = Pump(
@@ -120,9 +117,6 @@ def build(number_of_stages=2):
     for pump in m.fs.BoosterPumps.values():
         pump.costing = UnitModelCostingBlock(
             default={"flowsheet_costing_block": m.fs.costing}
-        )
-        m.fs.costing.cost_flow(
-            pyunits.convert(pump.work_mechanical[0], to_units=pyunits.kW), "electricity"
         )
 
     # Add the stages ROs
@@ -149,12 +143,6 @@ def build(number_of_stages=2):
         default={
             "flowsheet_costing_block": m.fs.costing,
         }
-    )
-    m.fs.costing.cost_flow(
-        pyunits.convert(
-            m.fs.EnergyRecoveryDevice.work_mechanical[0], to_units=pyunits.kW
-        ),
-        "electricity",
     )
 
     # additional variables or expressions


### PR DESCRIPTION
## Fixes/Addresses:
Part of #402.

## Summary/Motivation:
The zero-order costing package also costs electricity and chemical flows in its methods. Generally speaking its a modeling error *not* to do this, so this PR would adopt the same convention for the WaterTAP costing package.

I am not certain this is what we should be doing. But given a lack of conventions for new-style IDAES costing packages it seems best to standardize within WaterTAP.

## Changes proposed in this PR:
- Cost flows in WaterTAP costing package methods
- Remove explicit flow costing from affected flowsheets.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
