### PR TITLE
Increase tolerance for Codecov patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
     patch:
       default:
         target: auto
-        threshold: 0%
+        threshold: 10%
     project:
       default:
         target: auto


### PR DESCRIPTION
## Resolves: #514 

## Summary/Motivation:

- Tolerance for Codecov patch check was set to 0%, resulting in too many false positive and/or frustrating DX

## Changes proposed in this PR:
- Set tolerance for patch check to 10%, i.e. the check will pass as long as the patch coverage is within 10% of the `auto` target (which is the project coverage)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
