### PR TITLE
fix a few typos and change costing params in yamls

### DIFF
--- a/watertap/data/techno_economic/aeration_basin.yaml
+++ b/watertap/data/techno_economic/aeration_basin.yaml
@@ -48,4 +48,4 @@ default:
     total_coliforms_fecal_ecoli:
       value: 0.998798
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and E. Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E. Coli)

--- a/watertap/data/techno_economic/anaerobic_digestion_oxidation.yaml
+++ b/watertap/data/techno_economic/anaerobic_digestion_oxidation.yaml
@@ -17,7 +17,7 @@ default:
   recovery_frac_mass_H2O:
     value: 0.9999
     units: dimensionless
-    reference: 'Beef Processing case study. '
+    reference: 'Beef Processing case study.'
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless

--- a/watertap/data/techno_economic/backwash_solids_handling.yaml
+++ b/watertap/data/techno_economic/backwash_solids_handling.yaml
@@ -18,10 +18,10 @@ default:
     tss:
       value: 0.95
       units: dimensionless
-      constituent_longform: Total Suspended Solids (TSS))
+      constituent_longform: Total Suspended Solids (TSS)
   capital_cost:
     basis: flow_mass
-    cost_factor: TPEC
+    cost_factor: None
     reference_state:
       value: 1577255
       units: kg/hr

--- a/watertap/data/techno_economic/coag_and_floc.yaml
+++ b/watertap/data/techno_economic/coag_and_floc.yaml
@@ -52,28 +52,28 @@ default:
     cost_factor: TPEC
     capital_mix_a_parameter:
       value: 7.0814
-      units: USD_2020/gallons
+      units: USD_2007/gallons
     capital_mix_b_parameter:
       value: 33269
-      units: USD_2020
+      units: USD_2007
     capital_floc_a_parameter:
       value: 952902
-      units: USD_2020/Mgallons
+      units: USD_2007/Mgallons
     capital_floc_b_parameter:
       value: 177335
-      units: USD_2020
+      units: USD_2007
     capital_coag_inj_a_parameter:
       value: 212.32
-      units: USD_2020/(lb/hr)
+      units: USD_2007/(lb/hr)
     capital_coag_inj_b_parameter:
       value: 73225
-      units: USD_2020
+      units: USD_2007
     capital_floc_inj_a_parameter:
       value: 13662
-      units: USD_2020/(lb/day)
+      units: USD_2007/(lb/day)
     capital_floc_inj_b_parameter:
       value: 20861
-      units: USD_2020
+      units: USD_2007
 
 
 

--- a/watertap/data/techno_economic/conventional_activated_sludge.yaml
+++ b/watertap/data/techno_economic/conventional_activated_sludge.yaml
@@ -46,7 +46,7 @@ default:
     total_coliforms_fecal_ecoli:
       value: 0.998798
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and E. Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E. Coli)
 
 cas_nitrification:
   energy_electric_flow_vol_inlet:
@@ -96,7 +96,7 @@ cas_nitrification:
     total_coliforms_fecal_ecoli:
       value: 0.998798
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and E. Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E. Coli)
 
 cas_denitrification:
   energy_electric_flow_vol_inlet:
@@ -150,4 +150,4 @@ cas_denitrification:
     total_coliforms_fecal_ecoli:
       value: 0.998798
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and E. Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E. Coli)

--- a/watertap/data/techno_economic/dual_media_filtration.yaml
+++ b/watertap/data/techno_economic/dual_media_filtration.yaml
@@ -17,7 +17,7 @@ default:
   recovery_frac_mass_H2O:
     value: 0.99
     units: dimensionless
-    reference: 'Placeholder. Not utilized in any case studies. '
+    reference: 
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless

--- a/watertap/data/techno_economic/fixed_bed.yaml
+++ b/watertap/data/techno_economic/fixed_bed.yaml
@@ -10,7 +10,7 @@ default: # TODO: confirm any differentiation in removal across subtypes
     bod:
       value: 0.90  # adding this arbitrary default since no removal data provided
       units: dimensionless
-      constituent_longform: "Biological Oxygen Demand"
+      constituent_longform: Biological Oxygen Demand
   capital_cost:
     basis: flow_vol
     cost_factor: None
