### PR TITLE
Enforced guard on which builds do EDB

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,7 +119,7 @@ jobs:
         bash -c 'grep "SKIPPED" "$_pytest_output_to_inspect" ; test $? -eq 1'
         echo '::endgroup::'
     - name: Require EDB tests to connect to MongoDB if server is set up
-      # if: matrix.mongodb_server
+      if: matrix.mongodb_server
       run:
         |
         # --pyargs watertap is needed to be able to define the CLI options in watertap/conftest.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,8 +16,9 @@ defaults:
     shell: bash -l {0}
 
 env:
-  # needed for colorized output to be shown in GHA logs
-  PYTEST_ADDOPTS: "--color=yes"
+  # --color=yes needed for colorized output to be shown in GHA logs
+  # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py
+  PYTEST_ADDOPTS: "--color=yes --pyargs watertap"
 
 jobs:
 
@@ -122,9 +123,7 @@ jobs:
       if: matrix.mongodb_server
       run:
         |
-        # --pyargs watertap is needed to be able to define the CLI options in watertap/conftest.py
-        # 
-        echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --pyargs watertap --edb-no-mock" >> $GITHUB_ENV
+        echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --edb-no-mock" >> $GITHUB_ENV
     - name: Test EDB client
       run: pytest -k test_edb_client
     - name: Add coverage report pytest options


### PR DESCRIPTION
This will only try EDB on Linux now

## Fixes/Resolves:

EDB tests breaking across all PRs


## Changes proposed in this PR:
- one-line change, uncommented an 'if' that prevents the builds on non-Linux

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
