### PR TITLE
Add partial support for parallel unit costing

### DIFF
--- a/watertap/core/tests/test_zero_order_costing.py
+++ b/watertap/core/tests/test_zero_order_costing.py
@@ -373,7 +373,10 @@ class TestWorkflow:
         assert degrees_of_freedom(model.fs.unit2) == 0
 
         model.fs.unit2.costing = UnitModelCostingBlock(
-            default={"flowsheet_costing_block": model.fs.costing}
+            default={
+                "flowsheet_costing_block": model.fs.costing,
+                "costing_method_arguments": {"number_of_parallel_units": 2},
+            }
         )
 
         assert isinstance(model.fs.costing.chemical_addition, Block)
@@ -491,7 +494,7 @@ class TestWorkflow:
     @pytest.mark.component
     def test_solution(self, model):
         # Note all dollar values are in millions of dollars
-        assert pytest.approx(630.031, rel=1e-5) == value(
+        assert pytest.approx(630.596, rel=1e-5) == value(
             model.fs.costing.total_capital_cost
         )
 
@@ -503,7 +506,7 @@ class TestWorkflow:
         )
 
         # Note units (M$)
-        assert pytest.approx(1.73136e-7, rel=1e-5) == value(model.fs.costing.LCOW)
+        assert pytest.approx(1.73278e-7, rel=1e-5) == value(model.fs.costing.LCOW)
 
         assert pytest.approx(0.231345, rel=1e-5) == value(
             model.fs.costing.electricity_intensity

--- a/watertap/core/zero_order_costing.py
+++ b/watertap/core/zero_order_costing.py
@@ -358,7 +358,7 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
 
     # -------------------------------------------------------------------------
     # Unit operation costing methods
-    def cost_power_law_flow(blk):
+    def cost_power_law_flow(blk, number_of_parallel_units=1):
         """
         General method for costing equipment based on power law form. This is
         the most common costing form for zero-order models.
@@ -367,6 +367,10 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
 
         This method also registers electricity demand as a costed flow (if
         present in the unit operation model).
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         t0 = blk.flowsheet().time.first()
 
@@ -407,7 +411,9 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         factor = parameter_dict["capital_cost"]["cost_factor"]
 
         # Call general power law costing method
-        ZeroOrderCostingData._general_power_law_form(blk, A, B, sizing_term, factor)
+        ZeroOrderCostingData._general_power_law_form(
+            blk, A, B, sizing_term, factor, number_of_parallel_units
+        )
 
         # Register flows
         blk.config.flowsheet_costing_block.cost_flow(
@@ -625,13 +631,17 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.electricity[t0], "electricity"
         )
 
-    def cost_chemical_addition(blk):
+    def cost_chemical_addition(blk, number_of_parallel_units=1):
         """
         General method for costing chemical addition processes. Capital cost is
         based on the mass flow rate of chemical added.
 
         This method also registers the chemical flow and electricity demand as
         costed flows.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         chem_name = blk.unit_model.config.process_subtype
 
@@ -662,7 +672,9 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         factor = parameter_dict["capital_cost"]["cost_factor"]
 
         # Call general power law costing method
-        ZeroOrderCostingData._general_power_law_form(blk, A, B, sizing_term, factor)
+        ZeroOrderCostingData._general_power_law_form(
+            blk, A, B, sizing_term, factor, number_of_parallel_units
+        )
 
         # Register flows
         blk.config.flowsheet_costing_block.cost_flow(
@@ -843,11 +855,15 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.electricity[t0], "electricity"
         )
 
-    def cost_deep_well_injection(blk):
+    def cost_deep_well_injection(blk, number_of_parallel_units=1):
         """
         General method for costing deep well injection processes. Capital cost
         is based on the cost of pump and pipe.
         This method also registers the electricity demand as a costed flow.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         t0 = blk.flowsheet().time.first()
 
@@ -895,7 +911,12 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
 
         # Call general power law costing method
         ZeroOrderCostingData._general_power_law_form(
-            blk, cost_total, C, sizing_term, factor
+            blk,
+            cost_total,
+            C,
+            sizing_term,
+            factor,
+            number_of_parallel_units,
         )
 
         # Register flows
@@ -1011,17 +1032,21 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.MgCl2_flowrate[t0], "magnesium_chloride"
         )
 
-    def cost_fixed_bed(blk):
+    def cost_fixed_bed(blk, number_of_parallel_units=1):
         """
         General method for costing fixed bed units. This primarily calls the
         cost_power_law_flow method.
 
         This method also registers demand for a number of additional material
         flows.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         t0 = blk.flowsheet().time.first()
 
-        ZeroOrderCostingData.cost_power_law_flow(blk)
+        ZeroOrderCostingData.cost_power_law_flow(blk, number_of_parallel_units)
 
         # Register flows - electricity already done by cost_power_law_flow
         blk.config.flowsheet_costing_block.cost_flow(
@@ -1608,12 +1633,16 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.resin_demand[t0], "ion_exchange_resin"
         )
 
-    def cost_iron_and_manganese_removal(blk):
+    def cost_iron_and_manganese_removal(blk, number_of_parallel_units=1):
         """
         General method for costing iron and manganese removal processes. Capital cost
         is based on the cost of air blower, backwash and dual media filter.
 
         This method also registers the electricity demand as a costed flow.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         t0 = blk.flowsheet().time.first()
 
@@ -1672,7 +1701,12 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
 
         # Call general power law costing method
         ZeroOrderCostingData._general_power_law_form(
-            blk, cost_total, F, sizing_term, factor
+            blk,
+            cost_total,
+            F,
+            sizing_term,
+            factor,
+            number_of_parallel_units,
         )
 
         # Register flows
@@ -1727,10 +1761,14 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.electricity[t0], "electricity"
         )
 
-    def cost_sedimentation(blk):
+    def cost_sedimentation(blk, number_of_parallel_units=1):
         """
         General method for costing sedimentaion processes. Capital cost is
         based on the surface area of the basin.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         t0 = blk.flowsheet().time.first()
         sizing_term = blk.unit_model.basin_surface_area[t0] / pyo.units.foot**2
@@ -1751,17 +1789,23 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         factor = parameter_dict["capital_cost"]["cost_factor"]
 
         # Call general power law costing method
-        ZeroOrderCostingData._general_power_law_form(blk, A, B, sizing_term, factor)
+        ZeroOrderCostingData._general_power_law_form(
+            blk, A, B, sizing_term, factor, number_of_parallel_units
+        )
 
         # Register flows
         blk.config.flowsheet_costing_block.cost_flow(
             blk.unit_model.electricity[t0], "electricity"
         )
 
-    def cost_storage_tank(blk):
+    def cost_storage_tank(blk, number_of_parallel_units=1):
         """
         General method for costing storage tanks. Capital cost is based on the
         volume of the tank.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         t0 = blk.flowsheet().time.first()
         sizing_term = blk.unit_model.tank_volume[t0] / pyo.units.m**3
@@ -1783,7 +1827,9 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         factor = parameter_dict["capital_cost"]["cost_factor"]
 
         # Call general power law costing method
-        ZeroOrderCostingData._general_power_law_form(blk, A, B, sizing_term, factor)
+        ZeroOrderCostingData._general_power_law_form(
+            blk, A, B, sizing_term, factor, number_of_parallel_units
+        )
 
     def cost_surface_discharge(blk):
         """
@@ -2215,10 +2261,14 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.electricity[t0], "electricity"
         )
 