@@ -67,7 +67,7 @@ gravity_basin:
     bod:
       value: 0.90  # adding this arbitrary default since no removal data provided
       units: dimensionless
-      constituent_longform: "Biological Oxygen Demand"
+      constituent_longform: Biological Oxygen Demand
   capital_cost:
     basis: flow_vol
     cost_factor: None
@@ -124,7 +124,7 @@ fixed bed:
     bod:
       value: 0.90  # adding this arbitrary default since no removal data provided
       units: dimensionless
-      constituent_longform: "Biological Oxygen Demand"
+      constituent_longform: Biological Oxygen Demand
   capital_cost:
     basis: flow_vol
     cost_factor: None

--- a/watertap/data/techno_economic/mbr.yaml
+++ b/watertap/data/techno_economic/mbr.yaml
@@ -46,8 +46,7 @@ default:
     total_coliforms_fecal_ecoli:
       value: 0.998798
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and\uFFFD E.\
-        \ Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E.Coli)
     cryptosporidium:
       value: 0.9999
       units: dimensionless
@@ -100,8 +99,7 @@ mbr_denitrification:
     total_coliforms_fecal_ecoli:
       value: 0.998798
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and\uFFFD E.\
-        \ Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E.Coli)
     cryptosporidium:
       value: 0.9999
       units: dimensionless

--- a/watertap/data/techno_economic/ozonation.yaml
+++ b/watertap/data/techno_economic/ozonation.yaml
@@ -26,7 +26,7 @@ default:
     total_coliforms_fecal_ecoli:
       value: 0.997225
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and E.Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E.Coli)
     viruses_enteric:
       value: 0.997225
       units: dimensionless

--- a/watertap/data/techno_economic/ozone_aop.yaml
+++ b/watertap/data/techno_economic/ozone_aop.yaml
@@ -49,7 +49,7 @@ default:  #default aop is for hydrogen peroxide
     total_coliforms_fecal_ecoli:
       value: 0.997225
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and E.Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E.Coli)
     viruses_enteric:
       value: 0.997225
       units: dimensionless
@@ -120,7 +120,7 @@ hydrogen_peroxide:
     total_coliforms_fecal_ecoli:
       value: 0.997225
       units: dimensionless
-      constituent_longform: "Total Coliforms (including fecal coliform and E.Coli)"
+      constituent_longform: Total Coliforms (including fecal coliform and E.Coli)
     viruses_enteric:
       value: 0.997225
       units: dimensionless

--- a/watertap/data/techno_economic/settling_pond.yaml
+++ b/watertap/data/techno_economic/settling_pond.yaml
@@ -17,8 +17,7 @@ default:
   recovery_frac_mass_H2O:
     value: 0.9999
     units: dimensionless
-    reference: 'Based on "Sedimentation" cost model. See references in VAR. There
-      will be minimal water losses. '
+    reference: Based on "Sedimentation" cost model.
   default_removal_frac_mass_solute:
     value: 0
     units: dimensionless

--- a/watertap/data/techno_economic/static_mixer.yaml
+++ b/watertap/data/techno_economic/static_mixer.yaml
@@ -7,7 +7,7 @@ default:
     cost_factor: TPEC
     capital_a_parameter:
       value: 1065.7
-      units: USD_2014
+      units: USD_2010
     capital_b_parameter:
       value: 0.336
       units: dimensionless

--- a/watertap/data/techno_economic/sw_onshore_intake.yaml
+++ b/watertap/data/techno_economic/sw_onshore_intake.yaml
@@ -1,7 +1,7 @@
 default:
   capital_cost:
     basis: flow_vol
-    cost_factor: TPEC
+    cost_factor: None
     capital_a_parameter:
       value: 0.000215e6
       units: USD_2018

--- a/watertap/data/techno_economic/walnut_shell_filter.yaml
+++ b/watertap/data/techno_economic/walnut_shell_filter.yaml
@@ -26,22 +26,6 @@ default:
       value: 0.2
       units: dimensionless
       constituent_longform: Nonvolatile TOC
