### PR TITLE
add ref for zo costing package in unit files

### DIFF
--- a/docs/technical_reference/unit_models/zero_order_unit_models/CANDOP_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/CANDOP_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_CANDOP method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.CANDOP_zo;CANDOP_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/aeration_basin_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/aeration_basin_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.aeration_basin_zo;aeration_basin_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/air_flotation_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/air_flotation_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.air_flotation_zo;air_flotation_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/anaerobic_digestion_oxidation_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/anaerobic_digestion_oxidation_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.anaerobic_digestion_oxidation_zo;anaerobic_digestion_oxidation_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/anaerobic_mbr_mec_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/anaerobic_mbr_mec_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the False method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.anaerobic_mbr_mec_zo;anaerobic_mbr_mec_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/automate_rst_file_wt3.py
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/automate_rst_file_wt3.py
@@ -74,7 +74,9 @@ for i, u in enumerate(unit_name_list):
         f.write("-" * len("Costing Method"))
         f.write(f"\n{list[count]}")
         count += 1
-        f.write(f"\nSee documentation for the zero-order costing package.\n")
+        f.write(
+            f"\nSee documentation for the :ref:`zero-order costing package<zero_order_costing>`.\n"
+        )
         f.write("\n.. index::")
         f.write(f"\n{list[count]}\n")
         count += 1

