### PR TITLE
rename load_factor utilization_factor

### DIFF
--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -86,9 +86,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
 
         # Build flowsheet level costing components
         # This is package specific
-        self.load_factor = pyo.Var(
+        self.utilization_factor = pyo.Var(
             initialize=0.9,
-            doc="Load factor [fraction of uptime]",
+            doc="Plant capacity utilization [fraction of uptime]",
             units=pyo.units.dimensionless,
         )
         self.factor_total_investment = pyo.Var(
@@ -339,7 +339,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             == self.maintenance_labor_chemical_operating_cost
             + self.aggregate_fixed_operating_cost
             + self.aggregate_variable_operating_cost
-            + sum(self.aggregate_flow_costs.values()) * self.load_factor
+            + sum(self.aggregate_flow_costs.values()) * self.utilization_factor
         )
 
     def initialize_build(self):
@@ -382,7 +382,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                 pyo.units.convert(
                     flow_rate, to_units=pyo.units.m**3 / self.base_period
                 )
-                * self.load_factor
+                * self.utilization_factor
             ),
             doc=f"Constraint for Levelized Cost of Water based on flow {flow_rate.name}",
         )
@@ -406,7 +406,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                     pyo.units.convert(
                         flow_rate, to_units=pyo.units.m**3 / self.base_period
                     )
-                    * self.load_factor
+                    * self.utilization_factor
                 ),
                 doc=f"Annual water production based on flow {flow_rate.name}",
             ),

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -149,7 +149,7 @@ def build(
     m.fs.costing = WaterTAPCosting()
 
     # explicitly set the costing parameters used
-    m.fs.costing.load_factor.fix(0.9)
+    m.fs.costing.utilization_factor.fix(0.9)
     m.fs.costing.factor_total_investment.fix(2)
     m.fs.costing.factor_maintenance_labor_chemical.fix(0.03)
     m.fs.costing.factor_capital_annualization.fix(0.1)
@@ -352,7 +352,7 @@ def build(
         expr=pyunits.convert(
             m.fs.feed.properties[0].flow_vol, to_units=pyunits.m**3 / pyunits.year
         )
-        * m.fs.costing.load_factor
+        * m.fs.costing.utilization_factor
     )
     m.fs.final_permeate_concentration = Expression(
         expr=m.fs.product.flow_mass_phase_comp[0, "Liq", "NaCl"]
@@ -409,7 +409,7 @@ def build(
 
     m.fs.costing.electricity_lcow = Expression(
         expr=m.fs.costing.aggregate_flow_costs["electricity"]
-        * m.fs.costing.load_factor
+        * m.fs.costing.utilization_factor
         / m.fs.costing.annual_water_production
     )
 
@@ -1194,7 +1194,7 @@ def display_system(m):
     )
     electricity_cost = value(
         m.fs.costing.aggregate_flow_costs["electricity"]
-        * m.fs.costing.load_factor
+        * m.fs.costing.utilization_factor
         / m.fs.costing.annual_water_production
     )
     print(f"Electricity cost ($/m3): {electricity_cost}")


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
Name consistency between `WaterTAPCosting` and `ZeroOrderCosting`.

## Changes proposed in this PR:
- Rename `load_factor` to `utilization_factor` in `WaterTAPCosting`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