-    tds:
-      value: 0.9
-      units: dimensionless
-      constituent_longform: Total Dissolved Solids (TDS)
-    chloride:
-      value: 0.95
-      units: dimensionless
-      constituent_longform: Chloride
-    electrical_conductivity:
-      value: 0.95
-      units: dimensionless
-      constituent_longform: Electrical_Conductivity
-    sodium:
-      value: 0.95
-      units: dimensionless
-      constituent_longform: Sodium, Dissolved
     tss:
       value: 0.97
       units: dimensionless

--- a/watertap/examples/flowsheets/case_studies/municipal_treatment/tests/test_municipal_treatment.py
+++ b/watertap/examples/flowsheets/case_studies/municipal_treatment/tests/test_municipal_treatment.py
@@ -64,7 +64,7 @@ def test_municipal_treatment():
         m.fs.recharge_pump.properties[0].flow_mass_comp["tss"]
     ) == pytest.approx(1.656e-6, rel=1e-3)
 
-    assert value(m.fs.costing.LCOW) == pytest.approx(5.1533e-7, rel=1e-3)  # in M$/m**3
+    assert value(m.fs.costing.LCOW) == pytest.approx(5.1682e-7, rel=1e-3)  # in M$/m**3
     assert value(m.fs.costing.electricity_intensity) == pytest.approx(
         4.4812e-1, rel=1e-3
     )

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
@@ -98,7 +98,7 @@ def test_seawater_RO_desalination_pressure_exchanger():
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
 
-    assert value(m.LCOW) == pytest.approx(0.845256, rel=1e-5)
+    assert value(m.LCOW) == pytest.approx(0.845200, rel=1e-5)
 
 
 @pytest.mark.component
@@ -180,4 +180,4 @@ def test_seawater_RO_desalination_pump_as_turbine():
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
 
-    assert value(m.LCOW) == pytest.approx(1.11579, rel=1e-5)
+    assert value(m.LCOW) == pytest.approx(1.115729, rel=1e-5)

