### PR TITLE
Simple fix to remove _get_performance_contents from ED costing

### DIFF
--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -749,9 +749,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         if cost_electricity_flow:
             blk.costing_package.cost_flow(
                 pyo.units.convert(
-                    blk.unit_model._get_performance_contents(t0)["vars"][
-                        "Total electrical power consumption(Watt)"
-                    ],
+                    blk.unit_model.get_power_electrical(t0),
                     to_units=pyo.units.kW,
                 ),
                 "electricity",

--- a/watertap/unit_models/electrodialysis_0D.py
+++ b/watertap/unit_models/electrodialysis_0D.py
@@ -932,3 +932,6 @@ class Electrodialysis0DData(UnitModelBlockData):
             "exprs": {},
             "params": {},
         }
+
+    def get_power_electrical(self, time_point=0):
+        return self.power_electrical[time_point]

--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -1245,3 +1245,8 @@ class Electrodialysis1DData(UnitModelBlockData):
             "exprs": {},
             "params": {},
         }
+
+    def get_power_electrical(self, time_point=0):
+        return self.diluate.power_electrical_x[
+            time_point, self.diluate.length_domain.last()
+        ]


### PR DESCRIPTION
## Fixes/Resolves:

#613 

## Summary/Motivation:
Remove reference to the get performance dict from costing file. Simple solution is to have a function that just points to the correct var in both ED models. 

Alternative would be to use `add_object_reference` to the 1D ED model, but then we still need to handle the different indices that each of the `power_electrical` vars have. I think this is a good quick compromise. 

## Changes proposed in this PR:
- Adds a get_power_electrical function for 0D and 1D ED
- Uses get_power_electrical function in the costing package 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
