### PR TITLE
Adding costing to ED model v2

### DIFF
--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -918,7 +918,7 @@ def cost_electrodialysis_stack(
 def cost_by_flow_volume(blk, flow_cost, flow_to_cost):
     """
     Generic function for costing by flow volume.
-    
+
     Args:
         flow_cost - The cost of the pump in [currency]/([volume]/[time])
         flow_to_cost - The flow costed in [volume]/[time]

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -407,6 +407,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_nanofiltration(blk):
         """
         Nanofiltration costing method
+
         TODO: describe equations
         """
         make_capital_cost_var(blk)
@@ -422,7 +423,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_reverse_osmosis(blk, ro_type=ROType.standard):
         """
         Reverse osmosis costing method
+
         TODO: describe equations
+
         Args:
             ro_type: ROType Enum indicating reverse osmosis type,
                 default = ROType.standard
@@ -449,10 +452,13 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_pump(blk, pump_type=PumpType.high_pressure, cost_electricity_flow=True):
         """
         Pump costing method
+
         TODO: describe equations
+
         Args:
             pump_type: PumpType Enum indicating pump type,
                 default = PumpType.high_pressure
+
             cost_electricity_flow: bool, if True, the Pump's work_mechanical will be
                 converted to kW and costed as an electricity, default = True
         """
@@ -474,10 +480,13 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     ):
         """
         Energy recovery device costing method
+
         TODO: describe equations
+
         Args:
             energy_recovery_device_type: EnergyRecoveryDeviceType Enum indicating ERD type,
                 default = EnergyRecoveryDeviceType.pressure_exchanger.
+
             cost_electricity_flow: bool, if True, the ERD's work_mechanical will
                 be converted to kW and costed as an electricity default = True
         """
@@ -493,7 +502,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_high_pressure_pump(blk, cost_electricity_flow=True):
         """
         High pressure pump costing method
+
         `TODO: describe equations`
+
         Args:
             cost_electricity_flow - bool, if True, the Pump's work_mechanical will
                                     be converted to kW and costed as an electricity
@@ -518,7 +529,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_low_pressure_pump(blk, cost_electricity_flow=True):
         """
         Low pressure pump costing method
+
         TODO: describe equations
+
         Args:
             cost_electricity_flow - bool, if True, the Pump's work_mechanical will
                                     be converted to kW and costed as an electricity
@@ -545,7 +558,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_pressure_exchanger_erd(blk, cost_electricity_flow=True):
         """
         ERD pressure exchanger costing method
+
         TODO: describe equations
+
         Args:
             cost_electricity_flow - bool, if True, the ERD's work_mechanical will
                                     be converted to kW and costed as an electricity
@@ -572,6 +587,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_pressure_exchanger(blk):
         """
         Pressure exchanger costing method
+
         TODO: describe equations
         """
         cost_by_flow_volume(
@@ -587,10 +603,13 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_mixer(blk, mixer_type=MixerType.default, **kwargs):
         """
         Mixer costing method
+
         TODO: describe equations
+
         Args:
             mixer_type: MixerType Enum indicating mixer type,
                 default = MixerType.default
+
             `**kwargs`: Additional keywords for the MixerType, e.g., NaOCl
                 and CaOH2 mixers expect the `dosing_rate` keyword
                 argument.
