### PR TITLE
Update idaes-pse prerelease requirement to IDAES/idaes-pse#925

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ SPECIAL_DEPENDENCIES_FOR_PRERELEASE = [
     # update with a tag from the nawi-hub/idaes-pse
     # when a version of IDAES newer than the latest stable release from PyPI
     # will become needed for the watertap development
-    "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/2.0.0a2.zip"
+    "idaes-pse @ https://github.com/watertap-org/idaes-pse/archive/2.0.0.dev3.watertap.22.08.11.zip"
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.


### PR DESCRIPTION
## Summary/Motivation:

- Bring in the changes from IDAES/idaes-pse#925

## Changes proposed in this PR:
- Update `setup.py` to point to latest watertap-org/idaes-pse tag `2.0.0.dev3.watertap.22.08.11`
- **NOTE** the `2.0.0.dev3.watertap.22.08.11` tag is **not** pointing to the latest commit on `main`, since that commit introduces new deprecations that will be addressed separately
- This shouldn't affect anything in practical terms but I though it would be good to bring this up since usually the most recent tag happens to point to the most recent commit on `main`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