-    def cost_landfill(blk):
+    def cost_landfill(blk, number_of_parallel_units=1):
         """
         General method for costing landfill. Capital cost is based on the total mass and
         capacity basis.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
 
         t0 = blk.flowsheet().time.first()
@@ -2241,7 +2291,9 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         factor = parameter_dict["capital_cost"]["cost_factor"]
 
         # Call general power law costing method
-        ZeroOrderCostingData._general_power_law_form(blk, A, B, sizing_term, factor)
+        ZeroOrderCostingData._general_power_law_form(
+            blk, A, B, sizing_term, factor, number_of_parallel_units
+        )
 
         # Register flows
         blk.config.flowsheet_costing_block.cost_flow(
@@ -2307,18 +2359,24 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
             blk.unit_model.electricity[t0], "electricity"
         )
 
-    def cost_nanofiltration(blk):
+    def cost_nanofiltration(blk, number_of_parallel_units=1):
         """
         General method for costing nanofiltration. Costing is carried out
         using either the general_power_law form or the standard form which
         computes membrane cost and replacement rate.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         # Get cost method for this technology
         cost_method = _get_unit_cost_method(blk)
         valid_methods = ["cost_power_law_flow", "cost_membrane"]
         if cost_method == "cost_power_law_flow":
-            ZeroOrderCostingData.cost_power_law_flow(blk)
+            ZeroOrderCostingData.cost_power_law_flow(blk, number_of_parallel_units)
         elif cost_method == "cost_membrane":
+            # NOTE: number of units does not matter for cost_membrane
+            #       as its a linear function of membrane area
             ZeroOrderCostingData.cost_membrane(blk)
         else:
             raise KeyError(
@@ -2557,9 +2615,15 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
 
         return expr
 
-    def _general_power_law_form(blk, A, B, sizing_term, factor=None):
+    def _general_power_law_form(
+        blk, A, B, sizing_term, factor=None, number_of_parallel_units=1
+    ):
         """
         General method for building power law costing expressions.
+
+        Args:
+            number_of_parallel_units (int, optional) - cost this unit as
+                        number_of_parallel_units parallel units (default: 1)
         """
         blk.capital_cost = pyo.Var(
             initialize=1,
@@ -2569,9 +2633,16 @@ class ZeroOrderCostingData(FlowsheetCostingBlockData):
         )
 
         expr = pyo.units.convert(
-            A * pyo.units.convert(sizing_term, to_units=pyo.units.dimensionless) ** B,
+            A
+            * (
+                pyo.units.convert(sizing_term, to_units=pyo.units.dimensionless)
+                / number_of_parallel_units
+            )
+            ** B,
             to_units=blk.config.flowsheet_costing_block.base_currency,
         )
+
+        expr *= number_of_parallel_units
 
         if factor == "TPEC":
             expr *= blk.config.flowsheet_costing_block.TPEC


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
WaterTAP3 allowed multiple parallel units to be costed in a simple fashion, without creating multiple parallel unit models. This PR would begin to replicate that functionality in the zero-order costing package.

## Changes proposed in this PR:
- Add `number_of_parallel_units` keyword argument to all zero order costing methods utilizing the `_general_power_law_form`.
- Implement parallel unit costing in `_general_power_law_form`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