@@ -611,6 +630,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_default_mixer(blk):
         """
         Default mixer costing method
+
         TODO: describe equations
         """
         cost_by_flow_volume(
@@ -626,7 +646,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_naocl_mixer(blk, dosing_rate):
         """
         NaOCl mixer costing method
+
         TODO: describe equations
+
         Args:
             dosing_rate: An expression in [mass/time] for NaOCl dosage
         """
@@ -646,7 +668,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_caoh2_mixer(blk, dosing_rate):
         """
         CaOH2 mixer costing method
+
         TODO: describe equations
+
         Args:
             dosing_rate: An expression in [mass/time] for CaOH2 dosage
         """
@@ -671,6 +695,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_electrodialysis(blk, cost_electricity_flow=True):
         """
         Function for costing the Electrodialysis unit
+
         Args:
             cost_type - Option for electrodialysis cost function type - (UNKNOWN)
         """
@@ -701,6 +726,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
     def cost_crystallizer(blk, cost_type=CrystallizerCostType.default):
         """
         Function for costing the FC crystallizer by the mass flow of produced crystals.
+
         Args:
             cost_type - Option for crystallizer cost function type - volume or mass basis
         """
@@ -810,6 +836,7 @@ def cost_membrane(blk, membrane_cost, factor_membrane_replacement):
     """
     Generic function for costing a membrane. Assumes the unit_model
     has an `area` variable or parameter.
+
     Args:
         membrane_cost - The cost of the membrane in currency per area
         factor_membrane_replacement - Membrane replacement factor
@@ -840,12 +867,17 @@ def cost_electrodialysis_stack(
     Generic function for costing the stack in an electrodialysis unit.
     Assumes the unit_model has a `cell_pair_num`, `cell_width`, and `cell_length`
     set of variables used to size the total membrane area.
+
     Args:
         membrane_cost - The total cost of the CEM and AEM per cell pair in currency per area
+
         spacer_cost - The total cost of the spacers per cell pair in currency per area
+
         membrane_replacement_factor - Replacement factor for membranes and spacers
                                       [fraction of membranes/spacers replaced/year]
+
         electrode_cost - The total cost of electrodes in a given stack in currency per area
+
         electrode_replacement_factor - Replacement factor for electrodes
                                         [fraction of electrodes replaced/year]
     """
@@ -886,6 +918,7 @@ def cost_electrodialysis_stack(
 def cost_by_flow_volume(blk, flow_cost, flow_to_cost):
     """
     Generic function for costing by flow volume.
+    
     Args:
         flow_cost - The cost of the pump in [currency]/([volume]/[time])
         flow_to_cost - The flow costed in [volume]/[time]

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -37,6 +37,7 @@ from watertap.unit_models import (
     Pump,
     EnergyRecoveryDevice,
     Electrodialysis0D,
+    Electrodialysis1D,
 )
 
 
@@ -722,10 +723,15 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             blk.costing_package.factor_electrodialysis_electrode_replacement,
         )
 
+        # Changed this to grab power from performance table which is identified
+        #   by same key regardless of whether the Electrodialysis unit is 0D or 1D
         if cost_electricity_flow:
             blk.costing_package.cost_flow(
                 pyo.units.convert(
-                    blk.unit_model.power_electrical[t0], to_units=pyo.units.kW
+                    blk.unit_model._get_performance_contents(t0)["vars"][
+                        "Total electrical power consumption(Watt)"
+                    ],
+                    to_units=pyo.units.kW,
                 ),
                 "electricity",
             )
@@ -819,6 +825,7 @@ WaterTAPCostingData.unit_mapping = {
     NanofiltrationZO: WaterTAPCostingData.cost_nanofiltration,
     Crystallization: WaterTAPCostingData.cost_crystallizer,
     Electrodialysis0D: WaterTAPCostingData.cost_electrodialysis,
+    Electrodialysis1D: WaterTAPCostingData.cost_electrodialysis,
 }
 
 

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -198,14 +198,19 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             units=pyo.units.dimensionless,
         )
 
-        self.electrodialysis_total_membrane_cost = pyo.Var(
-            initialize=86,
-            doc="Electrodialysis membrane cost per cell pair is sum of costs for CEM and AEM",
+        self.electrodialysis_cem_membrane_cost = pyo.Var(
+            initialize=43,
+            doc="Cost of CEM membrane used in Electrodialysis ($/CEM/area)",
             units=self.base_currency / (pyo.units.meter**2),
         )
-        self.electrodialysis_total_flowspacer_cost = pyo.Var(
-            initialize=6,
-            doc="Electrodialysis spacer cost per cell pair is sum of costs for 2 flow spacers",
+        self.electrodialysis_aem_membrane_cost = pyo.Var(
+            initialize=43,
+            doc="Cost of AEM membrane used in Electrodialysis ($/AEM/area)",
+            units=self.base_currency / (pyo.units.meter**2),
+        )
+        self.electrodialysis_flowspacer_cost = pyo.Var(
+            initialize=3,
+            doc="Cost of the spacers used in Electrodialysis ($/spacer/area)",
             units=self.base_currency / (pyo.units.meter**2),
         )
         self.factor_electrodialysis_membrane_housing_replacement = pyo.Var(
@@ -213,9 +218,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             doc="Membrane housing replacement factor for CEM, AEM, and spacer replacements [fraction of membrane replaced/year]",
             units=pyo.units.year**-1,
         )
-        self.electrodialysis_total_electrode_cost = pyo.Var(
-            initialize=4000,
-            doc="Electrodialysis electrode cost per stack is sum of costs for 2 electrodes",
+        self.electrodialysis_electrode_cost = pyo.Var(
+            initialize=2000,
+            doc="Cost of the electrodes used in Electrodialysis ($/electrode/area)",
             units=self.base_currency / (pyo.units.meter**2),
         )
         self.factor_electrodialysis_electrode_replacement = pyo.Var(
@@ -697,13 +702,16 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         Function for costing the Electrodialysis unit
 
         Args:
-            cost_type - Option for electrodialysis cost function type - (UNKNOWN)
+            cost_electricity_flow - Option for including the costing of electricity
         """
         t0 = blk.flowsheet().time.first()
 
-        membrane_cost = blk.costing_package.electrodialysis_total_membrane_cost
-        spacer_cost = blk.costing_package.electrodialysis_total_flowspacer_cost
-        electrode_cost = blk.costing_package.electrodialysis_total_electrode_cost
+        membrane_cost = (
+            blk.costing_package.electrodialysis_cem_membrane_cost
+            + blk.costing_package.electrodialysis_aem_membrane_cost
+        )
+        spacer_cost = 2.0 * blk.costing_package.electrodialysis_flowspacer_cost
+        electrode_cost = 2.0 * blk.costing_package.electrodialysis_electrode_cost
 
         cost_electrodialysis_stack(
             blk,

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -416,9 +416,6 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
 
         TODO: describe equations
         """
-        make_capital_cost_var(blk)
-        make_fixed_operating_cost_var(blk)
-
         cost_membrane(
             blk,
             blk.costing_package.nanofiltration_membrane_cost,
@@ -447,9 +444,6 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                 f"{blk.unit_model.name} received invalid argument for ro_type:"
                 f" {ro_type}. Argument must be a member of the ROType Enum."
             )
-        make_capital_cost_var(blk)
-        make_fixed_operating_cost_var(blk)
-
         cost_membrane(
             blk, membrane_cost, blk.costing_package.factor_membrane_replacement
         )
@@ -858,6 +852,8 @@ def cost_membrane(blk, membrane_cost, factor_membrane_replacement):
                                       [fraction of membrane replaced/year]
     """
 
+    make_capital_cost_var(blk)
+    make_fixed_operating_cost_var(blk)
     blk.membrane_cost = pyo.Expression(expr=membrane_cost)
     blk.factor_membrane_replacement = pyo.Expression(expr=factor_membrane_replacement)
 

--- a/watertap/unit_models/__init__.py
+++ b/watertap/unit_models/__init__.py
@@ -19,3 +19,4 @@ from .pressure_exchanger import PressureExchanger
 from .pressure_changer import Pump, EnergyRecoveryDevice
 from .crystallizer import Crystallization
 from .electrodialysis_0D import Electrodialysis0D
+from .electrodialysis_1D import Electrodialysis1D

--- a/watertap/unit_models/__init__.py
+++ b/watertap/unit_models/__init__.py
@@ -18,3 +18,4 @@ from .nanofiltration_ZO import NanofiltrationZO
 from .pressure_exchanger import PressureExchanger
 from .pressure_changer import Pump, EnergyRecoveryDevice
 from .crystallizer import Crystallization
+from .electrodialysis_0D import Electrodialysis0D

--- a/watertap/unit_models/electrodialysis_0D.py
+++ b/watertap/unit_models/electrodialysis_0D.py
@@ -932,8 +932,10 @@ class Electrodialysis0DData(UnitModelBlockData):
     def _get_performance_contents(self, time_point=0):
         return {
             "vars": {
-                "Electrical power consumption(Watt)": self.power_electrical[time_point],
-                "Specific electrical power consumption (kWh/m**3)": self.specific_power_electrical[
+                "Total electrical power consumption(Watt)": self.power_electrical[
+                    time_point
+                ],
+                "Specific electrical power consumption (kW*h/m**3)": self.specific_power_electrical[
                     time_point
                 ],
                 "Current efficiency for deionzation": self.current_efficiency[

--- a/watertap/unit_models/electrodialysis_0D.py
+++ b/watertap/unit_models/electrodialysis_0D.py
@@ -205,7 +205,7 @@ class Electrodialysis0DData(UnitModelBlockData):
 
         self.cell_pair_num = Var(
             initialize=1,
-            domain=NonNegativeIntegers,
+            domain=NonNegativeReals,
             bounds=(1, 10000),
             units=pyunits.dimensionless,
             doc="cell pair number in a stack",
@@ -227,7 +227,7 @@ class Electrodialysis0DData(UnitModelBlockData):
         self.spacer_thickness = Var(
             initialize=0.0001,
             units=pyunits.meter,
-            doc="The distance between the concecutive aem and cem",
+            doc="The distance between the consecutive aem and cem",
         )
 
         # Material and Operational properties

--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -696,8 +696,6 @@ class Electrodialysis1DData(UnitModelBlockData):
             self.diluate.length_domain,
             doc="Electrical power consumption of a stack",
         )
-        # # TODO: Check this constraint formulation. Is this correct?
-        #           it states: dP/dx = b*L*u(x)*i(x)
         def eq_power_electrical(self, t, x):
             if x == self.diluate.length_domain.first():
                 return self.diluate.power_electrical_x[t, x] == 0
@@ -1072,7 +1070,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                     )
                     ** 0.5
                 )
-                sf_eleosm = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
+                sf_eleosm = value(Constants.faraday_constant)
                 iscale.constraint_scaling_transform(
                     c, (sf_osm**2 + sf_eleosm**2) ** 0.5
                 )
@@ -1102,7 +1100,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                         ** 0.5
                     )
                 )
-                sf_elemig = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
+                sf_elemig = value(Constants.faraday_constant)
                 iscale.constraint_scaling_transform(
                     c, (sf_diff**2 + sf_elemig**2) ** 0.5
                 )
@@ -1159,7 +1157,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                     )
                     ** 0.5
                 )
-                sf_eleosm = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
+                sf_eleosm = value(Constants.faraday_constant)
                 iscale.constraint_scaling_transform(
                     c, (sf_osm**2 + sf_eleosm**2) ** 0.5
                 )
@@ -1189,7 +1187,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                         ** 0.5
                     )
                 )
