### PR TITLE
Removing testing the output of the `report` method

### DIFF
--- a/watertap/core/tests/test_zero_order_base.py
+++ b/watertap/core/tests/test_zero_order_base.py
@@ -351,3 +351,89 @@ class TestZOBase:
                 index="D",
                 use_default_removal=True,
             )
+
+    @pytest.mark.unit
+    def test_get_performance_contents(self, model):
+        model.fs.params.phase_list = ["Liq"]
+        model.fs.params.solvent_set = ["H2O"]
+        model.fs.params.solute_set = ["A", "B", "C"]
+        model.fs.params.component_list = ["H2O", "A", "B", "C"]
+
+        model.fs.unit = DerivedZOBase(default={"property_package": model.fs.params})
+
+        model.fs.unit.removal_frac_mass_solute = Var(
+            model.fs.time, model.fs.params.solute_set
+        )
+
+        model.fs.unit.set_param_from_data(
+            model.fs.unit.removal_frac_mass_solute[0, "A"],
+            {
+                "removal_frac_mass_solute": {"A": {"value": 0.42, "units": "m^3/m^3"}},
+                "default_removal_frac_mass_solute": {"value": 0.70, "units": "kg/kg"},
+            },
+            index="D",
+            use_default_removal=True,
+        )
+
+        model.fs.unit._perf_var_dict[
+            "Solute Removal"
+        ] = model.fs.unit.removal_frac_mass_solute
+
+        model.fs.unit.time_indexed_performance_var = Var(
+            model.fs.time, doc="test variable"
+        )
+
+        model.fs.unit._perf_var_dict[
+            "Test Variable 1"
+        ] = model.fs.unit.time_indexed_performance_var
+
+        model.fs.unit.nonindexed_performance_var = Var(doc="test_variable")
+        model.fs.unit._perf_var_dict[
+            "Test Variable 2"
+        ] = model.fs.unit.nonindexed_performance_var
+
+        perf_dict = model.fs.unit._get_performance_contents()
+
+        expected = {
+            "vars": {
+                "Solute Removal [A]": model.fs.unit.removal_frac_mass_solute[0, "A"],
+                "Solute Removal [B]": model.fs.unit.removal_frac_mass_solute[0, "B"],
+                "Solute Removal [C]": model.fs.unit.removal_frac_mass_solute[0, "C"],
+                "Test Variable 1": model.fs.unit.time_indexed_performance_var[0],
+                "Test Variable 2": model.fs.unit.nonindexed_performance_var,
+            }
+        }
+
+        assert perf_dict == expected
+
+    @pytest.mark.unit
+    def test_get_stream_table_contents(self, model):
+        model.fs.params.phase_list = ["Liq"]
+        model.fs.params.solvent_set = ["H2O"]
+        model.fs.params.solute_set = ["A", "B", "C"]
+        model.fs.params.component_list = ["H2O", "A", "B", "C"]
+
+        model.fs.unit = DerivedZOBase(default={"property_package": model.fs.params})
+
+        model.fs.unit.port_properties = model.fs.params.build_state_block(
+            model.fs.time, doc="test"
+        )
+
+        model.fs.unit.add_port(
+            "test_port", model.fs.unit.port_properties, doc="test port"
+        )
+
+        model.fs.unit._stream_table_dict["test port"] = model.fs.unit.test_port
+        stable = model.fs.unit._get_stream_table_contents()
+
+        expected = {
+            "test port": {
+                "Mass Concentration A": pytest.approx(250.000, rel=1e-4),
+                "Mass Concentration B": pytest.approx(250.000, rel=1e-4),
+                "Mass Concentration C": pytest.approx(250.000, rel=1e-4),
+                "Mass Concentration H2O": pytest.approx(250.000, rel=1e-4),
+                "Volumetric Flowrate": pytest.approx(0.004, rel=1e-4),
+            }
+        }
+
+        assert stable.to_dict() == expected

--- a/watertap/core/tests/test_zero_order_diso.py
+++ b/watertap/core/tests/test_zero_order_diso.py
@@ -14,7 +14,6 @@
 Tests for zero-order DISO unit model
 """
 import pytest
-from io import StringIO
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -185,30 +184,4 @@ class TestDISO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value   : Fixed : Bounds
-    Solute Removal [A] : 0.10000 :  True : (0, None)
-    Solute Removal [B] : 0.20000 :  True : (0, None)
-    Solute Removal [C] : 0.30000 :  True : (0, None)
-        Water Recovery :  0.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                            Inlet 1  Inlet 2   Treated 
-    Volumetric Flowrate     1.0600   1.0600    0.092000
-    Mass Concentration H2O  943.40   943.40  1.0870e-12
-    Mass Concentration A    9.4340   9.4340      195.65
-    Mass Concentration B    18.868   18.868      347.83
-    Mass Concentration C    28.302   28.302      456.52
-====================================================================================
-"""
+        model.fs.unit.report()

--- a/watertap/core/tests/test_zero_order_diso.py
+++ b/watertap/core/tests/test_zero_order_diso.py
@@ -212,5 +212,3 @@ Unit : fs.unit                                                             Time:
     Mass Concentration C    28.302   28.302      456.52
 ====================================================================================
 """
-
-        assert output == stream.getvalue()

--- a/watertap/core/tests/test_zero_order_electricity.py
+++ b/watertap/core/tests/test_zero_order_electricity.py
@@ -14,7 +14,6 @@
 Tests for general zero-order property package
 """
 import pytest
-from io import StringIO
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -116,29 +115,7 @@ class TestConstantIntensity:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value  : Fixed : Bounds
-       Electricity Demand : 420.00 : False : (0, None)
-    Electricity Intensity : 10.000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-    Empty DataFrame
-    Columns: []
-    Index: []
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestPumpElectricity:
@@ -209,25 +186,4 @@ class TestPumpElectricity:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value    : Fixed : Bounds
-    Electricity Demand : 0.023248 : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-    Empty DataFrame
-    Columns: []
-    Index: []
-====================================================================================
-"""
+        model.fs.unit.report()

--- a/watertap/core/tests/test_zero_order_electricity.py
+++ b/watertap/core/tests/test_zero_order_electricity.py
@@ -140,8 +140,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 class TestPumpElectricity:
     @pytest.fixture(scope="module")
@@ -233,5 +231,3 @@ Unit : fs.unit                                                             Time:
     Index: []
 ====================================================================================
 """
-
-        assert output == stream.getvalue()

--- a/watertap/core/tests/test_zero_order_pt.py
+++ b/watertap/core/tests/test_zero_order_pt.py
@@ -120,5 +120,3 @@ Unit : fs.unit                                                             Time:
     Mass Concentration C   28.302  28.302
 ====================================================================================
 """
-
-        assert output == stream.getvalue()

--- a/watertap/core/tests/test_zero_order_pt.py
+++ b/watertap/core/tests/test_zero_order_pt.py
@@ -14,7 +14,6 @@
 Tests for general zero-order property package
 """
 import pytest
-from io import StringIO
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -100,23 +99,4 @@ class TestPT:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-
-------------------------------------------------------------------------------------
-    Stream Table
-                            Inlet  Outlet
-    Volumetric Flowrate    1.0600  1.0600
-    Mass Concentration H2O 943.40  943.40
-    Mass Concentration A   9.4340  9.4340
-    Mass Concentration B   18.868  18.868
-    Mass Concentration C   28.302  28.302
-====================================================================================
-"""
+        model.fs.unit.report()

--- a/watertap/core/tests/test_zero_order_sido.py
+++ b/watertap/core/tests/test_zero_order_sido.py
@@ -14,7 +14,6 @@
 Tests for general zero-order property package
 """
 import pytest
-from io import StringIO
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -232,30 +231,4 @@ class TestSIDO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value   : Fixed : Bounds
-    Solute Removal [A] : 0.10000 :  True : (0, None)
-    Solute Removal [B] : 0.20000 :  True : (0, None)
-    Solute Removal [C] : 0.30000 :  True : (0, None)
-        Water Recovery : 0.80000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                            Inlet  Treated  Byproduct
-    Volumetric Flowrate    1.0600 0.84600   0.21400  
-    Mass Concentration H2O 943.40  945.63    934.58  
-    Mass Concentration A   9.4340  10.638    4.6729  
-    Mass Concentration B   18.868  18.913    18.692  
-    Mass Concentration C   28.302  24.823    42.056  
-====================================================================================
-"""
+        model.fs.unit.report()

--- a/watertap/core/tests/test_zero_order_sido.py
+++ b/watertap/core/tests/test_zero_order_sido.py
@@ -259,5 +259,3 @@ Unit : fs.unit                                                             Time:
     Mass Concentration C   28.302  24.823    42.056  
 ====================================================================================
 """
-
-        assert output == stream.getvalue()

--- a/watertap/core/tests/test_zero_order_sido_reactive.py
+++ b/watertap/core/tests/test_zero_order_sido_reactive.py
@@ -14,7 +14,6 @@
 Tests for general zero-order property package
 """
 import pytest
-from io import StringIO
 import os
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
@@ -293,35 +292,7 @@ class TestSIDOR:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                    : Value   : Fixed : Bounds
-    Reaction Extent [Rxn1] :  8.0000 : False : (None, None)
-    Reaction Extent [Rxn2] :  2.0000 : False : (None, None)
-        Solute Removal [A] : 0.50000 :  True : (0, None)
-        Solute Removal [B] : 0.40000 :  True : (0, None)
-        Solute Removal [C] :  0.0000 :  True : (0, None)
-            Water Recovery : 0.85000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                            Inlet  Treated  Byproduct
-    Volumetric Flowrate    1.0600 0.89947     0.16113
-    Mass Concentration H2O 943.40  943.30      929.25
-    Mass Concentration A   9.4340  1.1118      6.2062
-    Mass Concentration B   18.868  17.344      64.544
-    Mass Concentration C   28.302  38.245  6.2062e-13
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestSIDORErrors:

--- a/watertap/core/tests/test_zero_order_sido_reactive.py
+++ b/watertap/core/tests/test_zero_order_sido_reactive.py
@@ -323,8 +323,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 class TestSIDORErrors:
     @pytest.mark.unit

--- a/watertap/core/tests/test_zero_order_siso.py
+++ b/watertap/core/tests/test_zero_order_siso.py
@@ -202,5 +202,3 @@ Unit : fs.unit                                                             Time:
     Mass Concentration C   28.302  20.076 
 ====================================================================================
 """
-
-        assert output == stream.getvalue()

--- a/watertap/core/tests/test_zero_order_siso.py
+++ b/watertap/core/tests/test_zero_order_siso.py
@@ -14,7 +14,6 @@
 Tests for zero-order SISO unit model
 """
 import pytest
-from io import StringIO
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -176,29 +175,4 @@ class TestSISO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value   : Fixed : Bounds
-    Solute Removal [A] : 0.10000 :  True : (0, None)
-    Solute Removal [B] : 0.20000 :  True : (0, None)
-    Solute Removal [C] : 0.30000 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                            Inlet  Treated
-    Volumetric Flowrate    1.0600  1.0460 
-    Mass Concentration H2O 943.40  956.02 
-    Mass Concentration A   9.4340  8.6042 
-    Mass Concentration B   18.868  15.296 
-    Mass Concentration C   28.302  20.076 
-====================================================================================
-"""
+        model.fs.unit.report()

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
@@ -12,7 +12,6 @@
 ###############################################################################
 
 import pytest