--- a/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
@@ -51,10 +51,6 @@ class TestWalnutShellFilterZO_w_default_removal:
             default={
                 "solute_list": [
                     "nonvolatile_toc",
-                    "tds",
-                    "chloride",
-                    "electrical_conductivity",
-                    "sodium",
                     "tss",
                     "foo",
                 ]
@@ -67,10 +63,6 @@ class TestWalnutShellFilterZO_w_default_removal:
 
         m.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(1000)
         m.fs.unit.inlet.flow_mass_comp[0, "nonvolatile_toc"].fix(1)
-        m.fs.unit.inlet.flow_mass_comp[0, "tds"].fix(1)
-        m.fs.unit.inlet.flow_mass_comp[0, "chloride"].fix(1)
-        m.fs.unit.inlet.flow_mass_comp[0, "electrical_conductivity"].fix(1)
-        m.fs.unit.inlet.flow_mass_comp[0, "sodium"].fix(1)
         m.fs.unit.inlet.flow_mass_comp[0, "tss"].fix(1)
         m.fs.unit.inlet.flow_mass_comp[0, "foo"].fix(1)
 
@@ -134,80 +126,40 @@ class TestWalnutShellFilterZO_w_default_removal:
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
-        assert pytest.approx(1.007, rel=1e-5) == value(
+        assert pytest.approx(1.003, rel=1e-5) == value(
             model.fs.unit.properties_in[0].flow_vol
         )
-        assert pytest.approx(0.993049, rel=1e-5) == value(
+        assert pytest.approx(0.997008, rel=1e-5) == value(
             model.fs.unit.properties_in[0].conc_mass_comp["nonvolatile_toc"]
         )
-        assert pytest.approx(0.993049, rel=1e-5) == value(
-            model.fs.unit.properties_in[0].conc_mass_comp["tds"]
-        )
-        assert pytest.approx(0.993049, rel=1e-5) == value(
-            model.fs.unit.properties_in[0].conc_mass_comp["chloride"]
-        )
-        assert pytest.approx(0.993049, rel=1e-5) == value(
-            model.fs.unit.properties_in[0].conc_mass_comp["electrical_conductivity"]
-        )
-        assert pytest.approx(0.993049, rel=1e-5) == value(
-            model.fs.unit.properties_in[0].conc_mass_comp["sodium"]
-        )
-        assert pytest.approx(0.993049, rel=1e-5) == value(
+        assert pytest.approx(0.997008, rel=1e-5) == value(
             model.fs.unit.properties_in[0].conc_mass_comp["tss"]
         )
-        assert pytest.approx(0.993049, rel=1e-5) == value(
+        assert pytest.approx(0.997008, rel=1e-5) == value(
             model.fs.unit.properties_in[0].conc_mass_comp["foo"]
         )
-        assert pytest.approx(0.99208, rel=1e-5) == value(
+        assert pytest.approx(0.991829, rel=1e-5) == value(
             model.fs.unit.properties_treated[0].flow_vol
         )
-        assert pytest.approx(0.80639, rel=1e-5) == value(
+        assert pytest.approx(0.806589, rel=1e-5) == value(
             model.fs.unit.properties_treated[0].conc_mass_comp["nonvolatile_toc"]
         )
-        assert pytest.approx(0.1007983, rel=1e-5) == value(
-            model.fs.unit.properties_treated[0].conc_mass_comp["tds"]
-        )
-        assert pytest.approx(0.050399, rel=1e-5) == value(
-            model.fs.unit.properties_treated[0].conc_mass_comp["chloride"]
-        )
-        assert pytest.approx(0.050399, rel=1e-5) == value(
-            model.fs.unit.properties_treated[0].conc_mass_comp[
-                "electrical_conductivity"
-            ]
-        )
-        assert pytest.approx(0.050399, rel=1e-5) == value(
-            model.fs.unit.properties_treated[0].conc_mass_comp["sodium"]
-        )
-        assert pytest.approx(0.0302395, rel=1e-5) == value(
+        assert pytest.approx(0.030247, rel=1e-5) == value(
             model.fs.unit.properties_treated[0].conc_mass_comp["tss"]
         )
-        assert pytest.approx(1.007983, rel=1e-5) == value(
+        assert pytest.approx(1.008237, rel=1e-5) == value(
             model.fs.unit.properties_treated[0].conc_mass_comp["foo"]
         )
-        assert pytest.approx(0.01492, rel=1e-5) == value(
+        assert pytest.approx(0.01117, rel=1e-5) == value(
             model.fs.unit.properties_byproduct[0].flow_vol
         )
-        assert pytest.approx(13.4048, rel=1e-5) == value(
+        assert pytest.approx(17.90510, rel=1e-5) == value(
             model.fs.unit.properties_byproduct[0].conc_mass_comp["nonvolatile_toc"]
         )
-        assert pytest.approx(60.322, rel=1e-5) == value(
-            model.fs.unit.properties_byproduct[0].conc_mass_comp["tds"]
-        )
-        assert pytest.approx(63.673, rel=1e-5) == value(
-            model.fs.unit.properties_byproduct[0].conc_mass_comp["chloride"]
-        )
-        assert pytest.approx(63.673, rel=1e-5) == value(
-            model.fs.unit.properties_byproduct[0].conc_mass_comp[
-                "electrical_conductivity"
-            ]
-        )
-        assert pytest.approx(63.673, rel=1e-5) == value(
-            model.fs.unit.properties_byproduct[0].conc_mass_comp["sodium"]
-        )
-        assert pytest.approx(65.013, rel=1e-5) == value(
+        assert pytest.approx(86.83974, rel=1e-5) == value(
             model.fs.unit.properties_byproduct[0].conc_mass_comp["tss"]
         )
-        assert pytest.approx(6.7024e-07, rel=1e-5) == value(
+        assert pytest.approx(8.952551e-07, rel=1e-5) == value(
             model.fs.unit.properties_byproduct[0].conc_mass_comp["foo"]
         )
         assert pytest.approx(1.007 * 0 * 3600, abs=1e-5) == value(


### PR DESCRIPTION
## Fixes/Resolves:

incorrect costing params in a few yamls, typo fixes in others

## Summary/Motivation:

fix costing params in a few models as part of WT3 model validation, I also fixed a few obvious typos in a few yamls from the data migration 

## Changes proposed in this PR:
- remove cost factor from backwash solids handling, sw onshore intake
- change costing year in coag and floc, static mixer
- fix obvious typos in a few yamls
- remove TDS and electrical conductivity constituent removal factors from walnut shell filter 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