-                sf_elemig = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
+                sf_elemig = value(Constants.faraday_constant)
                 iscale.constraint_scaling_transform(
                     c, (sf_diff**2 + sf_elemig**2) ** 0.5
                 )

--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -696,6 +696,8 @@ class Electrodialysis1DData(UnitModelBlockData):
             self.diluate.length_domain,
             doc="Electrical power consumption of a stack",
         )
+        # # TODO: Check this constraint formulation. Is this correct?
+        #           it states: dP/dx = b*L*u(x)*i(x)
         def eq_power_electrical(self, t, x):
             if x == self.diluate.length_domain.first():
                 return self.diluate.power_electrical_x[t, x] == 0

--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -1072,7 +1072,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                     )
                     ** 0.5
                 )
-                sf_eleosm = Constants.faraday_constant
+                sf_eleosm = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
                 iscale.constraint_scaling_transform(
                     c, (sf_osm**2 + sf_eleosm**2) ** 0.5
                 )
@@ -1102,7 +1102,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                         ** 0.5
                     )
                 )
-                sf_elemig = Constants.faraday_constant
+                sf_elemig = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
                 iscale.constraint_scaling_transform(
                     c, (sf_diff**2 + sf_elemig**2) ** 0.5
                 )
@@ -1159,7 +1159,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                     )
                     ** 0.5
                 )
