### PR TITLE
Add CI workflow for linkchecking

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -8,7 +8,7 @@ on:
         default: https://watertap.readthedocs.io/en/latest/
         required: false
         description: Base url to check
-      exclude_url_regex:
+      ignore_url_regex:
         description: URLs matching this regex will not be checked
         type: choice
         required: false
@@ -36,8 +36,8 @@ jobs:
         linkchecker --version
     - name: Run linkchecker
       env:
-        _url_to_check: ${{ inputs.base_url }}
-        _exclude_url_regex: ${{ inputs.exclude_url_regex }}
+        _url_to_check: ${{ inputs.base_url || 'https://watertap.readthedocs.io/en/latest/' }}
+        _ignore_url_regex: ${{ inputs.ignore_url_regex || '.*(?:en/(?!latest|stable)).*' }}
       run: |
-        linkchecker --exclude-url="$_exclude_url_regex" $_url_to_check
+        linkchecker --ignore-url="$_ignore_url_regex" $_url_to_check
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Install linkchecker
       run: |
         pip install "linkchecker==10.1.*"
+        # linkchecker refuses to load files from its own installation directory if they are world-writable
+        linkchecker_pkg_dir=$(python -c 'import linkcheck as l, pathlib as p; print(p.Path(l.__file__).parent.resolve())')
+        chmod -R o-w "$linkchecker_pkg_dir"
         linkchecker --version
     - name: Run linkchecker
       env:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -38,8 +38,6 @@ jobs:
         chmod -R o-w "$linkchecker_pkg_dir"
         linkchecker --version
     - name: Run linkchecker
-      # run through TTY to enable colored output
-      shell: 'script --return --quiet --command "bash {0}"'
       env:
         _url_to_check: ${{ inputs.base_url || 'https://watertap.readthedocs.io/en/latest/' }}
         _ignore_url_regex: ${{ inputs.ignore_url_regex || '.*(?:en/(?!latest|stable)).*' }}

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -38,6 +38,8 @@ jobs:
         chmod -R o-w "$linkchecker_pkg_dir"
         linkchecker --version
     - name: Run linkchecker
+      # run through TTY to enable colored output
+      shell: 'script --return --quiet --command "bash {0}"'
       env:
         _url_to_check: ${{ inputs.base_url || 'https://watertap.readthedocs.io/en/latest/' }}
         _ignore_url_regex: ${{ inputs.ignore_url_regex || '.*(?:en/(?!latest|stable)).*' }}

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,43 @@
+name: Linkcheck
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        type: string
+        default: https://watertap.readthedocs.io/en/latest/
+        required: false
+        description: Base url to check
+      exclude_url_regex:
+        description: URLs matching this regex will not be checked
+        type: choice
+        required: false
+        default: ".*(?:en/(?!latest|stable)).*"
+        options:
+        - ".*(?:en/(?!latest|stable)).*"
+        - ""
+  schedule:
+    # run daily at 12:00 pm UTC (8 am ET/5 am PT)
+    - cron: '0 12 * * *'
+  # FIXME remove once we're reasonably sure it works
+  # (workflow_dispatch and schedule triggers only work from the default branch)
+  push:
+
+jobs:
+  linkchecker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install linkchecker
+      run: |
+        pip install "linkchecker==10.1.*"
+        linkchecker --version
+    - name: Run linkchecker
+      env:
+        _url_to_check: ${{ inputs.base_url }}
+        _exclude_url_regex: ${{ inputs.exclude_url_regex }}
+      run: |
+        linkchecker --exclude-url="$_exclude_url_regex" $_url_to_check
+


### PR DESCRIPTION
## Resolves: #429

## Summary/Motivation:

- Instead of running for every PR, this workflow will run:
  - On schedule (currently 1/day)
  - On demand (will become available once the PR is merged), with the possibility to set options

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
