### PR TITLE
Revise  electricity coefficients for Crystallizer

### DIFF
--- a/watertap/data/techno_economic/brine_concentrator.yaml
+++ b/watertap/data/techno_economic/brine_concentrator.yaml
@@ -185,11 +185,11 @@ crystallizer:
     units: L/mg*kWh/m^3
     reference: Survey of High-Recovery and Zero Liquid Discharge Technologies for Water Utilities (2008).
   elec_coeff_3:
-    value: 9.47
+    value: -9.47
     units: kWh/m^3
     reference: Survey of High-Recovery and Zero Liquid Discharge Technologies for Water Utilities (2008).
   elec_coeff_4:
-    value: 8.63E-4
+    value: -8.63E-4
     units: kWh/m^6*hr
     reference: Survey of High-Recovery and Zero Liquid Discharge Technologies for Water Utilities (2008).
   recovery_frac_mass_H2O:


### PR DESCRIPTION
## Fixes/Resolves:
## Summary/Motivation:
Reduces difference between WT and WT3 results for the crystallizer (subtype of brine_concentrator) by correcting elec_coefficient_3 and elec_coefficient_4 (should be negative).

## Changes proposed in this PR:
- revise brine_concentrator yaml file 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
