### PR TITLE
Update idaes-pse requirement to 2.0.0a2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,14 +36,14 @@ for active use by water treatment researchers and engineers.""".replace(
 
 
 SPECIAL_DEPENDENCIES_FOR_RELEASE = [
-    "idaes-pse>=1.12.0",  # from PyPI
+    "idaes-pse>=2.0.0a2",  # from PyPI
 ]
 
 SPECIAL_DEPENDENCIES_FOR_PRERELEASE = [
     # update with a tag from the nawi-hub/idaes-pse
     # when a version of IDAES newer than the latest stable release from PyPI
     # will become needed for the watertap development
-    "idaes-pse[prerelease] @ https://github.com/watertap-org/idaes-pse/archive/2.0.0.dev0.watertap.2022.05.18.zip"
+    "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/2.0.0a2.zip"
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.


### PR DESCRIPTION
## Summary/Motivation:

- Check if WaterTAP is compatible with latest alpha version of `idaes-pse`
  - Currently from GitHub archive since it's not yet on PyPI


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
