### PR TITLE
Get rid of some depr warnings = Fix imports on UV-AOP and ED 1D 

### DIFF
--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -15,17 +15,14 @@
 from pyomo.environ import (
     Set,
     Var,
-    Param,
     Suffix,
     Constraint,
     NonNegativeReals,
     NonNegativeIntegers,
-    Reference,
     value,
     units as pyunits,
 )
 from pyomo.dae import (
-    ContinuousSet,
     DerivativeVar,
 )
 from pyomo.common.config import ConfigBlock, ConfigValue, In
@@ -38,16 +35,13 @@ from idaes.core import (
     ControlVolume1DBlock,
     declare_process_block_class,
     MaterialBalanceType,
-    EnergyBalanceType,
     MomentumBalanceType,
     UnitModelBlockData,
     useDefault,
-    MaterialFlowBasis,
 )
-from idaes.core.control_volume1d import DistributedVars
+from idaes.core.base.control_volume1d import DistributedVars
 from idaes.core.util.constants import Constants
-from idaes.core.util.misc import add_object_reference
-from idaes.core.util import get_solver
+from idaes.core.solvers.get_solver import get_solver
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError

--- a/watertap/unit_models/uv_aop.py
+++ b/watertap/unit_models/uv_aop.py
@@ -13,16 +13,17 @@
 
 # Import Pyomo libraries
 from pyomo.environ import (
-    Block,
-    Set,
-    Var,
-    Param,
-    Suffix,
     NonNegativeReals,
-    Reference,
+    exp,
+    log10,
+    Param,
+    Var,
+    Set,
+    Suffix,
     units as pyunits,
 )
-from pyomo.environ import *
+
+# from pyomo.environ import *
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
 # Import IDAES cores
@@ -35,12 +36,11 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.util import get_solver
+from idaes.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
-from idaes.core.util.math import smooth_min, smooth_max
 
 _log = idaeslog.getLogger(__name__)
 


### PR DESCRIPTION
## Fixes/Resolves: #628 
## Summary/Motivation:
Eliminate deprecation warnings related to UV-AOP and DitributedVars (tied to ED 1D import).

## Changes proposed in this PR:
- remove unnecessary imports
- update specific imports 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
