### PR TITLE
Add ability to specify a separate probe function within parameter sweep

### DIFF
--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -770,13 +770,16 @@ def _read_output_h5(filepath):
 
 # ================================================================
 
-def _param_sweep_kernel(model, optimize_function,
+
+def _param_sweep_kernel(
+    model,
+    optimize_function,
     optimize_kwargs,
     reinitialize_before_sweep,
     reinitialize_function,
     reinitialize_kwargs,
-    reinitialize_values
-    ):
+    reinitialize_values,
+):
 
     run_successful = False  # until proven otherwise
 
@@ -821,7 +824,9 @@ def _param_sweep_kernel(model, optimize_function,
 
     return run_successful
 
+
 # ================================================================
+
 
 def _do_param_sweep(
     model,
@@ -866,12 +871,16 @@ def _do_param_sweep(
 
         run_successful = False  # until proven otherwise
 
-        if test_function is None:
-            run_successful = _param_sweep_kernel(model, optimize_function, optimize_kwargs, reinitialize_before_sweep,
-                reinitialize_function, reinitialize_kwargs, reinitialize_values)
-        elif test_function(model):
-            run_successful = _param_sweep_kernel(model, optimize_function, optimize_kwargs, reinitialize_before_sweep,
-                reinitialize_function, reinitialize_kwargs, reinitialize_values)
+        if test_function is None or test_function(model):
+            run_successful = _param_sweep_kernel(
+                model,
+                optimize_function,
+                optimize_kwargs,
+                reinitialize_before_sweep,
+                reinitialize_function,
+                reinitialize_kwargs,
+                reinitialize_values,
+            )
 
         # Update the loop based on the reinitialization
         _update_local_output_dict(

--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -838,7 +838,7 @@ def _do_param_sweep(
     reinitialize_function,
     reinitialize_kwargs,
     reinitialize_before_sweep,
-    test_function,
+    probe_function,
     comm,
 ):
 
@@ -869,7 +869,7 @@ def _do_param_sweep(
         # Update the model values with a single combination from the parameter space
         _update_model_values(model, sweep_params, local_values[k, :])
 
-        if test_function is None or test_function(model):
+        if probe_function is None or probe_function(model):
             run_successful = _param_sweep_kernel(
                 model,
                 optimize_function,
@@ -1001,7 +1001,7 @@ def parameter_sweep(
     reinitialize_function=None,
     reinitialize_kwargs=None,
     reinitialize_before_sweep=False,
-    test_function=None,
+    probe_function=None,
     mpi_comm=None,
     debugging_data_dir=None,
     interpolate_nan_outputs=False,
@@ -1070,7 +1070,7 @@ def parameter_sweep(
                                               Note the parameter sweep model will try to reinitialize the
                                               solve regardless of the option if the run fails.
 
-        test_function (optional): A user-defined function that can cheaply test if a current model
+        probe_function (optional): A user-defined function that can cheaply check if a current model
                                   configuration is solvable without actually reinitializing or solving.
 
         mpi_comm (optional) : User-provided MPI communicator for parallel parameter sweeps.
@@ -1140,7 +1140,7 @@ def parameter_sweep(
         reinitialize_function,
         reinitialize_kwargs,
         reinitialize_before_sweep,
-        test_function,
+        probe_function,
         comm,
     )
 

--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -872,44 +872,6 @@ def _do_param_sweep(
         elif test_function(model):
             run_successful = _param_sweep_kernel(model, optimize_function, optimize_kwargs, reinitialize_before_sweep,
                 reinitialize_function, reinitialize_kwargs, reinitialize_values)
-            # Forced reinitialization of the flowsheet if enabled
-            # if reinitialize_before_sweep:
-            #     if reinitialize_function is None:
-            #         raise ValueError(
-            #             "Reinitialization function was not specified. The model will not be reinitialized."
-            #         )
-            #     else:
-            #         for v, val in reinitialize_values.items():
-            #             if not v.fixed:
-            #                 v.set_value(val, skip_validation=True)
-            #         reinitialize_function(model, **reinitialize_kwargs)
-            #
-            # try:
-            #     # Simulate/optimize with this set of parameter
-            #     with capture_output():
-            #         results = optimize_function(model, **optimize_kwargs)
-            #     pyo.assert_optimal_termination(results)
-            #
-            # except:
-            #     # run_successful remains false. We try to reinitialize and solve again
-            #     if reinitialize_function is not None:
-            #         for v, val in reinitialize_values.items():
-            #             if not v.fixed:
-            #                 v.set_value(val, skip_validation=True)
-            #         try:
-            #             reinitialize_function(model, **reinitialize_kwargs)
-            #             with capture_output():
-            #                 results = optimize_function(model, **optimize_kwargs)
-            #             pyo.assert_optimal_termination(results)
-            #
-            #         except:
-            #             pass  # run_successful is still False
-            #         else:
-            #             run_successful = True
-            #
-            # else:
-            #     # If the simulation suceeds, report stats
-            #     run_successful = True
 
         # Update the loop based on the reinitialization
         _update_local_output_dict(

--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -1070,6 +1070,9 @@ def parameter_sweep(
                                               Note the parameter sweep model will try to reinitialize the
                                               solve regardless of the option if the run fails.
 
+        test_function (optional): A user-defined function that can cheaply test if a current model
+                                  configuration is solvable without actually reinitializing or solving.
+
         mpi_comm (optional) : User-provided MPI communicator for parallel parameter sweeps.
                               If None COMM_WORLD will be used. The default is sufficient for most
                               users.

--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -770,6 +770,58 @@ def _read_output_h5(filepath):
 
 # ================================================================
 
+def _param_sweep_kernel(model, optimize_function,
+    optimize_kwargs,
+    reinitialize_before_sweep,
+    reinitialize_function,
+    reinitialize_kwargs,
+    reinitialize_values
+    ):
+
+    run_successful = False  # until proven otherwise
+
+    # Forced reinitialization of the flowsheet if enabled
+    if reinitialize_before_sweep:
+        if reinitialize_function is None:
+            raise ValueError(
+                "Reinitialization function was not specified. The model will not be reinitialized."
+            )
+        else:
+            for v, val in reinitialize_values.items():
+                if not v.fixed:
+                    v.set_value(val, skip_validation=True)
+            reinitialize_function(model, **reinitialize_kwargs)
+
+    try:
+        # Simulate/optimize with this set of parameter
+        with capture_output():
+            results = optimize_function(model, **optimize_kwargs)
+        pyo.assert_optimal_termination(results)
+
+    except:
+        # run_successful remains false. We try to reinitialize and solve again
+        if reinitialize_function is not None:
+            for v, val in reinitialize_values.items():
+                if not v.fixed:
+                    v.set_value(val, skip_validation=True)
+            try:
+                reinitialize_function(model, **reinitialize_kwargs)
+                with capture_output():
+                    results = optimize_function(model, **optimize_kwargs)
+                pyo.assert_optimal_termination(results)
+
+            except:
+                pass  # run_successful is still False
+            else:
+                run_successful = True
+
+    else:
+        # If the simulation suceeds, report stats
+        run_successful = True
+
+    return run_successful
+
+# ================================================================
 
 def _do_param_sweep(
     model,
@@ -781,6 +833,7 @@ def _do_param_sweep(
     reinitialize_function,
     reinitialize_kwargs,
     reinitialize_before_sweep,
+    test_function,
     comm,
 ):
 
@@ -800,6 +853,8 @@ def _do_param_sweep(
         reinitialize_values = ComponentMap()
         for v in model.component_data_objects(pyo.Var):
             reinitialize_values[v] = v.value
+    else:
+        reinitialize_values = None
 
     # ================================================================
     # Run all optimization cases
@@ -811,44 +866,50 @@ def _do_param_sweep(
 
         run_successful = False  # until proven otherwise
 
-        # Forced reinitialization of the flowsheet if enabled
-        if reinitialize_before_sweep:
-            if reinitialize_function is None:
-                raise ValueError(
-                    "Reinitialization function was not specified. The model will not be reinitialized."
-                )
-            else:
-                for v, val in reinitialize_values.items():
-                    if not v.fixed:
-                        v.set_value(val, skip_validation=True)
-                reinitialize_function(model, **reinitialize_kwargs)
-
-        try:
-            # Simulate/optimize with this set of parameter
-            with capture_output():
-                results = optimize_function(model, **optimize_kwargs)
-            pyo.assert_optimal_termination(results)
-
-        except:
-            # run_successful remains false. We try to reinitialize and solve again
-            if reinitialize_function is not None:
-                for v, val in reinitialize_values.items():
-                    if not v.fixed:
-                        v.set_value(val, skip_validation=True)
-                try:
-                    reinitialize_function(model, **reinitialize_kwargs)
-                    with capture_output():
-                        results = optimize_function(model, **optimize_kwargs)
-                    pyo.assert_optimal_termination(results)
-
-                except:
-                    pass  # run_successful is still False
-                else:
-                    run_successful = True
-
-        else:
-            # If the simulation suceeds, report stats
-            run_successful = True
+        if test_function is None:
+            run_successful = _param_sweep_kernel(model, optimize_function, optimize_kwargs, reinitialize_before_sweep,
+                reinitialize_function, reinitialize_kwargs, reinitialize_values)
+        elif test_function(model):
+            run_successful = _param_sweep_kernel(model, optimize_function, optimize_kwargs, reinitialize_before_sweep,
+                reinitialize_function, reinitialize_kwargs, reinitialize_values)
+            # Forced reinitialization of the flowsheet if enabled
+            # if reinitialize_before_sweep:
+            #     if reinitialize_function is None:
+            #         raise ValueError(
+            #             "Reinitialization function was not specified. The model will not be reinitialized."
+            #         )
+            #     else:
+            #         for v, val in reinitialize_values.items():
+            #             if not v.fixed:
+            #                 v.set_value(val, skip_validation=True)
+            #         reinitialize_function(model, **reinitialize_kwargs)
+            #
+            # try:
+            #     # Simulate/optimize with this set of parameter
+            #     with capture_output():
+            #         results = optimize_function(model, **optimize_kwargs)
+            #     pyo.assert_optimal_termination(results)
+            #
+            # except:
+            #     # run_successful remains false. We try to reinitialize and solve again
+            #     if reinitialize_function is not None:
+            #         for v, val in reinitialize_values.items():
+            #             if not v.fixed:
+            #                 v.set_value(val, skip_validation=True)
+            #         try:
+            #             reinitialize_function(model, **reinitialize_kwargs)
+            #             with capture_output():
+            #                 results = optimize_function(model, **optimize_kwargs)
+            #             pyo.assert_optimal_termination(results)
+            #
+            #         except:
+            #             pass  # run_successful is still False
+            #         else:
+            #             run_successful = True
+            #
+            # else:
+            #     # If the simulation suceeds, report stats
+            #     run_successful = True
 
         # Update the loop based on the reinitialization
         _update_local_output_dict(
@@ -969,6 +1030,7 @@ def parameter_sweep(
     reinitialize_function=None,
     reinitialize_kwargs=None,
     reinitialize_before_sweep=False,
+    test_function=None,
     mpi_comm=None,
     debugging_data_dir=None,
     interpolate_nan_outputs=False,
@@ -1104,6 +1166,7 @@ def parameter_sweep(
         reinitialize_function,
         reinitialize_kwargs,
         reinitialize_before_sweep,
+        test_function,
         comm,
     )
 

--- a/watertap/tools/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep.py
@@ -869,8 +869,6 @@ def _do_param_sweep(
         # Update the model values with a single combination from the parameter space
         _update_model_values(model, sweep_params, local_values[k, :])
 
-        run_successful = False  # until proven otherwise
-
         if test_function is None or test_function(model):
             run_successful = _param_sweep_kernel(
                 model,
@@ -881,6 +879,8 @@ def _do_param_sweep(
                 reinitialize_kwargs,
                 reinitialize_values,
             )
+        else:
+            run_successful = False
 
         # Update the loop based on the reinitialization
         _update_local_output_dict(

--- a/watertap/tools/recursive_parameter_sweep.py
+++ b/watertap/tools/recursive_parameter_sweep.py
@@ -126,6 +126,7 @@ def recursive_parameter_sweep(
     reinitialize_function=None,
     reinitialize_kwargs=None,
     reinitialize_before_sweep=False,
+    test_function=None,
     mpi_comm=None,
     debugging_data_dir=None,
     interpolate_nan_outputs=False,
@@ -176,6 +177,7 @@ def recursive_parameter_sweep(
             reinitialize_function,
             reinitialize_kwargs,
             reinitialize_before_sweep,
+            test_function,
             comm,
         )
 

--- a/watertap/tools/recursive_parameter_sweep.py
+++ b/watertap/tools/recursive_parameter_sweep.py
@@ -126,7 +126,7 @@ def recursive_parameter_sweep(
     reinitialize_function=None,
     reinitialize_kwargs=None,
     reinitialize_before_sweep=False,
-    test_function=None,
+    probe_function=None,
     mpi_comm=None,
     debugging_data_dir=None,
     interpolate_nan_outputs=False,
@@ -177,7 +177,7 @@ def recursive_parameter_sweep(
             reinitialize_function,
             reinitialize_kwargs,
             reinitialize_before_sweep,
-            test_function,
+            probe_function,
             comm,
         )
 

--- a/watertap/tools/tests/test_parameter_sweep.py
+++ b/watertap/tools/tests/test_parameter_sweep.py
@@ -1464,30 +1464,20 @@ class TestParallelManager:
                         "lower bound": 0,
                         "units": "None",
                         "upper bound": 1,
-                        "value": np.array(
-                            [np.nan] * 9
-                        ),
+                        "value": np.array([np.nan] * 9),
                     },
                     "output_d": {
                         "lower bound": 0,
                         "units": "None",
                         "upper bound": 1,
                         "value": np.array(
-                            np.array(
-                                [np.nan] * 9
-                            ),
+                            np.array([np.nan] * 9),
                         ),
                     },
-                    "performance": {
-                        "value": np.array(
-                            [np.nan] * 9
-                        )
-                    },
+                    "performance": {"value": np.array([np.nan] * 9)},
                     "objective": {
                         "value": np.array(
-                            np.array(
-                                [np.nan] * 9
-                            ),
+                            np.array([np.nan] * 9),
                         )
                     },
                 },
@@ -1542,8 +1532,10 @@ def _get_rank0_path(comm, tmp_path):
         return tmp_path
     return comm.bcast(tmp_path, root=0)
 
+
 def _good_test_function(m):
     return True
+
 
 def _bad_test_function(m):
     return False

--- a/watertap/tools/tests/test_parameter_sweep.py
+++ b/watertap/tools/tests/test_parameter_sweep.py
@@ -847,6 +847,7 @@ class TestParallelManager:
             h5_results_file_name=h5_results_file_name,
             optimize_function=_optimization,
             optimize_kwargs={"relax_feasibility": True},
+            test_function=_good_test_function,
             mpi_comm=comm,
         )
 
@@ -1404,6 +1405,118 @@ class TestParallelManager:
                 mpi_comm=comm,
             )
 
+    @pytest.mark.component
+    def test_parameter_sweep_bad_test_function(self, model, tmp_path):
+        comm, rank, num_procs = _init_mpi()
+        tmp_path = _get_rank0_path(comm, tmp_path)
+
+        m = model
+        m.fs.slack_penalty = 1000.0
+        m.fs.slack.setub(0)
+
+        A = m.fs.input["a"]
+        B = m.fs.input["b"]
+        sweep_params = {A.name: (A, 0.1, 0.9, 3), B.name: (B, 0.0, 0.5, 3)}
+        outputs = {
+            "output_c": m.fs.output["c"],
+            "output_d": m.fs.output["d"],
+            "performance": m.fs.performance,
+            "objective": m.objective,
+        }
+        results_fname = os.path.join(tmp_path, "global_results")
+        csv_results_file_name = str(results_fname) + ".csv"
+        h5_results_file_name = str(results_fname) + ".h5"
+
+        # Call the parameter_sweep function
+        global_save_data = parameter_sweep(
+            m,
+            sweep_params,
+            outputs=outputs,
+            csv_results_file_name=csv_results_file_name,
+            h5_results_file_name=h5_results_file_name,
+            optimize_function=_optimization,
+            optimize_kwargs={"relax_feasibility": True},
+            test_function=_bad_test_function,
+            mpi_comm=comm,
+        )
+
+        if rank == 0:
+            # Check that the global results file is created
+            assert os.path.isfile(csv_results_file_name)
+
+            # Attempt to read in the data
+            data = np.genfromtxt(csv_results_file_name, skip_header=1, delimiter=",")
+            # Compare the last row of the imported data to truth
+            truth_data = [
+                0.9,
+                0.5,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+            ]
+
+            assert np.allclose(data[-1], truth_data, equal_nan=True)
+
+            truth_dict = {
+                "outputs": {
+                    "output_c": {
+                        "lower bound": 0,
+                        "units": "None",
+                        "upper bound": 1,
+                        "value": np.array(
+                            [np.nan] * 9
+                        ),
+                    },
+                    "output_d": {
+                        "lower bound": 0,
+                        "units": "None",
+                        "upper bound": 1,
+                        "value": np.array(
+                            np.array(
+                                [np.nan] * 9
+                            ),
+                        ),
+                    },
+                    "performance": {
+                        "value": np.array(
+                            [np.nan] * 9
+                        )
+                    },
+                    "objective": {
+                        "value": np.array(
+                            np.array(
+                                [np.nan] * 9
+                            ),
+                        )
+                    },
+                },
+                "solve_successful": [False] * 9,
+                "sweep_params": {
+                    "fs.input[a]": {
+                        "lower bound": 0,
+                        "units": "None",
+                        "upper bound": 1,
+                        "value": np.array(
+                            [0.1, 0.1, 0.1, 0.5, 0.5, 0.5, 0.9, 0.9, 0.9]
+                        ),
+                    },
+                    "fs.input[b]": {
+                        "lower bound": 0,
+                        "units": "None",
+                        "upper bound": 1,
+                        "value": np.array(
+                            [0.0, 0.25, 0.5, 0.0, 0.25, 0.5, 0.0, 0.25, 0.5]
+                        ),
+                    },
+                },
+            }
+
+            read_dict = _read_output_h5(h5_results_file_name)
+
+            _assert_dictionary_correctness(truth_dict, read_dict)
+            _assert_h5_csv_agreement(csv_results_file_name, read_dict)
+
 
 def _optimization(m, relax_feasibility=False):
     if relax_feasibility:
@@ -1428,6 +1541,12 @@ def _get_rank0_path(comm, tmp_path):
     if comm is None:
         return tmp_path
     return comm.bcast(tmp_path, root=0)
+
+def _good_test_function(m):
+    return True
+
+def _bad_test_function(m):
+    return False
 
 
 def _assert_dictionary_correctness(truth_dict, test_dict):

--- a/watertap/tools/tests/test_parameter_sweep.py
+++ b/watertap/tools/tests/test_parameter_sweep.py
@@ -847,7 +847,7 @@ class TestParallelManager:
             h5_results_file_name=h5_results_file_name,
             optimize_function=_optimization,
             optimize_kwargs={"relax_feasibility": True},
-            test_function=_good_test_function,
+            probe_function=_good_test_function,
             mpi_comm=comm,
         )
 
@@ -1436,7 +1436,7 @@ class TestParallelManager:
             h5_results_file_name=h5_results_file_name,
             optimize_function=_optimization,
             optimize_kwargs={"relax_feasibility": True},
-            test_function=_bad_test_function,
+            probe_function=_bad_test_function,
             mpi_comm=comm,
         )
 


### PR DESCRIPTION
## Fixes/Resolves:

This PR adds an option to specify a light weight test function to check whether the pyomo model can be initialized and solved with the current values.

## Summary/Motivation:

Larger and more complicated Watertap models can take a long time to initialize and then solve. It is possible to cheaply check whether the model within the parameter sweep loop can be solved without attempting to initialize and solve the full model.

## Changes proposed in this PR:
- Create a separate function called _param_sweep_kernel which contains the kernel being called in the parameter sweep loop.
- Add an if statement that checks whether a test_function was specified or if it returns a True value.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