-from io import StringIO
 from pyomo.environ import value
 from watertap.examples.flowsheets.case_studies.seawater_RO_desalination.seawater_RO_desalination import (
     main,

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
@@ -24,97 +24,80 @@ from watertap.examples.flowsheets.case_studies.seawater_RO_desalination.seawater
 def test_seawater_RO_desalination_pressure_exchanger():
     m = main(erd_type="pressure_exchanger")
 
-    report_io = StringIO()
-    m.fs.feed.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.feed                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Stream Table
-                            Outlet 
-    Mass Concentration H2O   988.47
-    Mass Concentration tds   35.000
-    Mass Concentration tss 0.030000
-    Volumetric Flowrate     0.30920
-====================================================================================
-"""
-    assert output == report_io.getvalue()
+    f = m.fs.feed
+    assert pytest.approx(305.63, rel=1e-4) == value(f.flow_mass_comp[0, "H2O"])
+    assert pytest.approx(10.822, rel=1e-4) == value(f.flow_mass_comp[0, "tds"])
+    assert pytest.approx(9.2760e-3, rel=1e-4) == value(f.flow_mass_comp[0, "tss"])
+    assert pytest.approx(0.3092, rel=1e-4) == value(f.flow_vol[0])
 
-    report_io = StringIO()
-    m.fs.desalination.P1.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.desalination.P1                                                  Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
+    p1 = m.fs.desalination.P1
+    assert pytest.approx(0.8, rel=1e-4) == value(p1.efficiency_pump[0])
+    assert pytest.approx(1.1536e6, rel=1e-4) == value(p1.work_mechanical[0])
+    assert pytest.approx(6.9e6, rel=1e-4) == value(p1.deltaP[0])
+    assert pytest.approx(70.0, rel=1e-4) == value(p1.ratioP[0])
 
-    Variables: 
+    assert pytest.approx(132.15, rel=1e-4) == value(
+        p1.inlet.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(4.6800, rel=1e-4) == value(
+        p1.inlet.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.00, rel=1e-4) == value(p1.inlet.temperature[0.0])
+    assert pytest.approx(1.0e5, rel=1e-4) == value(p1.inlet.pressure[0.0])
+    assert pytest.approx(132.15, rel=1e-4) == value(
+        p1.outlet.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(4.6800, rel=1e-4) == value(
+        p1.outlet.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.00, rel=1e-4) == value(p1.outlet.temperature[0.0])
+    assert pytest.approx(7.0e6, rel=1e-4) == value(p1.outlet.pressure[0.0])
 
-    Key             : Value      : Fixed : Bounds
-         Efficiency :    0.80000 :  True : (None, None)
-    Mechanical Work : 1.1536e+06 : False : (None, None)
-    Pressure Change : 6.9000e+06 : False : (None, None)
-     Pressure Ratio :     70.000 : False : (None, None)
+    ro = m.fs.desalination.RO
+    assert pytest.approx(13914.0, rel=1e-4) == value(ro.area)
+    assert pytest.approx(0.43681, rel=1e-4) == value(
+        ro.recovery_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(0.43293, rel=1e-4) == value(ro.recovery_vol_phase[0.0, "Liq"])
+    assert pytest.approx(305.57, rel=1e-4) == value(
+        ro.inlet.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(10.822, rel=1e-4) == value(
+        ro.inlet.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.00, rel=1e-4) == value(ro.inlet.temperature[0.0])
+    assert pytest.approx(7.0e6, rel=1e-4) == value(ro.inlet.pressure[0.0])
+    assert pytest.approx(172.09, rel=1e-4) == value(
+        ro.retentate.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(10.792, rel=1e-4) == value(
+        ro.retentate.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.02, rel=1e-4) == value(ro.retentate.temperature[0.0])
+    assert pytest.approx(6.7759e6, rel=1e-4) == value(ro.retentate.pressure[0.0])
+    assert pytest.approx(133.48, rel=1e-4) == value(
+        ro.permeate.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(2.9557e-2, rel=1e-4) == value(
+        ro.permeate.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.02, rel=1e-4) == value(ro.permeate.temperature[0.0])
+    assert pytest.approx(1.0132e5, rel=1e-4) == value(ro.permeate.pressure[0.0])
 
-------------------------------------------------------------------------------------
-    Stream Table
-                                           Inlet     Outlet  
-    flow_mass_phase_comp ('Liq', 'H2O')     132.15     132.15
-    flow_mass_phase_comp ('Liq', 'TDS')     4.6800     4.6800
-    temperature                             298.00     298.00
-    pressure                            1.0000e+05 7.0000e+06
-====================================================================================
-"""
-    assert output == report_io.getvalue()
-
-    report_io = StringIO()
-    m.fs.desalination.RO.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.desalination.RO                                                  Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                        : Value   : Fixed : Bounds
-                 Membrane Area :  13914. :  True : (0.1, 20000)
-    Solvent Mass Recovery Rate : 0.43681 : False : (0.01, 0.999999)
-      Volumetric Recovery Rate : 0.43293 : False : (0.01, 0.999999)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Feed Inlet  Feed Outlet  Permeate Outlet
-    flow_mass_phase_comp ('Liq', 'H2O')      305.57      172.09         133.48   
-    flow_mass_phase_comp ('Liq', 'TDS')      10.822      10.792       0.029557   
-    temperature                              298.00      298.02         298.02   
-    pressure                             7.0000e+06  6.7759e+06     1.0132e+05   
-====================================================================================
-"""
-    assert output == report_io.getvalue()
-
-    report_io = StringIO()
-    m.fs.municipal.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.municipal                                                        Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 147.59 : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate    0.13351 0.13351
-    Mass Concentration H2O  999.78  999.78
-    Mass Concentration tds 0.22138 0.22138
-====================================================================================
-"""
-    assert output == report_io.getvalue()
+    muni = m.fs.municipal
+    assert pytest.approx(147.59, rel=1e-4) == value(muni.electricity[0])
+    assert pytest.approx(133.48, rel=1e-4) == value(
+        muni.inlet.flow_mass_comp[0.0, "H2O"]
+    )
+    assert pytest.approx(2.9557e-2, rel=1e-4) == value(
+        muni.inlet.flow_mass_comp[0.0, "tds"]
+    )
+    assert pytest.approx(133.48, rel=1e-4) == value(
+        muni.outlet.flow_mass_comp[0.0, "H2O"]
+    )
+    assert pytest.approx(2.9557e-2, rel=1e-4) == value(
+        muni.outlet.flow_mass_comp[0.0, "tds"]
+    )
 
     assert value(m.LCOW) == pytest.approx(0.845256, rel=1e-5)
 
@@ -123,96 +106,79 @@ Unit : fs.municipal                                                        Time:
 def test_seawater_RO_desalination_pump_as_turbine():
     m = main(erd_type="pump_as_turbine")
 
-    report_io = StringIO()
-    m.fs.feed.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.feed                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Stream Table
-                            Outlet 
-    Mass Concentration H2O   988.47
-    Mass Concentration tds   35.000
-    Mass Concentration tss 0.030000
-    Volumetric Flowrate     0.30920
-====================================================================================
-"""
-    assert output == report_io.getvalue()
+    f = m.fs.feed
+    assert pytest.approx(305.63, rel=1e-4) == value(f.flow_mass_comp[0, "H2O"])
+    assert pytest.approx(10.822, rel=1e-4) == value(f.flow_mass_comp[0, "tds"])
+    assert pytest.approx(9.2760e-3, rel=1e-4) == value(f.flow_mass_comp[0, "tss"])
+    assert pytest.approx(0.3092, rel=1e-4) == value(f.flow_vol[0])
 
-    report_io = StringIO()
-    m.fs.desalination.P1.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.desalination.P1                                                  Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
+    p1 = m.fs.desalination.P1
+    assert pytest.approx(0.8, rel=1e-4) == value(p1.efficiency_pump[0])
+    assert pytest.approx(2.6676e6, rel=1e-4) == value(p1.work_mechanical[0])
+    assert pytest.approx(6.9e6, rel=1e-4) == value(p1.deltaP[0])
+    assert pytest.approx(70.0, rel=1e-4) == value(p1.ratioP[0])
 
-    Variables: 
+    assert pytest.approx(305.57, rel=1e-4) == value(
+        p1.inlet.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(10.822, rel=1e-4) == value(
+        p1.inlet.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.00, rel=1e-4) == value(p1.inlet.temperature[0.0])
+    assert pytest.approx(1.0e5, rel=1e-4) == value(p1.inlet.pressure[0.0])
+    assert pytest.approx(305.57, rel=1e-4) == value(
+        p1.outlet.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(10.822, rel=1e-4) == value(
+        p1.outlet.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.00, rel=1e-4) == value(p1.outlet.temperature[0.0])
+    assert pytest.approx(7.0e6, rel=1e-4) == value(p1.outlet.pressure[0.0])
 
-    Key             : Value      : Fixed : Bounds
-         Efficiency :    0.80000 :  True : (None, None)
-    Mechanical Work : 2.6676e+06 : False : (None, None)
-    Pressure Change : 6.9000e+06 : False : (None, None)
-     Pressure Ratio :     70.000 : False : (None, None)
+    ro = m.fs.desalination.RO
+    assert pytest.approx(13914.0, rel=1e-4) == value(ro.area)
+    assert pytest.approx(0.43681, rel=1e-4) == value(
+        ro.recovery_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(0.43293, rel=1e-4) == value(ro.recovery_vol_phase[0.0, "Liq"])
+    assert pytest.approx(305.57, rel=1e-4) == value(
+        ro.inlet.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(10.822, rel=1e-4) == value(
+        ro.inlet.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.00, rel=1e-4) == value(ro.inlet.temperature[0.0])
+    assert pytest.approx(7.0e6, rel=1e-4) == value(ro.inlet.pressure[0.0])
+    assert pytest.approx(172.09, rel=1e-4) == value(
+        ro.retentate.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(10.792, rel=1e-4) == value(
+        ro.retentate.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.02, rel=1e-4) == value(ro.retentate.temperature[0.0])
+    assert pytest.approx(6.7759e6, rel=1e-4) == value(ro.retentate.pressure[0.0])
+    assert pytest.approx(133.48, rel=1e-4) == value(
+        ro.permeate.flow_mass_phase_comp[0.0, "Liq", "H2O"]
+    )
+    assert pytest.approx(2.9557e-2, rel=1e-4) == value(
+        ro.permeate.flow_mass_phase_comp[0.0, "Liq", "TDS"]
+    )
+    assert pytest.approx(298.02, rel=1e-4) == value(ro.permeate.temperature[0.0])
+    assert pytest.approx(1.0132e5, rel=1e-4) == value(ro.permeate.pressure[0.0])
 
-------------------------------------------------------------------------------------
-    Stream Table
-                                           Inlet     Outlet  
-    flow_mass_phase_comp ('Liq', 'H2O')     305.57     305.57
-    flow_mass_phase_comp ('Liq', 'TDS')     10.822     10.822
-    temperature                             298.00     298.00
-    pressure                            1.0000e+05 7.0000e+06
-====================================================================================
-"""
-    assert output == report_io.getvalue()
-
-    report_io = StringIO()
-    m.fs.desalination.RO.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.desalination.RO                                                  Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                        : Value   : Fixed : Bounds
-                 Membrane Area :  13914. :  True : (0.1, 20000)
-    Solvent Mass Recovery Rate : 0.43681 : False : (0.01, 0.999999)
-      Volumetric Recovery Rate : 0.43293 : False : (0.01, 0.999999)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Feed Inlet  Feed Outlet  Permeate Outlet
-    flow_mass_phase_comp ('Liq', 'H2O')      305.57      172.09         133.48   
-    flow_mass_phase_comp ('Liq', 'TDS')      10.822      10.792       0.029557   
-    temperature                              298.00      298.02         298.02   
-    pressure                             7.0000e+06  6.7759e+06     1.0132e+05   
-====================================================================================
-"""
-    assert output == report_io.getvalue()
-
-    report_io = StringIO()
-    m.fs.municipal.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.municipal                                                        Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 147.59 : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate    0.13351 0.13351
-    Mass Concentration H2O  999.78  999.78
-    Mass Concentration tds 0.22138 0.22138
-====================================================================================
-"""
-    assert output == report_io.getvalue()
+    muni = m.fs.municipal
+    assert pytest.approx(147.59, rel=1e-4) == value(muni.electricity[0])
+    assert pytest.approx(133.48, rel=1e-4) == value(
+        muni.inlet.flow_mass_comp[0.0, "H2O"]
+    )
+    assert pytest.approx(2.9557e-2, rel=1e-4) == value(
+        muni.inlet.flow_mass_comp[0.0, "tds"]
+    )
+    assert pytest.approx(133.48, rel=1e-4) == value(
+        muni.outlet.flow_mass_comp[0.0, "H2O"]
+    )
+    assert pytest.approx(2.9557e-2, rel=1e-4) == value(
+        muni.outlet.flow_mass_comp[0.0, "tds"]
+    )
 
     assert value(m.LCOW) == pytest.approx(1.11579, rel=1e-5)

--- a/watertap/unit_models/mvc/components/evaporator.py
+++ b/watertap/unit_models/mvc/components/evaporator.py
@@ -462,8 +462,10 @@ class EvaporatorData(UnitModelBlockData):
     def _get_performance_contents(self, time_point=0):
         var_dict = {
             "Heat transfer": self.feed_side.heat_transfer,
-            "Evaporator temperature": self.feed_side.properties_brine[0].temperature,
-            "Evaporator pressure": self.feed_side.properties_brine[0].pressure,
+            "Evaporator temperature": self.feed_side.properties_brine[
+                time_point
+            ].temperature,
+            "Evaporator pressure": self.feed_side.properties_brine[time_point].pressure,
         }
 
         return {"vars": var_dict}

--- a/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
+++ b/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
@@ -12,7 +12,6 @@
 ###############################################################################
 import sys
 import pytest
-from io import StringIO
 
 from pyomo.environ import ConcreteModel, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
@@ -86,35 +85,4 @@ def test_heat_exchanger():
     results = solver.solve(m, tee=False)
     assert_optimal_termination(results)
 
-    report_io = StringIO()
-    m.fs.unit.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key            : Value  : Fixed : Bounds
-           HX Area : 5.0000 :  True : (0, None)
-    HX Coefficient : 1000.0 :  True : (0, None)
-         Heat Duty : 89050. : False : (None, None)
-
-    Expressions: 
-
-    Key             : Value
-    Delta T Driving : 17.810
-         Delta T In : 9.2239
-        Delta T Out : 30.689
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Hot Inlet  Hot Outlet  Cold Inlet  Cold Outlet
-    flow_mass_phase_comp ('Liq', 'H2O')     1.0000      1.0000     0.50000     0.50000 
-    flow_mass_phase_comp ('Liq', 'TDS')   0.010000    0.010000    0.010000    0.010000 
-    temperature                             350.00      328.69      298.00      340.78 
-    pressure                            2.0000e+05  2.0000e+05  2.0000e+05  2.0000e+05 
-====================================================================================
-"""
-    assert output == report_io.getvalue()
+    m.fs.unit.report()

--- a/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
+++ b/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
@@ -13,7 +13,7 @@
 import sys
 import pytest
 
-from pyomo.environ import ConcreteModel, assert_optimal_termination
+from pyomo.environ import ConcreteModel, assert_optimal_termination, value
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
 from idaes.core.util import get_solver
@@ -84,5 +84,25 @@ def test_heat_exchanger():
     solver = get_solver()
     results = solver.solve(m, tee=False)
     assert_optimal_termination(results)
+
+    assert pytest.approx(89050.0, rel=1e-4) == value(m.fs.unit.head_duty[0])
+    assert pytest.approx(1.0, rel=1e-4) == value(
+        m.fs.unit.hot_outlet.flow_mass_phase_comp[0, "Liq", "H20"]
+    )
+    assert pytest.approx(0.01, rel=1e-4) == value(
+        m.fs.unit.hot_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
+    )
+    assert pytest.approx(328.69, rel=1e-4) == value(m.fs.unit.hot_outlet.temperature[0])
+    assert pytest.approx(2.0e5, rel=1e-4) == value(m.fs.unit.hot_outlet.pressure[0])
+    assert pytest.approx(0.5, rel=1e-4) == value(
+        m.fs.unit.cold_outlet.flow_mass_phase_comp[0, "Liq", "H20"]
+    )
+    assert pytest.approx(0.01, rel=1e-4) == value(
+        m.fs.unit.cold_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
+    )
+    assert pytest.approx(340.78, rel=1e-4) == value(
+        m.fs.unit.cold_outlet.temperature[0]
+    )
+    assert pytest.approx(2.0e5, rel=1e-4) == value(m.fs.unit.cold_outlet.pressure[0])
 
     m.fs.unit.report()

--- a/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
+++ b/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
@@ -87,7 +87,7 @@ def test_heat_exchanger():
 
     assert pytest.approx(89050.0, rel=1e-4) == value(m.fs.unit.heat_duty[0])
     assert pytest.approx(1.0, rel=1e-4) == value(
-        m.fs.unit.hot_outlet.flow_mass_phase_comp[0, "Liq", "H20"]
+        m.fs.unit.hot_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
     )
     assert pytest.approx(0.01, rel=1e-4) == value(
         m.fs.unit.hot_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
@@ -95,7 +95,7 @@ def test_heat_exchanger():
     assert pytest.approx(328.69, rel=1e-4) == value(m.fs.unit.hot_outlet.temperature[0])
     assert pytest.approx(2.0e5, rel=1e-4) == value(m.fs.unit.hot_outlet.pressure[0])
     assert pytest.approx(0.5, rel=1e-4) == value(
-        m.fs.unit.cold_outlet.flow_mass_phase_comp[0, "Liq", "H20"]
+        m.fs.unit.cold_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
     )
     assert pytest.approx(0.01, rel=1e-4) == value(
         m.fs.unit.cold_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]

--- a/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
+++ b/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
@@ -85,7 +85,7 @@ def test_heat_exchanger():
     results = solver.solve(m, tee=False)
     assert_optimal_termination(results)
 
-    assert pytest.approx(89050.0, rel=1e-4) == value(m.fs.unit.head_duty[0])
+    assert pytest.approx(89050.0, rel=1e-4) == value(m.fs.unit.heat_duty[0])
     assert pytest.approx(1.0, rel=1e-4) == value(
         m.fs.unit.hot_outlet.flow_mass_phase_comp[0, "Liq", "H20"]
     )

--- a/watertap/unit_models/mvc/components/tests/test_complete_condenser.py
+++ b/watertap/unit_models/mvc/components/tests/test_complete_condenser.py
@@ -11,7 +11,6 @@
 #
 ###############################################################################
 import pytest
-from io import StringIO
 
 from pyomo.environ import ConcreteModel, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
@@ -57,26 +56,4 @@ def test_complete_condense():
     results = solver.solve(m, tee=False)
     assert_optimal_termination(results)
 
-    report_io = StringIO()
-    m.fs.unit.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key       : Value       : Fixed : Bounds
-    Heat duty : -2.4358e+06 : False : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                           Inlet     Outlet  
-    flow_mass_phase_comp ('Liq', 'H2O') 1.0000e-08     1.0000
-    flow_mass_phase_comp ('Vap', 'H2O')     1.0000 1.0000e-10
-    temperature                             400.00     340.00
-    pressure                                50000.     50000.
-====================================================================================
-"""
-    assert output == report_io.getvalue()
+    m.fs.unit.report()

--- a/watertap/unit_models/mvc/components/tests/test_compressor.py
+++ b/watertap/unit_models/mvc/components/tests/test_compressor.py
@@ -11,7 +11,6 @@
 #
 ###############################################################################
 import pytest
-from io import StringIO
 
 from pyomo.environ import ConcreteModel, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
@@ -63,28 +62,4 @@ def test_compressor():
     results = solver.solve(m, tee=False)
     assert_optimal_termination(results)
 
-    report_io = StringIO()
-    m.fs.compressor.report(ostream=report_io)
-    output = """
-====================================================================================
-Unit : fs.compressor                                                       Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key            : Value      : Fixed : Bounds
-        Efficiency :    0.80000 :  True : (1e-08, 1)
-    Pressure ratio :     2.0000 :  True : (1, 10)
-              Work : 1.1534e+05 : False : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                           Inlet     Outlet  
-    flow_mass_phase_comp ('Liq', 'H2O') 1.0000e-08 1.0000e-08
-    flow_mass_phase_comp ('Vap', 'H2O')     1.0000     1.0000
-    temperature                             350.00     429.57
-    pressure                                50000. 1.0000e+05
-====================================================================================
-"""
-    assert output == report_io.getvalue()
+    m.fs.compressor.report()

--- a/watertap/unit_models/mvc/components/tests/test_evaporator.py
+++ b/watertap/unit_models/mvc/components/tests/test_evaporator.py
@@ -105,3 +105,16 @@ def test_evaporator():
     assert m.fs.evaporator.feed_side.heat_transfer.value == pytest.approx(
         1.230e6, rel=1e-3
     )
+
+    perf_dict = m.fs.evaporator._get_performance_contents()
+    assert perf_dict == {
+        "vars": {
+            "Heat transfer": m.fs.evaporator.feed_side.heat_transfer,
+            "Evaporator temperature": m.fs.evaporator.feed_side.properties_brine[
+                0
+            ].temperature,
+            "Evaporator pressure": m.fs.evaporator.feed_side.properties_brine[
+                0
+            ].pressure,
+        }
+    }

--- a/watertap/unit_models/mvc/components/tests/test_evaporator.py
+++ b/watertap/unit_models/mvc/components/tests/test_evaporator.py
@@ -12,7 +12,6 @@
 ###############################################################################
 import sys
 import pytest
-from io import StringIO
 
 from pyomo.environ import ConcreteModel, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent

--- a/watertap/unit_models/mvc/tests/test_mvc.py
+++ b/watertap/unit_models/mvc/tests/test_mvc.py
@@ -12,7 +12,6 @@
 ###############################################################################
 import sys
 import pytest
-from io import StringIO
 
 from pyomo.environ import (
     ConcreteModel,

--- a/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
@@ -240,7 +240,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration nitrous_oxide                0.0000 8.2992e-10     500.00
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
@@ -15,8 +15,6 @@ Tests for zero-order CANDO+P model
 """
 import pytest
 
-from io import StringIO
-
 from pyomo.environ import (
     Block,
     Var,
@@ -206,40 +204,7 @@ class TestCANDOPZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                                   : Value   : Fixed : Bounds
-                                       Electricity Demand :  10800. : False : (0, None)
-                                    Electricity Intensity :  4.0000 :  True : (0, None)
-                                            Oxygen Demand :  2.6250 : False : (0, None)
-    Oxygen consumed / nitrogen reacted ratio (mass basis) :  3.5000 :  True : (0, None)
-                             Reaction Extent [n_reaction] : 0.75000 : False : (None, None)
-                             Reaction Extent [p_reaction] : 0.75000 : False : (None, None)
-             Solute Removal [bioconcentrated_phosphorous] :  1.0000 :  True : (0, None)
-                                Solute Removal [nitrogen] :  0.0000 :  True : (0, None)
-                           Solute Removal [nitrous_oxide] :  1.0000 :  True : (0, None)
-                              Solute Removal [phosphates] :  0.0000 :  True : (0, None)
-                                           Water Recovery :  1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet   Treated   Byproduct
-    Volumetric Flowrate                            0.12200    0.12050  0.0015000
-    Mass Concentration H2O                          983.61     995.85 6.6667e-08
-    Mass Concentration nitrogen                     8.1967     2.0747 6.6670e-08
-    Mass Concentration phosphates                   8.1967     2.0747 6.6670e-08
-    Mass Concentration bioconcentrated_phosphorous  0.0000 8.2992e-10     500.00
-    Mass Concentration nitrous_oxide                0.0000 8.2992e-10     500.00
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
@@ -189,8 +189,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestAerationBasinZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -357,8 +355,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               76.923   88.417 4.7337e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
@@ -15,7 +15,6 @@ Tests for zero-order aeration basin model
 """
 import pytest
 
-from io import StringIO
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -160,34 +159,7 @@ class TestAerationBasinZO_no_default:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  17.810 : False : (0, None)
-               Electricity Intensity : 0.41227 :  True : (None, None)
-                Solute Removal [bod] : 0.70000 :  True : (0, None)
-    Solute Removal [viruses_enteric] : 0.99000 :  True : (0, None)
-                      Water Recovery :  1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.012000 0.010310  0.0016900
-    Mass Concentration H2O               833.33   969.93 4.7337e-07
-    Mass Concentration viruses_enteric   83.333  0.96993     585.80
-    Mass Concentration bod               83.333   29.098     414.20
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestAerationBasinZO_w_default_removal:
@@ -325,36 +297,7 @@ class TestAerationBasinZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  19.294 : False : (0, None)
-               Electricity Intensity : 0.41227 :  True : (None, None)
-                Solute Removal [bod] : 0.70000 :  True : (0, None)
-                Solute Removal [foo] :  0.0000 :  True : (0, None)
-    Solute Removal [viruses_enteric] : 0.99000 :  True : (0, None)
-                      Water Recovery :  1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.013000 0.011310  0.0016900
-    Mass Concentration H2O               769.23   884.17 4.7337e-07
-    Mass Concentration viruses_enteric   76.923  0.88417     585.80
-    Mass Concentration bod               76.923   26.525     414.20
-    Mass Concentration foo               76.923   88.417 4.7337e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
@@ -15,7 +15,6 @@ Tests for zero-order air flotation model
 """
 import pytest
 
-from io import StringIO
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -148,32 +147,7 @@ class TestAirFloatationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value   : Fixed : Bounds
-       Electricity Demand :  11.880 : False : (0, None)
-    Electricity Intensity : 0.30000 :  True : (None, None)
-     Solute Removal [tss] : 0.90000 :  True : (0, None)
-           Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.011000 0.010099 0.00090100
-    Mass Concentration H2O   909.09   990.10     1.1099
-    Mass Concentration tss   90.909   9.9020     998.89
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestAirFlotationZO_w_default_removal:
@@ -297,34 +271,7 @@ class TestAirFlotationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value   : Fixed : Bounds
-       Electricity Demand :  12.960 : False : (0, None)
-    Electricity Intensity : 0.30000 :  True : (None, None)
-     Solute Removal [foo] :  0.0000 :  True : (0, None)
-     Solute Removal [tss] : 0.90000 :  True : (0, None)
-           Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.012000 0.011099 0.00090100
-    Mass Concentration H2O   833.33   900.89     1.1099
-    Mass Concentration tss   83.333   9.0098     998.89
-    Mass Concentration foo   83.333   90.098 8.8790e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
@@ -175,8 +175,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestAirFlotationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -327,8 +325,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo   83.333   90.098 8.8790e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
@@ -15,7 +15,6 @@ Tests for zero-order anaerobic digestion oxidation model
 """
 import pytest
 
-from io import StringIO
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -158,34 +157,7 @@ class TestAnaerobicDigestionOxidationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value   : Fixed : Bounds
-       Electricity Demand :  6.4800 : False : (0, None)
-    Electricity Intensity : 0.15000 :  True : (None, None)
-     Solute Removal [bod] : 0.97000 :  True : (0, None)
-     Solute Removal [tss] : 0.75000 :  True : (0, None)
-           Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.012000 0.010279 0.0017210 
-    Mass Concentration H2O   833.33   972.76   0.58106 
-    Mass Concentration tss   83.333   24.321    435.79 
-    Mass Concentration bod   83.333   2.9186    563.63 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestAnaerobicDigestionOxidationZO_w_default_removal:
@@ -321,36 +293,7 @@ class TestAnaerobicDigestionOxidationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value   : Fixed : Bounds
-       Electricity Demand :  7.0200 : False : (0, None)
-    Electricity Intensity : 0.15000 :  True : (None, None)
-     Solute Removal [bod] : 0.97000 :  True : (0, None)
-     Solute Removal [foo] :  0.0000 :  True : (0, None)
-     Solute Removal [tss] : 0.75000 :  True : (0, None)
-           Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.013000 0.011279  0.0017210
-    Mass Concentration H2O   769.23   886.51    0.58106
-    Mass Concentration tss   76.923   22.165     435.79
-    Mass Concentration bod   76.923   2.6598     563.63
-    Mass Concentration foo   76.923   88.660 4.6485e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
@@ -187,8 +187,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestAnaerobicDigestionOxidationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -353,8 +351,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo   76.923   88.660 4.6485e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
@@ -15,7 +15,6 @@ Tests for zero-order anaerobic MBR-MEC model
 """
 import pytest
 
-from io import StringIO
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -190,39 +189,7 @@ class TestAnaerobicMBRMECZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                           : Value      : Fixed : Bounds
-                               Electricity Demand : 8.0000e-10 : False : (0, None)
-                            Electricity Intensity :     0.0000 :  True : (None, None)
-    Reaction Extent [cod_to_nonbiodegradable_cod] : 5.0313e-05 : False : (None, None)
-            Solute Removal [ammonium_as_nitrogen] :     0.0000 :  True : (0, None)
-                             Solute Removal [cod] :     0.0000 :  True : (0, None)
-            Solute Removal [nonbiodegradable_cod] :     1.0000 :  True : (0, None)
-        Solute Removal [phosphate_as_phosphorous] :     0.0000 :  True : (0, None)
-                                   Water Recovery :    0.39680 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                   Inlet     Treated   Byproduct
-    Volumetric Flowrate                         4.3750e-05 1.7374e-05 2.6376e-05
-    Mass Concentration H2O                          997.55     996.71     998.09
-    Mass Concentration cod                          2.3000     2.8958 3.0331e-05
-    Mass Concentration nonbiodegradable_cod     2.2857e-16 4.6045e-05     1.9076
-    Mass Concentration ammonium_as_nitrogen        0.10500    0.26444 3.0331e-05
-    Mass Concentration phosphate_as_phosphorous   0.050000    0.12595 3.0331e-05
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
@@ -224,8 +224,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 db = Database()
 params = db._get_technology("anaerobic_mbr_mec")

--- a/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
@@ -184,7 +184,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo     0.099960   0.10525 1.9887e-08
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
@@ -14,7 +14,6 @@
 Tests for zero-order backwash solids handling model
 """
 import pytest
-from io import StringIO
 
 from pyomo.environ import (
     Block,
@@ -153,37 +152,7 @@ class TestBackwashSolidsHandling_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                      : Value   : Fixed : Bounds
-          Electricity Demand :  3686.3 : False : (0, None)
-        Solute Removal [foo] :  0.0000 :  True : (0, None)
-    Solute Removal [nitrate] : 0.95000 :  True : (0, None)
-        Solute Removal [toc] : 0.95000 :  True : (0, None)
-        Solute Removal [tss] : 0.95000 :  True : (0, None)
-              Water Recovery : 0.95000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet    Treated  Byproduct
-    Volumetric Flowrate          10.004    9.5011    0.50285
-    Mass Concentration H2O       999.60    999.88     994.33
-    Mass Concentration nitrate 0.099960 0.0052625     1.8892
-    Mass Concentration tss     0.099960 0.0052625     1.8892
-    Mass Concentration toc     0.099960 0.0052625     1.8892
-    Mass Concentration foo     0.099960   0.10525 1.9887e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
@@ -15,7 +15,6 @@ Tests for zero-order biologically active filtration model
 """
 import pytest
 
-from io import StringIO
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -162,34 +161,7 @@ class TestBioActiveFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand : 7.0000e-10 : False : (0, None)
-               Electricity Intensity :     0.0000 :  True : (None, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.50000 :  True : (0, None)
-                      Water Recovery :    0.99000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.012000 0.011200 0.00080000
-    Mass Concentration H2O               833.33   883.93     125.00
-    Mass Concentration nonvolatile_toc   83.333   71.429     250.00
-    Mass Concentration tss               83.333   44.643     625.00
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestBioActiveFiltrationZO_w_default_removal:
@@ -327,36 +299,7 @@ class TestBioActiveFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand : 8.0000e-10 : False : (0, None)
-               Electricity Intensity :     0.0000 :  True : (None, None)
-                Solute Removal [foo] :     0.0000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.50000 :  True : (0, None)
-                      Water Recovery :    0.99000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.013000 0.012200 0.00080000
-    Mass Concentration H2O               769.23   811.48     125.00
-    Mass Concentration nonvolatile_toc   76.923   65.574     250.00
-    Mass Concentration tss               76.923   40.984     625.00
-    Mass Concentration foo               76.923   81.967 1.0000e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
@@ -191,8 +191,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestBioActiveFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -359,8 +357,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               76.923   81.967 1.0000e-06
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
@@ -14,7 +14,6 @@
 Tests for zero-order bioreactor model
 """
 import pytest
-from io import StringIO
 
 from pyomo.environ import (
     Block,
@@ -131,35 +130,7 @@ class TestBioreactorZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                       : Value      : Fixed : Bounds
-           Electricity Demand : 9.9000e-09 : False : (0, None)
-        Electricity Intensity :     0.0000 :  True : (None, None)
-       Solute Removal [boron] :    0.80000 :  True : (0, None)
-         Solute Removal [foo] :     0.0000 :  True : (0, None)
-    Solute Removal [selenium] :    0.96500 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                  Inlet    Treated
-    Volumetric Flowrate           10.003    9.7012
-    Mass Concentration H2O        999.70    999.87
-    Mass Concentration boron    0.099970  0.020616
-    Mass Concentration selenium 0.099970 0.0036078
-    Mass Concentration foo      0.099970   0.10308
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
@@ -160,7 +160,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo      0.099970   0.10308
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
@@ -139,8 +139,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
@@ -14,7 +14,6 @@
 Tests for zero-order blending reservoir model
 """
 import pytest
-from io import StringIO
 
 from pyomo.environ import (
     Block,
@@ -114,30 +113,7 @@ class TestBlendingReservoirZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate     1.0010  1.0010
-    Mass Concentration H2O  999.00  999.00
-    Mass Concentration foo 0.99900 0.99900
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
@@ -176,8 +176,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class Testbrine_concentratorZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -327,7 +325,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo 0.097551 0.11104  8.0321e-09
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
@@ -14,7 +14,6 @@
 Tests for zero-order brine concentrator model
 """
 import pytest
-from io import StringIO
 
 from pyomo.environ import (
     Block,
@@ -149,32 +148,7 @@ class TestBrineConcentratorZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                                : Value      : Fixed : Bounds
-    Electricity intensity per Inlet Flowrate  (kWh/m3) :     23.186 : False : (None, None)
-                                Power Consumption (kW) : 8.5557e+05 : False : (0, None)
-                                  Solute Removal [tds] :    0.98000 :  True : (0, None)
-                                        Water Recovery :    0.90000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                            Inlet  Treated  Byproduct
-    Volumetric Flowrate    10.250  9.0050    1.2450  
-    Mass Concentration H2O 975.61  999.44    803.21  
-    Mass Concentration tds 24.390 0.55525    196.79  
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class Testbrine_concentratorZO_w_default_removal:
@@ -297,34 +271,7 @@ class Testbrine_concentratorZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                                : Value      : Fixed : Bounds
-    Electricity intensity per Inlet Flowrate  (kWh/m3) :     23.186 : False : (None, None)
-                                Power Consumption (kW) : 8.5565e+05 : False : (0, None)
-                                  Solute Removal [foo] :     0.0000 :  True : (0, None)
-                                  Solute Removal [tds] :    0.98000 :  True : (0, None)
-                                        Water Recovery :    0.90000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate      10.251  9.0060      1.2450
-    Mass Concentration H2O   975.51  999.33      803.21
-    Mass Concentration tds   24.388 0.55519      196.79
-    Mass Concentration foo 0.097551 0.11104  8.0321e-09
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
@@ -135,8 +135,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order buffer tank model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -110,30 +110,8 @@ class TestBufferTankZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Outlet 
-    Volumetric Flowrate    0.011000 0.011000
-    Mass Concentration H2O   909.09   909.09
-    Mass Concentration tss   90.909   90.909
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
@@ -189,8 +189,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestCartridgeFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -355,8 +353,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               76.923   84.041 7.2661e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order cartridge filtration model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -160,34 +160,8 @@ class TestCartridgeFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand :  0.0086400 : False : (0, None)
-               Electricity Intensity : 0.00020000 :  True : (None, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.90000 :  True : (0, None)
-                      Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.012000 0.010899 0.0011010 
-    Mass Concentration H2O               833.33   917.42   0.90827 
-    Mass Concentration nonvolatile_toc   83.333   73.401    181.65 
-    Mass Concentration tss               83.333   9.1752    817.44 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestCartridgeFiltrationZO_w_default_removal:
@@ -323,36 +297,8 @@ class TestCartridgeFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand :  0.0093600 : False : (0, None)
-               Electricity Intensity : 0.00020000 :  True : (None, None)
-                Solute Removal [foo] :     0.0000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.90000 :  True : (0, None)
-                      Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.013000 0.011899  0.0011010
-    Mass Concentration H2O               769.23   840.32    0.90827
-    Mass Concentration nonvolatile_toc   76.923   67.233     181.65
-    Mass Concentration tss               76.923   8.4041     817.44
-    Mass Concentration foo               76.923   84.041 7.2661e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
@@ -169,8 +169,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 db = Database()
 params = db._get_technology("chemical_addition")

--- a/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order chemical addition model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import Block, ConcreteModel, Constraint, Param, value, Var
 from pyomo.util.check_units import assert_units_consistent
@@ -141,33 +141,8 @@ class TestChemAddZOAmmonia:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value      : Fixed : Bounds
-       Chemical Dosage :     1.0000 :  True : (0, None)
-         Chemical Flow : 2.0120e-06 : False : (0, None)
-    Electricity Demand : 0.00074140 : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                Inlet  Outlet
-    Volumetric Flowrate        1.0060  1.0060
-    Mass Concentration H2O     994.04  994.04
-    Mass Concentration sulfur 0.99404 0.99404
-    Mass Concentration toc     1.9881  1.9881
-    Mass Concentration tss     2.9821  2.9821
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
@@ -187,8 +187,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestChlorinationZO_w_o_default_removal:
     @pytest.fixture(scope="class")
@@ -327,8 +325,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration viruses_enteric              9.8039 0.0033600
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order Chlorination model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -152,40 +152,8 @@ class TestChlorinationZO_with_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value      : Fixed : Bounds
-                           CT Value ((mg*min)/L) :     450.00 :  True : (None, None)
-                 Chlorine Decay Rate (mg/(L*hr)) :     3.0000 :  True : (None, None)
-                            Chlorine Dose (mg/L) :     9.5000 : False : (None, None)
-                               Contact Time (hr) :     1.5000 :  True : (None, None)
-                              Electricity Demand :   0.018540 : False : (0, None)
-                           Electricity Intensity : 5.0000e-05 :  True : (None, None)
-                  Initial Chlorine Demand (mg/L) :     0.0000 :  True : (None, None)
-    Solute Removal [total_coliforms_fecal_ecoli] :    0.99915 :  True : (0, None)
-                            Solute Removal [tss] :     0.0000 :  True : (0, None)
-                Solute Removal [viruses_enteric] :    0.99966 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet   Treated
-    Volumetric Flowrate                            0.10300   0.10100
-    Mass Concentration H2O                          970.87    990.09
-    Mass Concentration total_coliforms_fecal_ecoli  9.7087 0.0084355
-    Mass Concentration viruses_enteric              9.7087 0.0033267
-    Mass Concentration tss                          9.7087    9.9009
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestChlorinationZO_w_o_default_removal:
@@ -293,38 +261,8 @@ class TestChlorinationZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value      : Fixed : Bounds
-                           CT Value ((mg*min)/L) :     450.00 :  True : (None, None)
-                 Chlorine Decay Rate (mg/(L*hr)) :     3.0000 :  True : (None, None)
-                            Chlorine Dose (mg/L) :     9.5000 : False : (None, None)
-                               Contact Time (hr) :     1.5000 :  True : (None, None)
-                              Electricity Demand :   0.018360 : False : (0, None)
-                           Electricity Intensity : 5.0000e-05 :  True : (None, None)
-                  Initial Chlorine Demand (mg/L) :     0.0000 :  True : (None, None)
-    Solute Removal [total_coliforms_fecal_ecoli] :    0.99915 :  True : (0, None)
-                Solute Removal [viruses_enteric] :    0.99966 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet   Treated
-    Volumetric Flowrate                            0.10200   0.10000
-    Mass Concentration H2O                          980.39    999.99
-    Mass Concentration total_coliforms_fecal_ecoli  9.8039 0.0085199
-    Mass Concentration viruses_enteric              9.8039 0.0033600
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
@@ -176,8 +176,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestClarifierZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -329,8 +327,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo   71.429   90.765 2.6823e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order clarifier model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -149,32 +149,8 @@ class TestClarifierZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [tss] :    0.99083 :  True : (0, None)
-           Water Recovery :    0.99900 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.013000 0.010018 0.0029825 
-    Mass Concentration H2O   769.23   997.25    3.3529 
-    Mass Concentration tss   230.77   2.7474    996.65 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestClarifierZO_w_default_removal:
@@ -299,34 +275,8 @@ class TestClarifierZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 8.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [foo] :     0.0000 :  True : (0, None)
-     Solute Removal [tss] :    0.99083 :  True : (0, None)
-           Water Recovery :    0.99900 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.014000 0.011018  0.0029825
-    Mass Concentration H2O   714.29   906.74     3.3529
-    Mass Concentration tss   214.29   2.4980     996.65
-    Mass Concentration foo   71.429   90.765 2.6823e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
@@ -149,8 +149,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order CO2 addition model.
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -120,34 +120,8 @@ class TestCO2AdditionZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet   Outlet 
-    Volumetric Flowrate        0.034130 0.034130
-    Mass Concentration H2O       293.00   293.00
-    Mass Concentration toc       87.899   87.899
-    Mass Concentration tds       2.9300   2.9300
-    Mass Concentration eeq      0.87899  0.87899
-    Mass Concentration nitrate   117.20   117.20
-    Mass Concentration tss       498.10   498.10
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
@@ -270,8 +270,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order coagulation/flocculation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -234,41 +234,8 @@ class TestCoagFlocZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                               : Value      : Fixed : Bounds
-                   Alum Dosage (mg/L) :     10.000 :  True : (0, None)
-                     Alum Flow (kg/s) : 0.00013000 : False : (0, None)
-              Floc Basin Volume (m^3) :     9.3600 : False : (None, None)
-                      Floc Power (kW) :    0.17971 : False : (None, None)
-            Floc Retention Time (min) :     12.000 :  True : (None, None)
-         Floc Velocity Gradient (1/s) :     80.000 :  True : (None, None)
-                Polymer Dosage (mg/L) :    0.10000 :  True : (0, None)
-                  Polymer Flow (kg/s) : 1.3000e-06 : False : (0, None)
-         Rapid Mix Basin Volume (m^3) :   0.071500 : False : (None, None)
-                 Rapid Mix Power (kW) :   0.057915 : False : (None, None)
-         Rapid Mix Retention Time (s) :     5.5000 :  True : (None, None)
-    Rapid Mix Velocity Gradient (1/s) :     900.00 :  True : (None, None)
-         Total Power Consumption (kW) :    0.23763 : False : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Outlet 
-    Volumetric Flowrate    0.013000 0.013000
-    Mass Concentration H2O   769.23   769.23
-    Mass Concentration tss   230.77   230.77
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order cofermentation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -204,32 +204,8 @@ class TestCofermentationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 1.0000e-14 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [cod] :    0.70000 :  True : (0, None)
-           Water Recovery :     0.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet 1    Inlet 2    Treated 
-    Volumetric Flowrate    3.7153e-07 3.7153e-08 7.8892e-09
-    Mass Concentration H2O     930.22     990.00 1.2675e-06
-    Mass Concentration cod     69.782     10.000     1000.0
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 @pytest.mark.unit

--- a/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
@@ -231,8 +231,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 @pytest.mark.unit
 def test_COD_not_in_solute_list():

--- a/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
@@ -139,4 +139,3 @@ Unit : fs.unit                                                             Time:
     Mass Concentration nitrate   90.909    65.934
 ====================================================================================
 """
-        assert output in stream.getvalue()

--- a/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order constructed wetlands
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -116,26 +116,5 @@ class TestConstructedWetlandsZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                      : Value   : Fixed : Bounds
-    Solute Removal [nitrate] : 0.40000 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet    Treated
-    Volumetric Flowrate        0.011000 0.0091000
-    Mass Concentration H2O       909.09    934.07
-    Mass Concentration nitrate   90.909    65.934
-====================================================================================
-"""
+        model.fs.unit.report()

--- a/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
@@ -202,8 +202,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 db = Database()
 params = db._get_technology("conventional_activated_sludge")

--- a/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order conventional activated sludge process
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -171,36 +171,8 @@ class TestCASZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  6.5520 : False : (0, None)
-               Electricity Intensity : 0.14000 :  True : (None, None)
-                Solute Removal [foo] :  0.0000 :  True : (0, None)
-                Solute Removal [tss] : 0.50000 :  True : (0, None)
-    Solute Removal [viruses_enteric] : 0.99000 :  True : (0, None)
-                      Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.013000 0.011509  0.0014910
-    Mass Concentration H2O               769.23   868.80    0.67069
-    Mass Concentration viruses_enteric   76.923  0.86889     663.98
-    Mass Concentration tss               76.923   43.444     335.35
-    Mass Concentration foo               76.923   86.889 5.3655e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order cooling supply model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -111,30 +111,8 @@ class TestCoolingSupplyZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Outlet 
-    Volumetric Flowrate    0.011000 0.011000
-    Mass Concentration H2O   909.09   909.09
-    Mass Concentration tss   90.909   90.909
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
@@ -136,8 +136,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order cooling tower model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -168,36 +168,8 @@ class TestCoolingTowerZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                        : Value      : Fixed : Bounds
-    Blowdown flowrate (m^3/hr) :     216.00 : False : (None, None)
-                        Cycles :     5.0000 :  True : (None, None)
-            Electricity Demand : 8.0000e-10 : False : (0, None)
-         Electricity Intensity :     0.0000 :  True : (None, None)
-          Solute Removal [foo] :     0.0000 :  True : (0, None)
-          Solute Removal [tss] :    0.90000 :  True : (0, None)
-                Water Recovery :    0.25000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet    Treated  Byproduct
-    Volumetric Flowrate    0.012000 0.0036000  0.0084000
-    Mass Concentration H2O   833.33    694.44     892.86
-    Mass Concentration tss   83.333    27.778     107.14
-    Mass Concentration foo   83.333    277.78 9.5238e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
@@ -199,8 +199,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
@@ -152,8 +152,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestDecarbonatorZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -280,8 +278,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo              83.333   90.901
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order air flotation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -126,31 +126,8 @@ class TestDecarbonatorZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                             : Value      : Fixed : Bounds
-                 Electricity Demand : 7.0000e-10 : False : (0, None)
-              Electricity Intensity :     0.0000 :  True : (None, None)
-    Solute Removal [carbon_dioxide] :    0.99900 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                        Inlet   Treated
-    Volumetric Flowrate               0.011000 0.010001
-    Mass Concentration H2O              909.09   999.90
-    Mass Concentration carbon_dioxide   90.909 0.099990
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestDecarbonatorZO_w_default_removal:
@@ -251,33 +228,8 @@ class TestDecarbonatorZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                             : Value      : Fixed : Bounds
-                 Electricity Demand : 7.0000e-10 : False : (0, None)
-              Electricity Intensity :     0.0000 :  True : (None, None)
-    Solute Removal [carbon_dioxide] :    0.99900 :  True : (0, None)
-               Solute Removal [foo] :     0.0000 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                        Inlet   Treated
-    Volumetric Flowrate               0.012000 0.011001
-    Mass Concentration H2O              833.33   909.01
-    Mass Concentration carbon_dioxide   83.333 0.090901
-    Mass Concentration foo              83.333   90.901
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
@@ -162,8 +162,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order well field model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -134,33 +134,8 @@ class TestDeepWellInjectionZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                    : Value  : Fixed : Bounds
-        Electricity Demand : 22.109 : False : (0, None)
-    Pipe Diameter (inches) : 8.0000 :  True : (None, None)
-     Pipe Distance (miles) : 0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet     Outlet  
-    Volumetric Flowrate         0.060000   0.060000
-    Mass Concentration H2O    0.00016667 0.00016667
-    Mass Concentration sulfur     166.67     166.67
-    Mass Concentration toc        333.33     333.33
-    Mass Concentration tss        500.00     500.00
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order dissolved air flotation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -170,36 +170,8 @@ class TestAirDissolvedFloatationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                             : Value    : Fixed : Bounds
-                 Electricity Demand :   2.7000 : False : (0, None)
-              Electricity Intensity : 0.050000 :  True : (None, None)
-               Solute Removal [bod] :  0.95000 :  True : (0, None)
-    Solute Removal [oil_and_grease] :  0.95000 :  True : (0, None)
-               Solute Removal [tss] :  0.95000 :  True : (0, None)
-                     Water Recovery :  0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                        Inlet   Treated  Byproduct
-    Volumetric Flowrate               0.015000 0.010249 0.0047510 
-    Mass Concentration H2O              666.67   975.61   0.21048 
-    Mass Concentration bod              66.667   4.8785    199.96 
-    Mass Concentration oil_and_grease   200.00   14.636    599.87 
-    Mass Concentration tss              66.667   4.8785    199.96 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestDissolvedAirFlotationZO_w_default_removal:
@@ -332,38 +304,8 @@ class TestDissolvedAirFlotationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                             : Value    : Fixed : Bounds
-                 Electricity Demand :   2.8800 : False : (0, None)
-              Electricity Intensity : 0.050000 :  True : (None, None)
-               Solute Removal [bod] :  0.95000 :  True : (0, None)
-               Solute Removal [foo] :   0.0000 :  True : (0, None)
-    Solute Removal [oil_and_grease] :  0.95000 :  True : (0, None)
-               Solute Removal [tss] :  0.95000 :  True : (0, None)
-                     Water Recovery :  0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                        Inlet   Treated  Byproduct
-    Volumetric Flowrate               0.016000 0.011249  0.0047510
-    Mass Concentration H2O              625.00   888.88    0.21048
-    Mass Concentration bod              62.500   4.4448     199.96
-    Mass Concentration oil_and_grease   187.50   13.335     599.87
-    Mass Concentration tss              62.500   4.4448     199.96
-    Mass Concentration foo              62.500   88.897 1.6839e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
@@ -201,8 +201,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestDissolvedAirFlotationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -366,8 +364,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo              62.500   88.897 1.6839e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order dmbr model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -190,42 +190,8 @@ class TestDMBRZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                   : Value      : Fixed : Bounds
-                       Electricity Demand : 8.0000e-10 : False : (0, None)
-                    Electricity Intensity :     0.0000 :  True : (None, None)
-              Reaction Extent [BOD_usage] :     2.2500 : False : (None, None)
-    Reaction Extent [nitrate_to_nitrogen] :    0.82500 : False : (None, None)
-    Solute Removal [ammonium_as_nitrogen] :     0.0000 :  True : (0, None)
-                     Solute Removal [bod] :     0.0000 :  True : (0, None)
-                 Solute Removal [nitrate] :     0.0000 :  True : (0, None)
-                Solute Removal [nitrogen] :     0.0000 :  True : (0, None)
-                     Solute Removal [tss] :    0.80000 :  True : (0, None)
-                           Water Recovery :    0.90000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                              Inlet   Treated  Byproduct
-    Volumetric Flowrate                     0.024000 0.016750  0.0050000
-    Mass Concentration H2O                    416.67   537.31     200.00
-    Mass Concentration bod                    208.33   164.18 1.6000e-07
-    Mass Concentration tss                    208.33   59.701     800.00
-    Mass Concentration ammonium_as_nitrogen   83.333   119.40 1.6000e-07
-    Mass Concentration nitrate                41.667   10.448 1.6000e-07
-    Mass Concentration nitrogen               41.667   108.96 1.6000e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
@@ -227,8 +227,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
@@ -201,8 +201,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestDualMediaFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -379,8 +377,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               71.429   79.808 5.4422e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order dual media filtration model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -170,36 +170,8 @@ class TestDualMediaFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value    : Fixed : Bounds
-                  Electricity Demand :   2.3736 : False : (0, None)
-               Electricity Intensity : 0.050719 :  True : (None, None)
-    Solute Removal [nonvolatile_toc] :  0.20000 :  True : (0, None)
-                Solute Removal [toc] :  0.20000 :  True : (0, None)
-                Solute Removal [tss] :  0.97000 :  True : (0, None)
-                      Water Recovery :  0.99000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.013000 0.011530 0.0014700 
-    Mass Concentration H2O               769.23   858.63    68.027 
-    Mass Concentration nonvolatile_toc   76.923   69.384    136.05 
-    Mass Concentration toc               76.923   69.384    136.05 
-    Mass Concentration tss               76.923   2.6019    659.86 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestDualMediaFiltrationZO_w_default_removal:
@@ -345,38 +317,8 @@ class TestDualMediaFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value    : Fixed : Bounds
-                  Electricity Demand :   2.5562 : False : (0, None)
-               Electricity Intensity : 0.050719 :  True : (None, None)
-                Solute Removal [foo] :   0.0000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :  0.20000 :  True : (0, None)
-                Solute Removal [toc] :  0.20000 :  True : (0, None)
-                Solute Removal [tss] :  0.97000 :  True : (0, None)
-                      Water Recovery :  0.99000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.014000 0.012530  0.0014700
-    Mass Concentration H2O               714.29   790.10     68.027
-    Mass Concentration nonvolatile_toc   71.429   63.847     136.05
-    Mass Concentration toc               71.429   63.847     136.05
-    Mass Concentration tss               71.429   2.3943     659.86
-    Mass Concentration foo               71.429   79.808 5.4422e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
@@ -16,7 +16,7 @@ Tests for zero-order electrochemical nutrient recovery model
 import pytest
 import os
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -185,41 +185,8 @@ class TestElectroNPZO:
     @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                       : Value   : Fixed : Bounds
-    Dosage of magnesium chloride per struvite : 0.38800 :  True : (0, None)
-                           Electricity Demand :  1350.5 : False : (0, None)
-                        Electricity Intensity : 0.20500 :  True : (None, None)
-                    Magnesium Chloride Demand :  2556.1 : False : (0, None)
-                Reaction Extent [extract_N_P] : 0.83000 : False : (None, None)
-                         Solute Removal [foo] :  0.0000 :  True : (0, None)
-                    Solute Removal [nitrogen] :  0.0000 :  True : (0, None)
-                  Solute Removal [phosphorus] :  0.0000 :  True : (0, None)
-                    Solute Removal [struvite] :  1.0000 :  True : (0, None)
-                               Water Recovery :  1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                    Inlet   Treated   Byproduct
-    Volumetric Flowrate            1.0040    0.99636  0.0018300
-    Mass Concentration H2O         996.02     998.66 5.4661e-08
-    Mass Concentration nitrogen   0.99602    0.17062 5.4645e-08
-    Mass Concentration phosphorus 0.99602    0.17062 5.4645e-08
-    Mass Concentration struvite   0.99602 1.0037e-10     1000.0
-    Mass Concentration foo        0.99602     1.0037 5.4645e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
@@ -221,8 +221,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
@@ -181,7 +181,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo 0.097551 0.10796  1.0120e-08
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order electrodialysis reversal model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -153,34 +153,8 @@ class TestElectrodialysisReversalZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                                : Value      : Fixed : Bounds
-    Electricity intensity per Inlet Flowrate  (kWh/m3) :     12.811 : False : (None, None)
-                                Power Consumption (kW) : 4.7276e+05 : False : (0, None)
-                                  Solute Removal [foo] :     0.0000 :  True : (0, None)
-                                  Solute Removal [tds] :    0.80870 :  True : (0, None)
-                                        Water Recovery :    0.92140 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate      10.251  9.2628     0.98817
-    Mass Concentration H2O   975.51  994.73      795.41
-    Mass Concentration tds   24.388  5.1632      204.59
-    Mass Concentration foo 0.097551 0.10796  1.0120e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
@@ -143,8 +143,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order energy recovery model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -118,30 +118,8 @@ class TestEnergyRecoveryZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value   : Fixed : Bounds
-       Electricity Demand : -11423. : False : (None, 0)
-    Electricity Intensity : -3.1700 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate     1.0010  1.0010
-    Mass Concentration H2O  999.00  999.00
-    Mass Concentration foo 0.99900 0.99900
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order evaporation pond model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -267,43 +267,8 @@ class TestEvaporationPondZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                        : Value      : Fixed : Bounds
-       Evaporation rate (mm/d) :     7.1673 : False : (None, None)
-             Pond area (acres) :     7176.3 : False : (None, None)
-         Pond dike height (ft) :     8.0000 :  True : (None, None)
-      Solute Removal [calcium] :    0.98000 :  True : (0, None)
-    Solute Removal [magnesium] :    0.98000 :  True : (0, None)
-      Solute Removal [nitrate] :    0.98000 :  True : (0, None)
-      Solute Removal [sulfate] :    0.98000 :  True : (0, None)
-          Solute Removal [tds] :    0.98000 :  True : (0, None)
-          Solute Removal [tss] :    0.98000 :  True : (0, None)
-                Water Recovery : 0.00010000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                  Inlet  Treated  Byproduct
-    Volumetric Flowrate          1.4110 0.028021   1.3830  
-    Mass Concentration H2O       7.0872 0.035688   7.2300  
-    Mass Concentration tds       87.172   87.791   87.160  
-    Mass Concentration magnesium 323.18   325.47   323.13  
-    Mass Concentration calcium   559.18   563.15   559.10  
-    Mass Concentration nitrate   7.0872   7.1375   7.0862  
-    Mass Concentration sulfate   7.7959   7.8513   7.7948  
-    Mass Concentration tss       8.5046   8.5650   8.5034  
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
@@ -305,8 +305,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
@@ -135,8 +135,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order feed water tank model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -110,30 +110,8 @@ class TestFeedWaterTankZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Outlet 
-    Volumetric Flowrate    0.011000 0.011000
-    Mass Concentration H2O   909.09   909.09
-    Mass Concentration tss   90.909   90.909
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order filter press model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -176,32 +176,8 @@ class TestFilterPressZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                         : Value      : Fixed : Bounds
-    Filter Press Capacity (ft3) :     9153.6 : False : (None, None)
-        Filter Press Power (kW) :     156.61 : False : (0, None)
-           Solute Removal [tss] :    0.98000 :  True : (0, None)
-                 Water Recovery : 0.00010000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet    Treated   Byproduct
-    Volumetric Flowrate    0.024000 0.00046010  0.023540 
-    Mass Concentration H2O   41.667    0.21734    42.477 
-    Mass Concentration tss   958.33     999.78    957.52 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
@@ -203,8 +203,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
 

--- a/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
@@ -245,8 +245,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestFixedBedZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -426,7 +424,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo  0.39980   0.39984
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order fixed bed model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -212,38 +212,8 @@ class TestFixedBedZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                     : Value    : Fixed : Bounds
-         Acetic Acid Demand :   1799.0 : False : (0, None)
-    Activated Carbon Demand :   58.448 : False : (0, None)
-          Anthracite Demand :   64.048 : False : (0, None)
-    Cationic Polymer Demand :   49.057 : False : (0, None)
-         Electricity Demand :   3082.6 : False : (0, None)
-      Electricity Intensity : 0.085618 :  True : (None, None)
-    Ferric Chlorided Demand :   359.80 : False : (0, None)
-     Phosphoric Acid Demand :   152.17 : False : (0, None)
-                Sand Demand :   64.897 : False : (0, None)
-       Solute Removal [bod] :  0.90000 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet    Treated
-    Volumetric Flowrate      10.001    10.000
-    Mass Concentration H2O   999.90    999.99
-    Mass Concentration bod 0.099990 0.0099999
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestFixedBedZO_w_default_removal:
@@ -390,40 +360,8 @@ class TestFixedBedZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                     : Value    : Fixed : Bounds
-         Acetic Acid Demand :   1799.7 : False : (0, None)
-    Activated Carbon Demand :   58.469 : False : (0, None)
-          Anthracite Demand :   64.072 : False : (0, None)
-    Cationic Polymer Demand :   49.073 : False : (0, None)
-         Electricity Demand :   3083.8 : False : (0, None)
-      Electricity Intensity : 0.085618 :  True : (None, None)
-    Ferric Chlorided Demand :   359.95 : False : (0, None)
-     Phosphoric Acid Demand :   152.23 : False : (0, None)
-                Sand Demand :   64.921 : False : (0, None)
-       Solute Removal [bod] :  0.90000 :  True : (0, None)
-       Solute Removal [foo] :   0.0000 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet    Treated
-    Volumetric Flowrate      10.005    10.004
-    Mass Concentration H2O   999.50    999.59
-    Mass Concentration bod 0.099950 0.0099959
-    Mass Concentration foo  0.39980   0.39984
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_gac_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_gac_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order granular activated carbon model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -163,36 +163,8 @@ class TestGACZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value    : Fixed : Bounds
-             Activated Carbon Demand :   1983.6 : False : (0, None)
-                  Electricity Demand :   637.99 : False : (0, None)
-               Electricity Intensity : 0.017718 : False : (None, None)
-              Empty Bed Contact Time :  0.16667 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :  0.20000 :  True : (0, None)
-                Solute Removal [tss] :  0.97000 :  True : (0, None)
-                      Water Recovery :  0.96000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet    Treated  Byproduct
-    Volumetric Flowrate                  10.002    9.6008  0.40117  
-    Mass Concentration H2O               999.80    999.91   997.08  
-    Mass Concentration tss             0.099980 0.0031247   2.4179  
-    Mass Concentration nonvolatile_toc 0.099980  0.083326  0.49854  
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestGACZO_w_default_removal:
@@ -320,38 +292,8 @@ class TestGACZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value    : Fixed : Bounds
-             Activated Carbon Demand :   1983.8 : False : (0, None)
-                  Electricity Demand :   638.05 : False : (0, None)
-               Electricity Intensity : 0.017718 : False : (None, None)
-              Empty Bed Contact Time :  0.16667 :  True : (0, None)
-                Solute Removal [foo] :   0.0000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :  0.20000 :  True : (0, None)
-                Solute Removal [tss] :  0.97000 :  True : (0, None)
-                      Water Recovery :  0.96000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet    Treated  Byproduct
-    Volumetric Flowrate                  10.003    9.6018    0.40117
-    Mass Concentration H2O               999.70    999.81     997.08
-    Mass Concentration tss             0.099970 0.0031244     2.4179
-    Mass Concentration nonvolatile_toc 0.099970  0.083317    0.49854
-    Mass Concentration foo             0.099970   0.10415 2.4927e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_gac_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_gac_zo.py
@@ -194,8 +194,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestGACZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -354,7 +352,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo             0.099970   0.10415 2.4927e-08
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
+++ b/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
@@ -279,5 +279,3 @@ Unit : fs.unit                                                             Time:
     Mass Concentration cod 0.99900 1.0215e-15    46.322 
 ====================================================================================
 """
-
-        assert output == stream.getvalue()

--- a/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
+++ b/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
@@ -14,7 +14,7 @@
 Tests for zero-order gas-sparged membrane unit
 """
 import pytest
-from io import StringIO
+
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -253,29 +253,5 @@ class TestGasSpargedMembraneZO:
     @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
 
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                                         : Value      : Fixed : Bounds
-                                             Electricity Demand :     368.86 : False : (0, None)
-                             Mass flow of gas extracted (kg/s)) :    0.41216 : False : (0, None)
-    Mass of gas extracted per mass flow of influent(kg/d/(kg/d) : 0.00041175 :  True : (0, None)
-                                           Solute Removal [cod] :     1.0000 :  True : (0, None)
-                                                 Water Recovery :    0.97900 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated   Byproduct
-    Volumetric Flowrate     1.0010    0.97900  0.021588 
-    Mass Concentration H2O  999.00     1000.0    953.68 
-    Mass Concentration cod 0.99900 1.0215e-15    46.322 
-====================================================================================
-"""
+        model.fs.unit.report()

--- a/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order intrusion mitigation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -118,33 +118,8 @@ class TestInjectionWellDisposalZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value   : Fixed : Bounds
-       Electricity Demand :  201.39 : False : (0, None)
-    Electricity Intensity : 0.40959 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet   Outlet 
-    Volumetric Flowrate         0.13658  0.13658
-    Mass Concentration H2O       900.60   900.60
-    Mass Concentration tss       29.288   29.288
-    Mass Concentration sulfate 0.036610 0.036610
-    Mass Concentration foo       4.9057   4.9057
-    Mass Concentration bar       65.166   65.166
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
@@ -146,8 +146,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
@@ -144,8 +144,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order intrusion mitigation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -116,33 +116,8 @@ class TestIntrusionMitigationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value    : Fixed : Bounds
-       Electricity Demand :   25.173 : False : (0, None)
-    Electricity Intensity : 0.051199 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet   Outlet 
-    Volumetric Flowrate         0.13658  0.13658
-    Mass Concentration H2O       900.60   900.60
-    Mass Concentration tss       29.288   29.288
-    Mass Concentration sulfate 0.036610 0.036610
-    Mass Concentration foo       4.9057   4.9057
-    Mass Concentration bar       65.166   65.166
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
@@ -182,7 +182,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo  0.39980   0.39984 1.1159e-07
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 class TestIonExchangeZO_clinoptilolite:
@@ -330,7 +329,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo                   0.39980    0.41093 3.6901e-08
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order Ion exchange model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -153,35 +153,8 @@ class TestIonExchangeZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                  : Value    : Fixed : Bounds
-      Electricity Demand :   2899.6 : False : (0, None)
-           NaCl Addition : 0.061031 : False : (0, None)
-            Resin Demand : 0.013630 : False : (0, None)
-    Solute Removal [foo] :   0.0000 :  True : (0, None)
-    Solute Removal [tds] :  0.90000 :  True : (0, None)
-          Water Recovery :   1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet    Treated  Byproduct
-    Volumetric Flowrate      10.005    10.004 0.00090000
-    Mass Concentration H2O   999.50    999.59 1.1112e-07
-    Mass Concentration tds 0.099950 0.0099959     1000.0
-    Mass Concentration foo  0.39980   0.39984 1.1159e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestIonExchangeZO_clinoptilolite:
@@ -298,37 +271,8 @@ class TestIonExchangeZO_clinoptilolite:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                         : Value      : Fixed : Bounds
-                             Electricity Demand :     2899.6 : False : (0, None)
-    Final mass flow of clay and nitrogen (kg/s) :     24.975 : False : (None, None)
-                                  NaCl Addition : 1.0000e-08 : False : (0, None)
-            Nitrogen-Clay Mixture Ratio (kg/kg) :   0.040000 :  True : (None, None)
-                                   Resin Demand : 1.0000e-08 : False : (0, None)
-          Solute Removal [ammonium_as_nitrogen] :    0.99900 :  True : (0, None)
-                           Solute Removal [foo] :     0.0000 :  True : (0, None)
-                                 Water Recovery :    0.97300 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                              Inlet    Treated   Byproduct
-    Volumetric Flowrate                       10.005     9.7340    0.27100
-    Mass Concentration H2O                    999.50     999.59     996.31
-    Mass Concentration ammonium_as_nitrogen 0.099950 0.00010273     3.6864
-    Mass Concentration foo                   0.39980    0.41093 3.6901e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
@@ -220,7 +220,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo       0.095229 0.099502 2.2173e-08
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order iron and manganese removal model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -190,36 +190,8 @@ class TestIronManganeseRemovalZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                                : Value   : Fixed : Bounds
-    Electricity intensity per Inlet Flowrate  (kWh/m3) : 0.11021 : False : (None, None)
-                                Power Consumption (kW) :  4166.5 : False : (0, None)
-                                  Solute Removal [foo] :  0.0000 :  True : (0, None)
-                                 Solute Removal [iron] : 0.90000 :  True : (0, None)
-                            Solute Removal [manganese] : 0.90000 :  True : (0, None)
-                                        Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                   Inlet   Treated  Byproduct
-    Volumetric Flowrate            10.501   10.050    0.45100
-    Mass Concentration H2O         952.29   994.93     2.2173
-    Mass Concentration iron        23.807   2.4876     498.89
-    Mass Concentration manganese   23.807   2.4876     498.89
-    Mass Concentration foo       0.095229 0.099502 2.2173e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_landfill_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_landfill_zo.py
@@ -134,8 +134,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 db = Database()
 params = db._get_technology("landfill")

--- a/watertap/unit_models/zero_order/tests/test_landfill_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_landfill_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order landfill model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import Block, ConcreteModel, Constraint, value, Var
 from pyomo.util.check_units import assert_units_consistent
@@ -105,34 +105,8 @@ class TestLandfillZOdefault:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                    : Value      : Fixed : Bounds
-    Capacity Basis (kg/hr) : 1.0000e+05 :  True : (None, None)
-        Electricity Demand : 1.6544e-24 : False : (0, None)
-     Electricity Intensity :     0.0000 :  True : (None, None)
-        Total Mass (kg/hr) : 2.1600e+05 : False : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet     Outlet  
-    Volumetric Flowrate         0.060000   0.060000
-    Mass Concentration H2O    0.00016667 0.00016667
-    Mass Concentration sulfur     166.67     166.67
-    Mass Concentration toc        333.33     333.33
-    Mass Concentration tss        500.00     500.00
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_mabr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mabr_zo.py
@@ -210,8 +210,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_mabr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mabr_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order mabr model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -175,40 +175,8 @@ class TestMABRZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                   : Value     : Fixed : Bounds
-                        Blower Size (m^2) :    1.0000 :  True : (0, None)
-                       Electricity Demand :   0.57380 : False : (0, None)
-                    Electricity Intensity : 0.0069300 :  True : (None, None)
-    Reaction Extent [ammonium_to_nitrate] :    1.4000 : False : (None, None)
-    Solute Removal [ammonium_as_nitrogen] :    0.0000 :  True : (0, None)
-                     Solute Removal [bod] :    0.0000 :  True : (0, None)
-                 Solute Removal [nitrate] :    0.0000 :  True : (0, None)
-                     Solute Removal [tss] :    0.0000 :  True : (0, None)
-                           Water Recovery :    1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                              Inlet   Treated  Byproduct
-    Volumetric Flowrate                     0.023000 0.023000 4.0000e-12
-    Mass Concentration H2O                    434.78   434.78     200.00
-    Mass Concentration bod                    217.39   217.39     200.00
-    Mass Concentration tss                    217.39   217.39     200.00
-    Mass Concentration ammonium_as_nitrogen   86.957   26.087     200.00
-    Mass Concentration nitrate                43.478   104.35     200.00
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_mbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mbr_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order membrane bioreactor model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -224,44 +224,8 @@ class TestMBRZOdefault:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value   : Fixed : Bounds
-                              Electricity Demand :  8580.8 : False : (0, None)
-                           Electricity Intensity :  2.3670 :  True : (None, None)
-                Solute Removal [cryptosporidium] : 0.99990 :  True : (0, None)
-                            Solute Removal [eeq] : 0.88000 :  True : (0, None)
-                Solute Removal [nonvolatile_toc] : 0.60000 :  True : (0, None)
-                            Solute Removal [toc] : 0.70854 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] : 0.99880 :  True : (0, None)
-                            Solute Removal [tss] : 0.50000 :  True : (0, None)
-                Solute Removal [viruses_enteric] : 0.99000 :  True : (0, None)
-                                  Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet   Treated   Byproduct
-    Volumetric Flowrate                             1.0070     1.0012 0.0057772 
-    Mass Concentration H2O                          993.05     998.68    17.309 
-    Mass Concentration tss                         0.99305    0.49939    86.547 
-    Mass Concentration nonvolatile_toc             0.99305    0.39951    103.86 
-    Mass Concentration toc                         0.99305    0.29110    122.64 
-    Mass Concentration eeq                         0.99305    0.11985    152.32 
-    Mass Concentration viruses_enteric             0.99305  0.0099878    171.36 
-    Mass Concentration total_coliforms_fecal_ecoli 0.99305  0.0012005    172.89 
-    Mass Concentration cryptosporidium             0.99305 9.9878e-05    173.08 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestMBRZO_w_default_removal:
@@ -462,46 +426,8 @@ class TestMBRZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value   : Fixed : Bounds
-                              Electricity Demand :  8589.3 : False : (0, None)
-                           Electricity Intensity :  2.3670 :  True : (None, None)
-                Solute Removal [cryptosporidium] : 0.99990 :  True : (0, None)
-                            Solute Removal [eeq] : 0.88000 :  True : (0, None)
-                            Solute Removal [foo] :  0.0000 :  True : (0, None)
-                Solute Removal [nonvolatile_toc] : 0.60000 :  True : (0, None)
-                            Solute Removal [toc] : 0.70854 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] : 0.99880 :  True : (0, None)
-                            Solute Removal [tss] : 0.50000 :  True : (0, None)
-                Solute Removal [viruses_enteric] : 0.99000 :  True : (0, None)
-                                  Water Recovery : 0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet   Treated   Byproduct
-    Volumetric Flowrate                             1.0080     1.0022  0.0057772
-    Mass Concentration H2O                          992.06     997.68     17.309
-    Mass Concentration tss                         0.99206    0.49889     86.547
-    Mass Concentration nonvolatile_toc             0.99206    0.39911     103.86
-    Mass Concentration toc                         0.99206    0.29081     122.64
-    Mass Concentration eeq                         0.99206    0.11973     152.32
-    Mass Concentration viruses_enteric             0.99206  0.0099778     171.36
-    Mass Concentration total_coliforms_fecal_ecoli 0.99206  0.0011993     172.89
-    Mass Concentration cryptosporidium             0.99206 9.9788e-05     173.08
-    Mass Concentration foo                         0.99206    0.99778 1.7309e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_mbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mbr_zo.py
@@ -263,8 +263,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestMBRZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -504,8 +502,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo                         0.99206    0.99778 1.7309e-06
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order dual media filtration model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -160,34 +160,8 @@ class TestMediaFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand :  0.0064800 : False : (0, None)
-               Electricity Intensity : 0.00015000 :  True : (None, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.50000 :  True : (0, None)
-                      Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.012000 0.011299 0.00070100
-    Mass Concentration H2O               833.33   884.95     1.4265
-    Mass Concentration nonvolatile_toc   83.333   70.803     285.31
-    Mass Concentration tss               83.333   44.252     713.27
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestMediaFiltrationZO_w_default_removal:
@@ -323,36 +297,8 @@ class TestMediaFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand :  0.0070200 : False : (0, None)
-               Electricity Intensity : 0.00015000 :  True : (None, None)
-                Solute Removal [foo] :     0.0000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.50000 :  True : (0, None)
-                      Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.013000 0.012299 0.00070100
-    Mass Concentration H2O               769.23   812.99     1.4265
-    Mass Concentration nonvolatile_toc   76.923   65.046     285.31
-    Mass Concentration tss               76.923   40.654     713.27
-    Mass Concentration foo               76.923   81.307 1.1412e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
@@ -189,8 +189,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestMediaFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -355,8 +353,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               76.923   81.307 1.1412e-06
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_metab_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_metab_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order bioreactor with simple reactions
 """
 import pytest
 import os
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Block,
@@ -135,35 +135,8 @@ class TestMetabZO_hydrogen:
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                               : Value     : Fixed : Bounds
-                   Electricity Demand :    368.28 : False : (0, None)
-    Reaction Extent [cod_to_hydrogen] : 0.0022000 : False : (None, None)
-                 Solute Removal [cod] :    0.0000 :  True : (0, None)
-            Solute Removal [hydrogen] :    1.0000 :  True : (0, None)
-                Thermal Energy Demand :    79.537 : False : (0, None)
-                       Water Recovery :    1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                   Inlet    Treated   Byproduct
-    Volumetric Flowrate         0.0010100  0.0010078 1.1066e-08
-    Mass Concentration H2O         990.10     992.26 9.7518e-09
-    Mass Concentration cod         9.9010     7.7396 9.1163e-09
-    Mass Concentration hydrogen    0.0000 1.2301e-12     1000.0
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestMetabZO_methane:
@@ -263,37 +236,8 @@ class TestMetabZO_methane:
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand :     60.024 : False : (0, None)
-    Reaction Extent [cod_to_methane] :  0.0059000 : False : (None, None)
-                Solute Removal [cod] :     0.0000 :  True : (0, None)
-           Solute Removal [hydrogen] :     0.0000 :  True : (0, None)
-            Solute Removal [methane] :     1.0000 :  True : (0, None)
-               Thermal Energy Demand : 1.0088e-14 : False : (0, None)
-                      Water Recovery :     1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                   Inlet    Treated   Byproduct
-    Volumetric Flowrate         0.0010100  0.0010041 5.9590e-07
-    Mass Concentration H2O         990.10     995.92 1.6781e-08
-    Mass Concentration cod         9.9010     4.0833 1.6929e-08
-    Mass Concentration hydrogen    0.0000 1.0047e-11 1.6929e-08
-    Mass Concentration methane     0.0000 2.7912e-09     1000.0
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestMetabZO_hydrogen_cost:

--- a/watertap/unit_models/zero_order/tests/test_metab_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_metab_zo.py
@@ -164,7 +164,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration hydrogen    0.0000 1.2301e-12     1000.0
 ====================================================================================
 """
-        assert output == stream.getvalue()
 
 
 class TestMetabZO_methane:
@@ -295,7 +294,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration methane     0.0000 2.7912e-09     1000.0
 ====================================================================================
 """
-        assert output == stream.getvalue()
 
 
 class TestMetabZO_hydrogen_cost:

--- a/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
@@ -213,8 +213,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestMicroFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -390,8 +388,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               66.667   82.433 2.7884e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order microfiltration model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -180,38 +180,8 @@ class TestMicroFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  9.0720 : False : (0, None)
-               Electricity Intensity : 0.18000 :  True : (None, None)
-    Solute Removal [cryptosporidium] : 0.99900 :  True : (0, None)
-                Solute Removal [eeq] : 0.30000 :  True : (0, None)
-                Solute Removal [toc] : 0.10000 :  True : (0, None)
-                Solute Removal [tss] : 0.97000 :  True : (0, None)
-                      Water Recovery : 0.95000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.014000 0.011131 0.0028690 
-    Mass Concentration H2O               714.29   853.47    174.28 
-    Mass Concentration eeq               71.429   62.887    104.57 
-    Mass Concentration toc               71.429   80.855    34.855 
-    Mass Concentration tss               71.429   2.6952    338.10 
-    Mass Concentration cryptosporidium   71.429 0.089839    348.20 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestMicroFiltrationZO_w_default_removal:
@@ -354,40 +324,8 @@ class TestMicroFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  9.7200 : False : (0, None)
-               Electricity Intensity : 0.18000 :  True : (None, None)
-    Solute Removal [cryptosporidium] : 0.99900 :  True : (0, None)
-                Solute Removal [eeq] : 0.30000 :  True : (0, None)
-                Solute Removal [foo] :  0.0000 :  True : (0, None)
-                Solute Removal [toc] : 0.10000 :  True : (0, None)
-                Solute Removal [tss] : 0.97000 :  True : (0, None)
-                      Water Recovery : 0.95000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.015000 0.012131  0.0028690
-    Mass Concentration H2O               666.67   783.12     174.28
-    Mass Concentration eeq               66.667   57.703     104.57
-    Mass Concentration toc               66.667   74.190     34.855
-    Mass Concentration tss               66.667   2.4730     338.10
-    Mass Concentration cryptosporidium   66.667 0.082433     348.20
-    Mass Concentration foo               66.667   82.433 2.7884e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
@@ -175,8 +175,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestMicroscreenFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -325,8 +323,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo   83.333   86.957 1.5997e-06
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order microscreen filtration model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -148,32 +148,8 @@ class TestMicroscreenFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [tss] :    0.50000 :  True : (0, None)
-           Water Recovery :    0.99999 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.011000 0.010500 0.00050010
-    Mass Concentration H2O   909.09   952.38    0.19996
-    Mass Concentration tss   90.909   47.620     999.80
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestMicroscreenFiltrationZO_w_default_removal:
@@ -295,34 +271,8 @@ class TestMicroscreenFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 8.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [foo] :     0.0000 :  True : (0, None)
-     Solute Removal [tss] :    0.50000 :  True : (0, None)
-           Water Recovery :    0.99999 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.012000 0.011500 0.00050010
-    Mass Concentration H2O   833.33   869.56    0.19996
-    Mass Concentration tss   83.333   43.479     999.80
-    Mass Concentration foo   83.333   86.957 1.5997e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order municipal drinking model.
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     check_optimal_termination,
@@ -110,29 +110,8 @@ class TestMunicipalDrinkingZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 11056. : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Outlet 
-    Volumetric Flowrate      10.001   10.001
-    Mass Concentration H2O   999.90   999.90
-    Mass Concentration foo 0.099990 0.099990
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
@@ -134,8 +134,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order municipal wastewater treatment plant model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -116,30 +116,8 @@ class TestMunicipalWWTPZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate     1.0010  1.0010
-    Mass Concentration H2O  999.00  999.00
-    Mass Concentration foo 0.99900 0.99900
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
@@ -141,8 +141,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -324,8 +324,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestNFZO_non_default_subtype:
     @pytest.fixture(scope="class")
@@ -490,8 +488,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration dye    2.5000   0.053854     9.7374
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order nanofiltration model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -291,38 +291,8 @@ class TestNFZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                     : Value   : Fixed : Bounds
-         Electricity Demand :  8336.7 : False : (0, None)
-      Electricity Intensity : 0.23134 :  True : (None, None)
-       Solute Removal [foo] :  0.0000 :  True : (0, None)
-    Solute Removal [sulfur] : 0.97000 :  True : (0, None)
-       Solute Removal [toc] : 0.75000 :  True : (0, None)
-       Solute Removal [tss] : 0.97000 :  True : (0, None)
-             Water Recovery : 0.85000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                Inlet    Treated  Byproduct
-    Volumetric Flowrate         10.010    8.5046     1.5054
-    Mass Concentration H2O      999.00    999.46     996.43
-    Mass Concentration sulfur 0.099900 0.0035275    0.64436
-    Mass Concentration toc     0.19980  0.058792    0.99643
-    Mass Concentration tss     0.29970  0.010582     1.9331
-    Mass Concentration foo     0.39960   0.47033 6.6428e-09
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestNFZO_non_default_subtype:
@@ -457,37 +427,8 @@ class TestNFZO_non_default_subtype:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                      : Value    : Fixed : Bounds
-                         Membrane Area (m^2) :   3.9023 : False : (None, None)
-                  Net Driving Pressure (bar) :   6.8950 :  True : (None, None)
-                             Rejection [dye] :  0.97846 : False : (None, None)
-                             Rejection [tds] : 0.017247 : False : (None, None)
-                        Solute Removal [dye] :  0.98390 :  True : (0, None)
-                        Solute Removal [tds] :  0.26550 :  True : (0, None)
-    Water Permeability Coefficient (LMH/bar) :   100.00 :  True : (None, None)
-                              Water Recovery :  0.75000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                              Inlet    Treated   Byproduct
-    Volumetric Flowrate    0.0010000 0.00074739 0.00025261
-    Mass Concentration H2O    947.50     950.81     937.71
-    Mass Concentration tds    50.000     49.138     52.551
-    Mass Concentration dye    2.5000   0.053854     9.7374
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order Ozone/AOP model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     check_optimal_termination,
@@ -199,50 +199,8 @@ class TestOzoneAOPZO_with_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value   : Fixed : Bounds
-                           Oxidant Dosage (mg/L) :  4673.4 : False : (None, None)
-                             Oxidant Flow (kg/s) : 0.50005 : False : (0, None)
-                             Oxidant/Ozone Ratio : 0.50000 :  True : (None, None)
-                     Ozone CT Value ((mg*min)/L) :  1.0000 :  True : (None, None)
-                        Ozone Contact Time (min) :  1.0000 :  True : (None, None)
-                         Ozone Mass Flow (lb/hr) :  9921.9 : False : (0, None)
-                  Ozone Mass Transfer Efficiency : 0.80000 :  True : (None, None)
-                    Ozone Unit Power Demand (kW) :  49609. : False : (0, None)
-                                 Ozone/TOC Ratio :  1.0001 : False : (None, None)
-                Solute Removal [cryptosporidium] : 0.29479 :  True : (0, None)
-                            Solute Removal [eeq] : 0.98943 :  True : (0, None)
-                Solute Removal [giardia_lamblia] : 0.90324 :  True : (0, None)
-                            Solute Removal [toc] : 0.72830 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] : 0.99723 :  True : (0, None)
-                            Solute Removal [tss] :  0.0000 :  True : (0, None)
-                Solute Removal [viruses_enteric] : 0.99723 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet  Treated
-    Volumetric Flowrate                            0.10700  0.10209
-    Mass Concentration H2O                          934.58   979.53
-    Mass Concentration cryptosporidium              9.3458   6.9078
-    Mass Concentration toc                          9.3458   2.6613
-    Mass Concentration giardia_lamblia              9.3458  0.94780
-    Mass Concentration eeq                          9.3458  0.10350
-    Mass Concentration total_coliforms_fecal_ecoli  9.3458 0.027182
-    Mass Concentration viruses_enteric              9.3458 0.027182
-    Mass Concentration tss                          9.3458   9.7953
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestOzoneAOPZO_w_o_default_removal:
@@ -400,48 +358,8 @@ class TestOzoneAOPZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value   : Fixed : Bounds
-                           Oxidant Dosage (mg/L) :  4673.4 : False : (None, None)
-                             Oxidant Flow (kg/s) : 0.50005 : False : (0, None)
-                             Oxidant/Ozone Ratio : 0.50000 :  True : (None, None)
-                     Ozone CT Value ((mg*min)/L) :  1.0000 :  True : (None, None)
-                        Ozone Contact Time (min) :  1.0000 :  True : (None, None)
-                         Ozone Mass Flow (lb/hr) :  9921.9 : False : (0, None)
-                  Ozone Mass Transfer Efficiency : 0.80000 :  True : (None, None)
-                    Ozone Unit Power Demand (kW) :  49609. : False : (0, None)
-                                 Ozone/TOC Ratio :  1.0001 : False : (None, None)
-                Solute Removal [cryptosporidium] : 0.29479 :  True : (0, None)
-                            Solute Removal [eeq] : 0.98943 :  True : (0, None)
-                Solute Removal [giardia_lamblia] : 0.90324 :  True : (0, None)
-                            Solute Removal [toc] : 0.72830 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] : 0.99723 :  True : (0, None)
-                Solute Removal [viruses_enteric] : 0.99723 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet  Treated
-    Volumetric Flowrate                            0.10700  0.10119
-    Mass Concentration H2O                          934.58   988.27
-    Mass Concentration cryptosporidium              9.3458   6.9694
-    Mass Concentration toc                          9.3458   2.6851
-    Mass Concentration giardia_lamblia              18.692   1.9125
-    Mass Concentration eeq                          9.3458  0.10442
-    Mass Concentration total_coliforms_fecal_ecoli  9.3458 0.027425
-    Mass Concentration viruses_enteric              9.3458 0.027425
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
@@ -244,8 +244,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestOzoneAOPZO_w_o_default_removal:
     @pytest.fixture(scope="class")
@@ -444,8 +442,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration viruses_enteric              9.3458 0.027425
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_ozone_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_zo.py
@@ -226,8 +226,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestOzoneZO_w_o_default_removal:
     @pytest.fixture(scope="class")
@@ -391,8 +389,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration viruses_enteric              9.4340 0.027451
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_ozone_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order Ozonation model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -185,46 +185,8 @@ class TestOzoneZO_with_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value   : Fixed : Bounds
-                     Ozone CT Value ((mg*min)/L) :  1.0000 :  True : (None, None)
-                        Ozone Contact Time (min) :  1.0000 :  True : (None, None)
-                         Ozone Mass Flow (lb/hr) :  9921.9 : False : (0, None)
-                  Ozone Mass Transfer Efficiency : 0.80000 :  True : (None, None)
-                    Ozone Unit Power Demand (kW) :  49609. : False : (0, None)
-                Solute Removal [cryptosporidium] : 0.29479 :  True : (0, None)
-                            Solute Removal [eeq] : 0.98943 :  True : (0, None)
-                Solute Removal [giardia_lamblia] : 0.90324 :  True : (0, None)
-                            Solute Removal [toc] : 0.72830 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] : 0.99723 :  True : (0, None)
-                            Solute Removal [tss] :  0.0000 :  True : (0, None)
-                Solute Removal [viruses_enteric] : 0.99723 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet  Treated
-    Volumetric Flowrate                            0.10700  0.10209
-    Mass Concentration H2O                          934.58   979.53
-    Mass Concentration cryptosporidium              9.3458   6.9078
-    Mass Concentration toc                          9.3458   2.6613
-    Mass Concentration giardia_lamblia              9.3458  0.94780
-    Mass Concentration eeq                          9.3458  0.10350
-    Mass Concentration total_coliforms_fecal_ecoli  9.3458 0.027182
-    Mass Concentration viruses_enteric              9.3458 0.027182
-    Mass Concentration tss                          9.3458   9.7953
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestOzoneZO_w_o_default_removal:
@@ -351,44 +313,8 @@ class TestOzoneZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value   : Fixed : Bounds
-                     Ozone CT Value ((mg*min)/L) :  1.0000 :  True : (None, None)
-                        Ozone Contact Time (min) :  1.0000 :  True : (None, None)
-                         Ozone Mass Flow (lb/hr) :  9921.9 : False : (0, None)
-                  Ozone Mass Transfer Efficiency : 0.80000 :  True : (None, None)
-                    Ozone Unit Power Demand (kW) :  49609. : False : (0, None)
-                Solute Removal [cryptosporidium] : 0.29479 :  True : (0, None)
-                            Solute Removal [eeq] : 0.98943 :  True : (0, None)
-                Solute Removal [giardia_lamblia] : 0.90324 :  True : (0, None)
-                            Solute Removal [toc] : 0.72830 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] : 0.99723 :  True : (0, None)
-                Solute Removal [viruses_enteric] : 0.99723 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet  Treated
-    Volumetric Flowrate                            0.10600  0.10109
-    Mass Concentration H2O                          943.40   989.22
-    Mass Concentration cryptosporidium              9.4340   6.9761
-    Mass Concentration toc                          9.4340   2.6877
-    Mass Concentration giardia_lamblia              9.4340  0.95718
-    Mass Concentration eeq                          9.4340  0.10452
-    Mass Concentration total_coliforms_fecal_ecoli  9.4340 0.027451
-    Mass Concentration viruses_enteric              9.4340 0.027451
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
@@ -15,7 +15,6 @@ Tests for zero-order photothermal membrane model
 """
 import pytest
 
-from io import StringIO
 
 from pyomo.environ import (
     Block,
@@ -148,30 +147,8 @@ class TestPhotothermalMembraneZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
-        model.fs.unit.report(ostream=stream)
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
 
-    Variables: 
-
-    Key                       : Value      : Fixed : Bounds
-                Membrane Area : 4.3200e+05 : False : (0, None)
-    Solute Removal [nitrogen] :     0.0000 :  True : (0, None)
-                   Water Flux :     1.0000 :  True : (0, None)
-               Water Recovery :    0.10000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                  Inlet  Treated  Byproduct
-    Volumetric Flowrate         0.12100 0.013000    0.10800
-    Mass Concentration H2O       991.74   923.08     1000.0
-    Mass Concentration nitrogen  8.2645   76.923 9.2593e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
@@ -172,7 +172,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration nitrogen  8.2645   76.923 9.2593e-08
 ====================================================================================
 """
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
@@ -201,8 +201,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestPrimarySeparatorZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -379,8 +377,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo              71.429   89.292 2.8563e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order primary separator model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -170,36 +170,8 @@ class TestPrimarySeparatorZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                             : Value      : Fixed : Bounds
-                 Electricity Demand : 7.0000e-10 : False : (0, None)
-              Electricity Intensity :     0.0000 :  True : (None, None)
-    Solute Removal [oil_and_grease] :    0.90000 :  True : (0, None)
-       Solute Removal [oily_matter] :    0.90000 :  True : (0, None)
-               Solute Removal [tss] :    0.99083 :  True : (0, None)
-                     Water Recovery :    0.99900 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                        Inlet   Treated  Byproduct
-    Volumetric Flowrate               0.013000 0.010199 0.0028008 
-    Mass Concentration H2O              769.23   979.49    3.5704 
-    Mass Concentration oil_and_grease   76.923   9.8047    321.33 
-    Mass Concentration oily_matter      76.923   9.8047    321.33 
-    Mass Concentration tss              76.923  0.89948    353.76 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestPrimarySeparatorZO_w_default_removal:
@@ -345,38 +317,8 @@ class TestPrimarySeparatorZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                             : Value      : Fixed : Bounds
-                 Electricity Demand : 8.0000e-10 : False : (0, None)
-              Electricity Intensity :     0.0000 :  True : (None, None)
-               Solute Removal [foo] :     0.0000 :  True : (0, None)
-    Solute Removal [oil_and_grease] :    0.90000 :  True : (0, None)
-       Solute Removal [oily_matter] :    0.90000 :  True : (0, None)
-               Solute Removal [tss] :    0.99083 :  True : (0, None)
-                     Water Recovery :    0.99900 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                        Inlet   Treated  Byproduct
-    Volumetric Flowrate               0.014000 0.011199  0.0028008
-    Mass Concentration H2O              714.29   892.03     3.5704
-    Mass Concentration oil_and_grease   71.429   8.9292     321.33
-    Mass Concentration oily_matter      71.429   8.9292     321.33
-    Mass Concentration tss              71.429  0.81917     353.76
-    Mass Concentration foo              71.429   89.292 2.8563e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order pump electricity model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -130,32 +130,8 @@ class TestPumpElectricityZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                    : Value  : Fixed : Bounds
-    Applied Pressure (bar) : 2.9881 : False : (0, None)
-          Electricity (kW) : 22.134 : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                  Inlet     Outlet  
-    Volumetric Flowrate          0.060000   0.060000
-    Mass Concentration H2O     0.00016667 0.00016667
-    Mass Concentration bod         166.67     166.67
-    Mass Concentration nitrate     333.33     333.33
-    Mass Concentration tss         500.00     500.00
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
@@ -157,8 +157,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_pump_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order pump model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import Block, ConcreteModel, Constraint, value, Var
 from pyomo.util.check_units import assert_units_consistent
@@ -101,32 +101,8 @@ class TestPumpZOdefault:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value    : Fixed : Bounds
-       Electricity Demand :   184.70 : False : (0, None)
-    Electricity Intensity : 0.051000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                Inlet  Outlet
-    Volumetric Flowrate        1.0060  1.0060
-    Mass Concentration H2O     994.04  994.04
-    Mass Concentration sulfur 0.99404 0.99404
-    Mass Concentration toc     1.9881  1.9881
-    Mass Concentration tss     2.9821  2.9821
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_pump_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_zo.py
@@ -128,8 +128,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 db = Database()
 params = db._get_technology("pump")

--- a/watertap/unit_models/zero_order/tests/test_screen_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_screen_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order screen model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -173,36 +173,8 @@ class TestScreenZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 1.0000e-08 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [bod] :    0.30000 :  True : (0, None)
-     Solute Removal [foo] :     0.0000 :  True : (0, None)
-     Solute Removal [tss] :    0.60000 :  True : (0, None)
-           Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Treated  Byproduct
-    Volumetric Flowrate     1.0030  1.0020   0.0010000
-    Mass Concentration H2O  997.01  997.90      100.00
-    Mass Concentration bod 0.99701 0.69860      300.00
-    Mass Concentration tss 0.99701 0.39920      600.00
-    Mass Concentration foo 0.99701 0.99800  1.0000e-05
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_screen_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_screen_zo.py
@@ -204,8 +204,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order a WWTP with secondary treatment
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -173,36 +173,8 @@ class TestSecondaryTreatmentWWTPZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  6.5520 : False : (0, None)
-               Electricity Intensity : 0.14000 :  True : (None, None)
-                Solute Removal [foo] :  0.0000 :  True : (0, None)
-                Solute Removal [tss] : 0.94231 :  True : (0, None)
-    Solute Removal [viruses_enteric] : 0.89910 :  True : (0, None)
-                      Water Recovery :  1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.013000 0.011159  0.0018414
-    Mass Concentration H2O               769.23   896.17 4.3445e-07
-    Mass Concentration viruses_enteric   76.923   9.0424     488.27
-    Mass Concentration tss               76.923   5.1700     511.73
-    Mass Concentration foo               76.923   89.617 4.3445e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
@@ -204,8 +204,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 db = Database()
 params = db._get_technology("secondary_treatment_wwtp")

--- a/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order sedimentation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -175,36 +175,8 @@ class TestSedimentationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                       : Value      : Fixed : Bounds
-    Basin Surface Area (ft^2) :     30.139 : False : (None, None)
-           Electricity Demand : 8.0000e-10 : False : (0, None)
-        Electricity Intensity :     0.0000 :  True : (None, None)
-      Settling Velocity (m/s) :  0.0050000 :  True : (None, None)
-         Solute Removal [foo] :     0.0000 :  True : (0, None)
-         Solute Removal [tss] :    0.99083 :  True : (0, None)
-               Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.014000 0.011027  0.0029735
-    Mass Concentration H2O   714.29   906.81    0.33631
-    Mass Concentration tss   214.29   2.4960     999.66
-    Mass Concentration foo   71.429   90.690 2.6905e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestSedimentationZO_phosphorus_capture_tss:
@@ -339,36 +311,8 @@ class TestSedimentationZO_phosphorus_capture_tss:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                         : Value      : Fixed : Bounds
-                      Basin Surface Area (ft^2) :     27.986 : False : (None, None)
-                             Electricity Demand : 7.0000e-10 : False : (0, None)
-                          Electricity Intensity :     0.0000 :  True : (None, None)
-    Final mass flow of settled phosphate (kg/s) :    0.44955 : False : (None, None)
-                Phosphorus-Solids Ratio (kg/kg) :    0.15000 :  True : (None, None)
-                        Settling Velocity (m/s) :  0.0050000 :  True : (None, None)
-                           Solute Removal [tss] :    0.99900 :  True : (0, None)
-                                 Water Recovery :    0.98610 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet    Treated  Byproduct
-    Volumetric Flowrate    0.013000 0.0098640 0.0031360 
-    Mass Concentration H2O   769.23    999.70    44.324 
-    Mass Concentration tss   230.77   0.30414    955.68 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestSedimentationZO_phosphorus_capture_phosphates:
@@ -503,36 +447,8 @@ class TestSedimentationZO_phosphorus_capture_phosphates:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                      : Value      : Fixed : Bounds
-                   Basin Surface Area (ft^2) :     27.986 : False : (None, None)
-                          Electricity Demand : 7.0000e-10 : False : (0, None)
-                       Electricity Intensity :     0.0000 :  True : (None, None)
-    Final mass flow of settled solids (kg/s) :     19.980 : False : (None, None)
-             Phosphorus-Solids Ratio (kg/kg) :    0.15000 :  True : (None, None)
-                     Settling Velocity (m/s) :  0.0050000 :  True : (None, None)
-                 Solute Removal [phosphates] :    0.99900 :  True : (0, None)
-                              Water Recovery :    0.98610 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                    Inlet    Treated  Byproduct
-    Volumetric Flowrate           0.013000 0.0098640 0.0031360 
-    Mass Concentration H2O          769.23    999.70    44.324 
-    Mass Concentration phosphates   230.77   0.30414    955.68 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
@@ -206,8 +206,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestSedimentationZO_phosphorus_capture_tss:
     @pytest.fixture(scope="class")
@@ -372,8 +370,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestSedimentationZO_phosphorus_capture_phosphates:
     @pytest.fixture(scope="class")
@@ -537,8 +533,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration phosphates   230.77   0.30414    955.68 
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order settling pond model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -148,32 +148,8 @@ class TestSettlingPondZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [tss] :    0.99083 :  True : (0, None)
-           Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.011000 0.010008 0.00099183
-    Mass Concentration H2O   909.09   999.08     1.0082
-    Mass Concentration tss   90.909  0.91665     998.99
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestSettlingPondZO_w_default_removal:
@@ -297,34 +273,8 @@ class TestSettlingPondZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 8.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [foo] :     0.0000 :  True : (0, None)
-     Solute Removal [tss] :    0.99083 :  True : (0, None)
-           Water Recovery :    0.99990 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.012000 0.011008 0.00099183
-    Mass Concentration H2O   833.33   908.33     1.0082
-    Mass Concentration tss   83.333  0.83338     998.99
-    Mass Concentration foo   83.333   90.842 8.0659e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
@@ -175,8 +175,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestSettlingPondZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -327,8 +325,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo   83.333   90.842 8.0659e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order sludge tank model.
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -204,40 +204,8 @@ class TestSludgeTankZO_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                      : Value      : Fixed : Bounds
-          Electricity Demand : 8.0000e-10 : False : (0, None)
-       Electricity Intensity :     0.0000 :  True : (None, None)
-        Solute Removal [eeq] :     0.0000 :  True : (0, None)
-    Solute Removal [nitrate] :     0.0000 :  True : (0, None)
-        Solute Removal [tds] :     0.0000 :  True : (0, None)
-        Solute Removal [toc] :     0.0000 :  True : (0, None)
-        Solute Removal [tss] :    0.99000 :  True : (0, None)
-              Water Recovery :    0.99999 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet   Treated  Byproduct
-    Volumetric Flowrate        0.034130 0.017300   0.016830
-    Mass Concentration H2O       293.00   578.03  0.0059418
-    Mass Concentration toc       87.899   173.41 4.7534e-08
-    Mass Concentration tds       2.9300   5.7804 4.7534e-08
-    Mass Concentration eeq      0.87899   1.7341 4.7534e-08
-    Mass Concentration nitrate   117.20   231.22 4.7534e-08
-    Mass Concentration tss       498.10   9.8266     999.99
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestSludgeTankZO_w_o_default_removal:
@@ -362,32 +330,8 @@ class TestSludgeTankZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-     Solute Removal [tss] :    0.99000 :  True : (0, None)
-           Water Recovery :    0.99999 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate    0.027000 0.010170  0.016830 
-    Mass Concentration H2O   370.37   983.28 0.0059418 
-    Mass Concentration tss   629.63   16.716    999.99 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
@@ -239,8 +239,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestSludgeTankZO_w_o_default_removal:
     @pytest.fixture(scope="class")
@@ -390,8 +388,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration tss   629.63   16.716    999.99 
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_smp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_smp_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order smp model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -112,30 +112,8 @@ class TestSMPZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate     1.0010  1.0010
-    Mass Concentration H2O  999.00  999.00
-    Mass Concentration foo 0.99900 0.99900
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_smp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_smp_zo.py
@@ -137,8 +137,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
@@ -142,8 +142,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order static mixer model.
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -114,33 +114,8 @@ class TestStaticMixerZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                   Inlet   Outlet 
-    Volumetric Flowrate          0.049103 0.049103
-    Mass Concentration H2O         855.34   855.34
-    Mass Concentration calcium     61.096   61.096
-    Mass Concentration magnesium   2.0365   2.0365
-    Mass Concentration foo       0.061096 0.061096
-    Mass Concentration sulfate     81.461   81.461
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
@@ -149,8 +149,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 db = Database()
 params = db._get_technology("storage_tank")

--- a/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order storage tank model.
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -119,35 +119,8 @@ class TestStorageTankZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-     Storage Time (hr) : 24.000 :  True : (None, None)
-    Surge Capacity (%) : 0.0000 :  True : (None, None)
-      Tank Volume (m3) : 45285. : False : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet   Outlet 
-    Volumetric Flowrate         0.52413  0.52413
-    Mass Concentration H2O       953.96   953.96
-    Mass Concentration toc       5.7238   5.7238
-    Mass Concentration tds      0.19079  0.19079
-    Mass Concentration eeq     0.057238 0.057238
-    Mass Concentration nitrate   7.6317   7.6317
-    Mass Concentration tss       32.435   32.435
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_surface_discharge.py
+++ b/watertap/unit_models/zero_order/tests/test_surface_discharge.py
@@ -15,7 +15,7 @@ Tests for zero-order surface discharge model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -133,34 +133,8 @@ class TestSurfaceDischargeZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 60.174 : False : (0, None)
-         Pipe Diameter : 8.0000 :  True : (None, None)
-         Pipe Distance : 0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet  Outlet
-    Volumetric Flowrate        0.16330 0.16330
-    Mass Concentration H2O      734.84  734.84
-    Mass Concentration toc      6.1237  6.1237
-    Mass Concentration nitrate  12.247  12.247
-    Mass Concentration sulfate  1.8371  1.8371
-    Mass Concentration bar      244.95  244.95
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestSurfaceDischargeZOsubtype:
@@ -261,34 +235,8 @@ class TestSurfaceDischargeZOsubtype:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 60.174 : False : (0, None)
-         Pipe Diameter : 8.0000 :  True : (None, None)
-         Pipe Distance : 70.000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                 Inlet  Outlet
-    Volumetric Flowrate        0.16330 0.16330
-    Mass Concentration H2O      734.84  734.84
-    Mass Concentration toc      6.1237  6.1237
-    Mass Concentration nitrate  12.247  12.247
-    Mass Concentration sulfate  1.8371  1.8371
-    Mass Concentration bar      244.95  244.95
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_surface_discharge.py
+++ b/watertap/unit_models/zero_order/tests/test_surface_discharge.py
@@ -162,8 +162,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestSurfaceDischargeZOsubtype:
     @pytest.fixture(scope="class")
@@ -291,8 +289,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration bar      244.95  244.95
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
@@ -132,8 +132,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order seawater onshore intake model.
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -108,29 +108,8 @@ class TestSWOnshoreIntakeZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 3685.2 : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Outlet 
-    Volumetric Flowrate      10.001   10.001
-    Mass Concentration H2O   999.90   999.90
-    Mass Concentration foo 0.099990 0.099990
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order tramp oil tank model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import Block, ConcreteModel, Constraint, value, Var
 from pyomo.util.check_units import assert_units_consistent
@@ -95,30 +95,8 @@ class TestTrampOilZOdefault:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand : 7.0000e-10 : False : (0, None)
-    Electricity Intensity :     0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet    Outlet 
-    Volumetric Flowrate                0.010000  0.010000
-    Mass Concentration H2O            0.0010000 0.0010000
-    Mass Concentration oil_and_grease    1000.0    1000.0
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
@@ -120,8 +120,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output == stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
@@ -225,8 +225,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestTriMediaFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -423,8 +421,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               62.500   79.051 2.3881e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order tri media filtration model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -190,40 +190,8 @@ class TestTriMediaFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand :   0.024300 : False : (0, None)
-               Electricity Intensity : 0.00045000 :  True : (None, None)
-                Solute Removal [eeq] :    0.20000 :  True : (0, None)
-            Solute Removal [nitrate] :    0.80000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.95000 :  True : (0, None)
-                      Water Recovery :    0.90000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.015000 0.011650 0.0033500 
-    Mass Concentration H2O               666.67   772.53    298.51 
-    Mass Concentration eeq               66.667   68.670    59.701 
-    Mass Concentration nonvolatile_toc   66.667   68.670    59.701 
-    Mass Concentration toc               66.667   68.670    59.701 
-    Mass Concentration nitrate           66.667   17.167    238.81 
-    Mass Concentration tss               66.667   4.2918    283.58 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestTriMediaFiltrationZO_w_default_removal:
@@ -385,42 +353,8 @@ class TestTriMediaFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value      : Fixed : Bounds
-                  Electricity Demand :   0.025920 : False : (0, None)
-               Electricity Intensity : 0.00045000 :  True : (None, None)
-                Solute Removal [eeq] :    0.20000 :  True : (0, None)
-                Solute Removal [foo] :     0.0000 :  True : (0, None)
-            Solute Removal [nitrate] :    0.80000 :  True : (0, None)
-    Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                Solute Removal [toc] :    0.20000 :  True : (0, None)
-                Solute Removal [tss] :    0.95000 :  True : (0, None)
-                      Water Recovery :    0.90000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet   Treated  Byproduct
-    Volumetric Flowrate                0.016000 0.012650  0.0033500
-    Mass Concentration H2O               625.00   711.46     298.51
-    Mass Concentration eeq               62.500   63.241     59.701
-    Mass Concentration nonvolatile_toc   62.500   63.241     59.701
-    Mass Concentration toc               62.500   63.241     59.701
-    Mass Concentration nitrate           62.500   15.810     238.81
-    Mass Concentration tss               62.500   3.9526     283.58
-    Mass Concentration foo               62.500   79.051 2.3881e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order ultra filtration model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -180,38 +180,8 @@ class TestUltraFiltrationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  11.660 : False : (0, None)
-               Electricity Intensity : 0.23134 :  True : (None, None)
-    Solute Removal [cryptosporidium] : 0.99990 :  True : (0, None)
-                Solute Removal [eeq] : 0.30000 :  True : (0, None)
-                Solute Removal [toc] : 0.30000 :  True : (0, None)
-                Solute Removal [tss] : 0.97000 :  True : (0, None)
-                      Water Recovery : 0.95000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet    Treated  Byproduct
-    Volumetric Flowrate                0.014000  0.010930 0.0030699 
-    Mass Concentration H2O               714.29    869.16    162.87 
-    Mass Concentration eeq               71.429    64.043    97.723 
-    Mass Concentration toc               71.429    64.043    97.723 
-    Mass Concentration tss               71.429    2.7447    315.97 
-    Mass Concentration cryptosporidium   71.429 0.0091490    325.71 
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestUltraFiltrationZO_w_default_removal:
@@ -367,40 +337,8 @@ class TestUltraFiltrationZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                              : Value   : Fixed : Bounds
-                  Electricity Demand :  12.493 : False : (0, None)
-               Electricity Intensity : 0.23134 :  True : (None, None)
-    Solute Removal [cryptosporidium] : 0.99990 :  True : (0, None)
-                Solute Removal [eeq] : 0.30000 :  True : (0, None)
-                Solute Removal [foo] :  0.0000 :  True : (0, None)
-                Solute Removal [toc] : 0.30000 :  True : (0, None)
-                Solute Removal [tss] : 0.97000 :  True : (0, None)
-                      Water Recovery : 0.95000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                         Inlet    Treated  Byproduct
-    Volumetric Flowrate                0.015000  0.011930  0.0030699
-    Mass Concentration H2O               666.67    796.31     162.87
-    Mass Concentration eeq               66.667    58.675     97.723
-    Mass Concentration toc               66.667    58.675     97.723
-    Mass Concentration tss               66.667    2.5146     315.97
-    Mass Concentration cryptosporidium   66.667 0.0083822     325.71
-    Mass Concentration foo               66.667    83.822 2.6059e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
@@ -213,8 +213,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestUltraFiltrationZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -403,8 +401,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo               66.667    83.822 2.6059e-07
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order UV-AOP model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     check_optimal_termination,
@@ -161,43 +161,8 @@ class TestUVAOPZO_with_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value    : Fixed : Bounds
-                              Electricity Demand :   3605.0 : False : (0, None)
-                           Electricity Intensity :  0.10000 :  True : (None, None)
-                           Oxidant Dosage (mg/L) :   5.0000 :  True : (None, None)
-                             Oxidant Flow (kg/s) : 0.050070 : False : (0, None)
-                Solute Removal [cryptosporidium] :  0.99999 :  True : (0, None)
-                            Solute Removal [toc] :  0.17461 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] :  0.99999 :  True : (0, None)
-                            Solute Removal [tss] :   0.0000 :  True : (0, None)
-                Solute Removal [viruses_enteric] :  0.96540 :  True : (0, None)
-          UV Reduced Equivalent Dosage (mJ/cm^2) :   100.00 :  True : (None, None)
-                        UV Transmittance of Feed :  0.90000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet    Treated 
-    Volumetric Flowrate                              10.014     10.005
-    Mass Concentration H2O                           998.60     999.53
-    Mass Concentration viruses_enteric             0.099860  0.0034581
-    Mass Concentration tss                          0.29958    0.29986
-    Mass Concentration toc                          0.19972    0.16500
-    Mass Concentration cryptosporidium              0.49930 5.4974e-06
-    Mass Concentration total_coliforms_fecal_ecoli  0.29958 1.7992e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestUVAOPZO_subtype_no_default_removal:
@@ -332,41 +297,8 @@ class TestUVAOPZO_subtype_no_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value    : Fixed : Bounds
-                              Electricity Demand :   3604.0 : False : (0, None)
-                           Electricity Intensity :  0.10000 :  True : (None, None)
-                           Oxidant Dosage (mg/L) :   5.0000 :  True : (None, None)
-                             Oxidant Flow (kg/s) : 0.050055 : False : (0, None)
-                Solute Removal [cryptosporidium] :  0.99999 :  True : (0, None)
-                            Solute Removal [toc] :  0.17461 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] :  0.99999 :  True : (0, None)
-                Solute Removal [viruses_enteric] :  0.96540 :  True : (0, None)
-          UV Reduced Equivalent Dosage (mJ/cm^2) :   100.00 :  True : (None, None)
-                        UV Transmittance of Feed :  0.90000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet    Treated 
-    Volumetric Flowrate                              10.011     10.002
-    Mass Concentration H2O                           998.90     999.83
-    Mass Concentration viruses_enteric             0.099890  0.0034591
-    Mass Concentration toc                          0.19978    0.16505
-    Mass Concentration cryptosporidium              0.49945 5.4991e-06
-    Mass Concentration total_coliforms_fecal_ecoli  0.29967 1.7997e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
@@ -199,8 +199,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestUVAOPZO_subtype_no_default_removal:
     @pytest.fixture(scope="class")