--- a/docs/technical_reference/unit_models/zero_order_unit_models/backwash_solids_handling_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/backwash_solids_handling_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.backwash_solids_handling_zo;backwash_solids_handling_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/bio_active_filtration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/bio_active_filtration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.bio_active_filtration_zo;bio_active_filtration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/bioreactor_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/bioreactor_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.bioreactor_zo;bioreactor_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/blending_reservoir_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/blending_reservoir_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.blending_reservoir_zo;blending_reservoir_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/brine_concentrator_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/brine_concentrator_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_brine_concentrator method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.brine_concentrator_zo;brine_concentrator_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/buffer_tank_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/buffer_tank_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.buffer_tank_zo;buffer_tank_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/cartridge_filtration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/cartridge_filtration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.cartridge_filtration_zo;cartridge_filtration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/chemical_addition_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/chemical_addition_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_chemical_addition method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.chemical_addition_zo;chemical_addition_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/chlorination_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/chlorination_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_chlorination method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.chlorination_zo;chlorination_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/clarifier_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/clarifier_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.clarifier_zo;clarifier_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/co2_addition_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/co2_addition_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.co2_addition_zo;co2_addition_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/coag_and_floc_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/coag_and_floc_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_coag_and_floc method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.coag_and_floc_zo;coag_and_floc_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/cofermentation_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/cofermentation_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the False method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.cofermentation_zo;cofermentation_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/constructed_wetlands_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/constructed_wetlands_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the False method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.constructed_wetlands_zo;constructed_wetlands_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/conventional_activated_sludge_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/conventional_activated_sludge_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.conventional_activated_sludge_zo;conventional_activated_sludge_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/cooling_supply_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/cooling_supply_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.cooling_supply_zo;cooling_supply_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/cooling_tower_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/cooling_tower_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.cooling_tower_zo;cooling_tower_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/decarbonator_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/decarbonator_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.decarbonator_zo;decarbonator_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/deep_well_injection_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/deep_well_injection_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_deep_well_injection method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.deep_well_injection_zo;deep_well_injection_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/dissolved_air_flotation_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/dissolved_air_flotation_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.dissolved_air_flotation_zo;dissolved_air_flotation_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/dmbr_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/dmbr_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_dmbr method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.dmbr_zo;dmbr_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/dual_media_filtration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/dual_media_filtration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.dual_media_filtration_zo;dual_media_filtration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/electrochemical_nutrient_removal_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/electrochemical_nutrient_removal_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_electrochemical_nutrient_removal method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.electrochemical_nutrient_removal_zo;electrochemical_nutrient_removal_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/electrodialysis_reversal_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/electrodialysis_reversal_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.electrodialysis_reversal_zo;electrodialysis_reversal_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/energy_recovery_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/energy_recovery_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.energy_recovery_zo;energy_recovery_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/evaporation_pond_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/evaporation_pond_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_evaporation_pond method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.evaporation_pond_zo;evaporation_pond_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/feed_water_tank_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/feed_water_tank_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.feed_water_tank_zo;feed_water_tank_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/feed_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/feed_zo.rst
@@ -13,7 +13,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the False method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.feed_zo;feed_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/filter_press_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/filter_press_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_filter_press method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.filter_press_zo;filter_press_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/fixed_bed_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/fixed_bed_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_fixed_bed method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.fixed_bed_zo;fixed_bed_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/gac_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/gac_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_gac method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.gac_zo;gac_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/gas_sparged_membrane_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/gas_sparged_membrane_zo.rst
@@ -13,7 +13,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the False method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.gas_sparged_membrane_zo;gas_sparged_membrane_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/injection_well_disposal_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/injection_well_disposal_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.injection_well_disposal_zo;injection_well_disposal_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/intrusion_mitigation_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/intrusion_mitigation_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.intrusion_mitigation_zo;intrusion_mitigation_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/ion_exchange_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/ion_exchange_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_ion_exchange method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.ion_exchange_zo;ion_exchange_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/iron_and_manganese_removal_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/iron_and_manganese_removal_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_iron_and_manganese_removal method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.iron_and_manganese_removal_zo;iron_and_manganese_removal_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/landfill_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/landfill_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_landfill method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.landfill_zo;landfill_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/mabr_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/mabr_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_mabr method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.mabr_zo;mabr_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/mbr_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/mbr_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.mbr_zo;mbr_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/media_filtration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/media_filtration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.media_filtration_zo;media_filtration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/metab_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/metab_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_metab method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.metab_zo;metab_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/microfiltration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/microfiltration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.microfiltration_zo;microfiltration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/microscreen_filtration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/microscreen_filtration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.microscreen_filtration_zo;microscreen_filtration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/municipal_drinking_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/municipal_drinking_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.municipal_drinking_zo;municipal_drinking_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/municipal_wwtp_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/municipal_wwtp_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.municipal_wwtp_zo;municipal_wwtp_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/nanofiltration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/nanofiltration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_nanofiltration method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.nanofiltration_zo;nanofiltration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/ozone_aop_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/ozone_aop_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_ozonation_aop method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.ozone_aop_zo;ozone_aop_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/ozone_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/ozone_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_ozonation method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.ozone_zo;ozone_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/photothermal_membrane_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/photothermal_membrane_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_photothermal_membrane method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.photothermal_membrane_zo;photothermal_membrane_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/primary_separator_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/primary_separator_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.primary_separator_zo;primary_separator_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/pump_electricity_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/pump_electricity_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_pump_electricity method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.pump_electricity_zo;pump_electricity_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/pump_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/pump_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.pump_zo;pump_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/screen_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/screen_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.screen_zo;screen_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/secondary_treatment_wwtp_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/secondary_treatment_wwtp_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.secondary_treatment_wwtp_zo;secondary_treatment_wwtp_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/sedimentation_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/sedimentation_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_sedimentation method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.sedimentation_zo;sedimentation_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/settling_pond_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/settling_pond_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.settling_pond_zo;settling_pond_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/sludge_tank_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/sludge_tank_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.sludge_tank_zo;sludge_tank_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/smp_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/smp_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.smp_zo;smp_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/static_mixer_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/static_mixer_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.static_mixer_zo;static_mixer_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/storage_tank_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/storage_tank_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_storage_tank method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.storage_tank_zo;storage_tank_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/surface_discharge_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/surface_discharge_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_surface_discharge method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.surface_discharge_zo;surface_discharge_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/sw_onshore_intake_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/sw_onshore_intake_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.sw_onshore_intake_zo;sw_onshore_intake_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/tramp_oil_tank_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/tramp_oil_tank_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.tramp_oil_tank_zo;tramp_oil_tank_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/tri_media_filtration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/tri_media_filtration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.tri_media_filtration_zo;tri_media_filtration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/ultra_filtration_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/ultra_filtration_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.ultra_filtration_zo;ultra_filtration_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/uv_aop_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/uv_aop_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_uv_aop method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.uv_aop_zo;uv_aop_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/uv_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/uv_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_uv method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.uv_zo;uv_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/vfa_recovery_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/vfa_recovery_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the False method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.vfa_recovery_zo;vfa_recovery_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/waiv_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/waiv_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.waiv_zo;waiv_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/walnut_shell_filter_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/walnut_shell_filter_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.walnut_shell_filter_zo;walnut_shell_filter_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/water_pumping_station_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/water_pumping_station_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_power_law_flow method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.water_pumping_station_zo;water_pumping_station_zo

--- a/docs/technical_reference/unit_models/zero_order_unit_models/well_field_zo.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/well_field_zo.rst
@@ -14,7 +14,7 @@ See documentation for :ref:`Helper Methods for Electricity Demand<electricity_me
 Costing Method
 --------------
 Costing is calculated using the cost_well_field method in the zero-order costing package.
-See documentation for the zero-order costing package.
+See documentation for the :ref:`zero-order costing package<zero_order_costing>`.
 
 .. index::
    pair: watertap.unit_models.zero_order.well_field_zo;well_field_zo


### PR DESCRIPTION
## Fixes/Resolves:

## Summary/Motivation:
This PR simply adds a ref directive in all zero-order unit model .rst files to link to the zero order costing package .rst file.

## Changes proposed in this PR:
- add appropriate ref directive in automate script 
-  run automate script again

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