-                sf_eleosm = Constants.faraday_constant
+                sf_eleosm = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
                 iscale.constraint_scaling_transform(
                     c, (sf_osm**2 + sf_eleosm**2) ** 0.5
                 )
@@ -1189,7 +1189,7 @@ class Electrodialysis1DData(UnitModelBlockData):
                         ** 0.5
                     )
                 )
-                sf_elemig = Constants.faraday_constant
+                sf_elemig = Constants.faraday_constant * pyunits.mol / pyunits.coulomb
                 iscale.constraint_scaling_transform(
                     c, (sf_diff**2 + sf_elemig**2) ** 0.5
                 )

--- a/watertap/unit_models/tests/test_electrodialysis_0D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_0D.py
@@ -272,7 +272,8 @@ class TestElectrodialysisVoltageConst:
         m.fs.costing = WaterTAPCosting()
 
         # Set costing var
-        m.fs.costing.electrodialysis_total_membrane_cost.set_value(86)
+        m.fs.costing.electrodialysis_aem_membrane_cost.set_value(45)
+        m.fs.costing.electrodialysis_cem_membrane_cost.set_value(41)
         m.fs.costing.factor_electrodialysis_membrane_housing_replacement.set_value(0.2)
 
         m.fs.unit.costing = UnitModelCostingBlock(

--- a/watertap/unit_models/tests/test_electrodialysis_0D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_0D.py
@@ -253,10 +253,10 @@ class TestElectrodialysisVoltageConst:
         perform_dict = m.fs.unit._get_performance_contents()
         assert "vars" in perform_dict
         assert value(
-            perform_dict["vars"]["Electrical power consumption(Watt)"]
+            perform_dict["vars"]["Total electrical power consumption(Watt)"]
         ) == pytest.approx(3.06, rel=5e-3)
         assert value(
-            perform_dict["vars"]["Specific electrical power consumption (kWh/m**3)"]
+            perform_dict["vars"]["Specific electrical power consumption (kW*h/m**3)"]
         ) == pytest.approx(0.202, rel=5e-3)
         assert value(
             perform_dict["vars"]["Current efficiency for deionzation"]
@@ -520,10 +520,10 @@ class TestElectrodialysisCurrentConst:
         perform_dict = m.fs.unit._get_performance_contents()
         assert "vars" in perform_dict
         assert value(
-            perform_dict["vars"]["Electrical power consumption(Watt)"]
+            perform_dict["vars"]["Total electrical power consumption(Watt)"]
         ) == pytest.approx(5.4, rel=5e-3)
         assert value(
-            perform_dict["vars"]["Specific electrical power consumption (kWh/m**3)"]
+            perform_dict["vars"]["Specific electrical power consumption (kW*h/m**3)"]
         ) == pytest.approx(0.361, rel=5e-3)
         assert value(
             perform_dict["vars"]["Current efficiency for deionzation"]
@@ -744,10 +744,10 @@ class TestElectrodialysis_withNeutralSPecies:
         perform_dict = m.fs.unit._get_performance_contents()
         assert "vars" in perform_dict
         assert value(
-            perform_dict["vars"]["Electrical power consumption(Watt)"]
+            perform_dict["vars"]["Total electrical power consumption(Watt)"]
         ) == pytest.approx(5.3, rel=5e-3)
         assert value(
-            perform_dict["vars"]["Specific electrical power consumption (kWh/m**3)"]
+            perform_dict["vars"]["Specific electrical power consumption (kW*h/m**3)"]
         ) == pytest.approx(0.353, rel=5e-3)
         assert value(
             perform_dict["vars"]["Current efficiency for deionzation"]

--- a/watertap/unit_models/tests/test_electrodialysis_1D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_1D.py
@@ -13,6 +13,7 @@
 import pytest
 from watertap.property_models.ion_DSPMDE_prop_pack import DSPMDEParameterBlock
 from watertap.unit_models.electrodialysis_1D import Electrodialysis1D
+from watertap.costing import WaterTAPCosting
 from pyomo.environ import (
     ConcreteModel,
     assert_optimal_termination,
@@ -34,6 +35,7 @@ from idaes.core import (
     MomentumBalanceType,
     EnergyBalanceType,
 )
+from idaes.generic_models.costing import UnitModelCostingBlock
 from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
@@ -211,6 +213,10 @@ class TestElectrodialysisVoltageConst:
         # check to make sure DOF does not change
         assert degrees_of_freedom(m) == 0
 
+        # Added this unit check
+        # # TODO: reactivate
+        # assert_units_consistent(m)
+
     @pytest.mark.component
     def test_solve(self, electrodialysis_1d_cell1):
         m = electrodialysis_1d_cell1
@@ -256,6 +262,39 @@ class TestElectrodialysisVoltageConst:
         assert value(
             perform_dict["vars"]["Specific electrical power consumption (kW*h/m**3)"]
         ) == pytest.approx(0.197, rel=5e-3)
+
+    @pytest.mark.component
+    def test_costing(self, electrodialysis_1d_cell1):
+        m = electrodialysis_1d_cell1
+        blk = m.fs.unit
+
+        m.fs.costing = WaterTAPCosting()
+
+        m.fs.unit.costing = UnitModelCostingBlock(
+            default={
+                "flowsheet_costing_block": m.fs.costing,
+                "costing_method_arguments": {"cost_electricity_flow": True},
+            },
+        )
+        m.fs.costing.cost_process()
+
+        # # TODO: Reactivate
+        # assert_units_consistent(m)
+
+        assert degrees_of_freedom(m) == 0
+
+        results = solver.solve(m, tee=True)
+        assert_optimal_termination(results)
+
+        assert pytest.approx(388.6800, rel=1e-3) == value(
+            m.fs.costing.total_capital_cost
+        )
+        assert pytest.approx(45.86804, rel=1e-3) == value(
+            m.fs.costing.total_operating_cost
+        )
+        assert pytest.approx(777.3600, rel=1e-3) == value(
+            m.fs.costing.total_investment_cost
+        )
 
 
 class TestElectrodialysisCurrentConst:

--- a/watertap/unit_models/tests/test_electrodialysis_1D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_1D.py
@@ -205,6 +205,10 @@ class TestElectrodialysisVoltageConst:
         iscale.set_scaling_factor(m.fs.unit.cell_width, 10)
         iscale.set_scaling_factor(m.fs.unit.cell_length, 10)
         iscale.calculate_scaling_factors(m.fs)
+
+        # Added this unit check scaling
+        assert_units_consistent(m)
+
         initialization_tester(m)
         badly_scaled_var_values = {
             var.name: val for (var, val) in iscale.badly_scaled_var_generator(m)
@@ -212,10 +216,6 @@ class TestElectrodialysisVoltageConst:
         assert not badly_scaled_var_values
         # check to make sure DOF does not change
         assert degrees_of_freedom(m) == 0
-
-        # Added this unit check
-        # # TODO: reactivate
-        # assert_units_consistent(m)
 
     @pytest.mark.component
     def test_solve(self, electrodialysis_1d_cell1):
@@ -278,8 +278,7 @@ class TestElectrodialysisVoltageConst:
         )
         m.fs.costing.cost_process()
 
-        # # TODO: Reactivate
-        # assert_units_consistent(m)
+        assert_units_consistent(m)
 
         assert degrees_of_freedom(m) == 0
 


### PR DESCRIPTION
## Fixes/Resolves:

Partially addresses model enhancements in #489

Replaces PR #555

## Summary/Motivation:

Adds costing methods and variables for electrodialysis to the WaterTAP costing block

## Changes proposed in this PR:
- Adding costing for electrodialysis to WaterTAP costing block
- Adding unit tests for costing in the electrodialysis unit model
- Minor fixes to electrodialysis model


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
