### PR TITLE
Address IDAES v2 change in `ProcessBlock` kwargs API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ SPECIAL_DEPENDENCIES_FOR_PRERELEASE = [
     # update with a tag from the nawi-hub/idaes-pse
     # when a version of IDAES newer than the latest stable release from PyPI
     # will become needed for the watertap development
-    "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/2.0.0a2.zip"
+    "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/f0e136f61663214ce69fb52c001a3e21c42f7862.zip"
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.


### PR DESCRIPTION
## Summary/Motivation:

- Preparations for IDAES Aug release
- Most significant is the changes in the kwargs usage for `ProcessBlock`, which introduces deprecations for when the old API with the `default={...}` kwarg is used
- To ensure that all instances of code causing deprecations have been addressed, we should a more robust way to enforce this
  - Currently we're relying on some of the doctests failing when unexpected output is emitted to stdout, which is not very reliable

## Changes proposed in this PR:

- Update prerelease requirement for `idaes-pse` in `setup.py`


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