@@ -369,8 +367,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration total_coliforms_fecal_ecoli  0.29967 1.7997e-06
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_uv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_zo.py
@@ -185,8 +185,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestUVZO_w_o_default_removal:
     @pytest.fixture(scope="class")
@@ -335,8 +333,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration total_coliforms_fecal_ecoli  0.29967 1.7997e-06
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_uv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order UV model
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     check_optimal_termination,
@@ -149,41 +149,8 @@ class TestUVZO_with_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value    : Fixed : Bounds
-                              Electricity Demand :   3605.0 : False : (0, None)
-                           Electricity Intensity :  0.10000 :  True : (None, None)
-                Solute Removal [cryptosporidium] :  0.99999 :  True : (0, None)
-                            Solute Removal [toc] : 0.054565 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] :  0.99999 :  True : (0, None)
-                            Solute Removal [tss] :   0.0000 :  True : (0, None)
-                Solute Removal [viruses_enteric] :  0.96540 :  True : (0, None)
-          UV Reduced Equivalent Dosage (mJ/cm^2) :   100.00 :  True : (None, None)
-                        UV Transmittance of Feed :  0.90000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet    Treated 
-    Volumetric Flowrate                              10.014     10.005
-    Mass Concentration H2O                           998.60     999.51
-    Mass Concentration viruses_enteric             0.099860  0.0034580
-    Mass Concentration tss                          0.29958    0.29985
-    Mass Concentration toc                          0.19972    0.18899
-    Mass Concentration cryptosporidium              0.49930 5.4973e-06
-    Mass Concentration total_coliforms_fecal_ecoli  0.29958 1.7991e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestUVZO_w_o_default_removal:
@@ -300,39 +267,8 @@ class TestUVZO_w_o_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                          : Value    : Fixed : Bounds
-                              Electricity Demand :   3604.0 : False : (0, None)
-                           Electricity Intensity :  0.10000 :  True : (None, None)
-                Solute Removal [cryptosporidium] :  0.99999 :  True : (0, None)
-                            Solute Removal [toc] : 0.054565 :  True : (0, None)
-    Solute Removal [total_coliforms_fecal_ecoli] :  0.99999 :  True : (0, None)
-                Solute Removal [viruses_enteric] :  0.96540 :  True : (0, None)
-          UV Reduced Equivalent Dosage (mJ/cm^2) :   100.00 :  True : (None, None)
-                        UV Transmittance of Feed :  0.90000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                     Inlet    Treated 
-    Volumetric Flowrate                              10.011     10.002
-    Mass Concentration H2O                           998.90     999.81
-    Mass Concentration viruses_enteric             0.099890  0.0034590
-    Mass Concentration toc                          0.19978    0.18905
-    Mass Concentration cryptosporidium              0.49945 5.4989e-06
-    Mass Concentration total_coliforms_fecal_ecoli  0.29967 1.7997e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order VFA recovery model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -147,32 +147,8 @@ class TestVFARecoveryZO_no_default:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                   : Value      : Fixed : Bounds
-                       Electricity Demand : 8.0000e-10 : False : (0, None)
-                    Electricity Intensity :     0.0000 :  True : (None, None)
-    Solute Removal [nonbiodegradable_cod] :    0.50000 :  True : (0, None)
-                           Water Recovery :     1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                              Inlet   Treated  Byproduct
-    Volumetric Flowrate                     0.011000 0.010500 0.00050000
-    Mass Concentration H2O                    909.09   952.38 1.6000e-06
-    Mass Concentration nonbiodegradable_cod   90.909   47.619     1000.0
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestVFARecoveryZO_w_default_removal:
@@ -298,34 +274,8 @@ class TestVFARecoveryZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                   : Value      : Fixed : Bounds
-                       Electricity Demand : 8.0000e-10 : False : (0, None)
-                    Electricity Intensity :     0.0000 :  True : (None, None)
-                     Solute Removal [foo] :     0.0000 :  True : (0, None)
-    Solute Removal [nonbiodegradable_cod] :    0.50000 :  True : (0, None)
-                           Water Recovery :     1.0000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                              Inlet   Treated  Byproduct
-    Volumetric Flowrate                     0.012000 0.011500 0.00050000
-    Mass Concentration H2O                    833.33   869.57 1.6000e-06
-    Mass Concentration nonbiodegradable_cod   83.333   43.478     1000.0
-    Mass Concentration foo                    83.333   86.957 1.6000e-06
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
@@ -174,8 +174,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestVFARecoveryZO_w_default_removal:
     @pytest.fixture(scope="class")
@@ -328,8 +326,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo                    83.333   86.957 1.6000e-06
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_waiv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_waiv_zo.py
@@ -188,8 +188,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_waiv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_waiv_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order wind-aided intensified evaporation model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -159,34 +159,8 @@ class TestWAIVZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                   : Value      : Fixed : Bounds
-       Electricity Demand :     2344.7 : False : (0, None)
-    Electricity Intensity :    0.65000 :  True : (None, None)
-     Solute Removal [foo] :     0.0000 :  True : (0, None)
-     Solute Removal [tds] :     0.0000 :  True : (0, None)
-           Water Recovery : 0.00010000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet   Treated  Byproduct
-    Volumetric Flowrate     1.0020 0.0021000    0.99990
-    Mass Concentration H2O  998.00    47.619     1000.0
-    Mass Concentration tds 0.99800    476.19 1.0001e-08
-    Mass Concentration foo 0.99800    476.19 1.0001e-08
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order walnut shell filter model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     Block,
     ConcreteModel,
@@ -229,44 +229,8 @@ class TestWalnutShellFilterZO_w_default_removal:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                                      : Value      : Fixed : Bounds
-                          Electricity Demand : 1.0000e-08 : False : (0, None)
-                       Electricity Intensity :     0.0000 :  True : (None, None)
-                   Solute Removal [chloride] :    0.95000 :  True : (0, None)
-    Solute Removal [electrical_conductivity] :    0.95000 :  True : (0, None)
-                        Solute Removal [foo] :     0.0000 :  True : (0, None)
-            Solute Removal [nonvolatile_toc] :    0.20000 :  True : (0, None)
-                     Solute Removal [sodium] :    0.95000 :  True : (0, None)
-                        Solute Removal [tds] :    0.90000 :  True : (0, None)
-                        Solute Removal [tss] :    0.97000 :  True : (0, None)
-                              Water Recovery :    0.99000 :  True : (1e-08, 1.0000001)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                                 Inlet  Treated  Byproduct
-    Volumetric Flowrate                         1.0070  0.99208   0.014920
-    Mass Concentration H2O                      993.05   997.90     670.24
-    Mass Concentration nonvolatile_toc         0.99305  0.80639     13.405
-    Mass Concentration tds                     0.99305  0.10080     60.322
-    Mass Concentration chloride                0.99305 0.050399     63.673
-    Mass Concentration electrical_conductivity 0.99305 0.050399     63.673
-    Mass Concentration sodium                  0.99305 0.050399     63.673
-    Mass Concentration tss                     0.99305 0.030239     65.013
-    Mass Concentration foo                     0.99305   1.0080 6.7024e-07
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 def test_costing():

--- a/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
@@ -268,8 +268,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 def test_costing():
     m = ConcreteModel()

--- a/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
@@ -143,8 +143,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestWaterPumpingStationZO_without_fix_pump_power_config:
     @pytest.fixture(scope="class")
@@ -253,8 +251,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration foo 0.99900 0.99900
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
@@ -14,7 +14,7 @@
 Tests for zero-order water pumping station model.
 """
 import pytest
-from io import StringIO
+
 
 from pyomo.environ import (
     Block,
@@ -119,29 +119,8 @@ class TestWaterPumpingStationZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 93.210 :  True : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate     1.0010  1.0010
-    Mass Concentration H2O  999.00  999.00
-    Mass Concentration foo 0.99900 0.99900
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestWaterPumpingStationZO_without_fix_pump_power_config:
@@ -228,29 +207,8 @@ class TestWaterPumpingStationZO_without_fix_pump_power_config:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                : Value  : Fixed : Bounds
-    Electricity Demand : 93.210 : False : (0, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                             Inlet  Outlet
-    Volumetric Flowrate     1.0010  1.0010
-    Mass Concentration H2O  999.00  999.00
-    Mass Concentration foo 0.99900 0.99900
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_well_field_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_well_field_zo.py
@@ -15,7 +15,7 @@ Tests for zero-order well field model
 """
 import pytest
 
-from io import StringIO
+
 from pyomo.environ import (
     ConcreteModel,
     Constraint,
@@ -137,35 +137,8 @@ class TestWellFieldZO:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                    : Value  : Fixed : Bounds
-        Electricity Demand : 60.174 : False : (0, None)
-    Pipe Diameter (inches) : 8.0000 :  True : (None, None)
-     Pipe Distance (miles) : 0.0000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                  Inlet    Outlet 
-    Volumetric Flowrate          0.16330   0.16330
-    Mass Concentration H2O        734.84    734.84
-    Mass Concentration toc        6.1237    6.1237
-    Mass Concentration nitrate    12.247    12.247
-    Mass Concentration sulfate    1.8371    1.8371
-    Mass Concentration bar        244.95    244.95
-    Mass Concentration crux    0.0030618 0.0030618
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 class TestWellFieldZOsubtype:
@@ -268,35 +241,8 @@ class TestWellFieldZOsubtype:
 
     @pytest.mark.component
     def test_report(self, model):
-        stream = StringIO()
 
-        model.fs.unit.report(ostream=stream)
-
-        output = """
-====================================================================================
-Unit : fs.unit                                                             Time: 0.0
-------------------------------------------------------------------------------------
-    Unit Performance
-
-    Variables: 
-
-    Key                    : Value  : Fixed : Bounds
-        Electricity Demand : 60.174 : False : (0, None)
-    Pipe Diameter (inches) : 8.0000 :  True : (None, None)
-     Pipe Distance (miles) : 70.000 :  True : (None, None)
-
-------------------------------------------------------------------------------------
-    Stream Table
-                                  Inlet    Outlet 
-    Volumetric Flowrate          0.16330   0.16330
-    Mass Concentration H2O        734.84    734.84
-    Mass Concentration toc        6.1237    6.1237
-    Mass Concentration nitrate    12.247    12.247
-    Mass Concentration sulfate    1.8371    1.8371
-    Mass Concentration bar        244.95    244.95
-    Mass Concentration crux    0.0030618 0.0030618
-====================================================================================
-"""
+        model.fs.unit.report()
 
 
 db = Database()

--- a/watertap/unit_models/zero_order/tests/test_well_field_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_well_field_zo.py
@@ -167,8 +167,6 @@ Unit : fs.unit                                                             Time:
 ====================================================================================
 """
 
-        assert output in stream.getvalue()
-
 
 class TestWellFieldZOsubtype:
     @pytest.fixture(scope="class")
@@ -299,8 +297,6 @@ Unit : fs.unit                                                             Time:
     Mass Concentration crux    0.0030618 0.0030618
 ====================================================================================
 """
-
-        assert output in stream.getvalue()
 
 
 db = Database()


### PR DESCRIPTION
## Fixes/Addresses: #521

## Summary/Motivation:
Testing the output of report has been a pain point for our tests. Needed for #520.

## Changes proposed in this PR:
- Remove testing the output of `report`
- Replace with testing values directly, where not already tested

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
