### PR TITLE
API for UI: guarantee flowsheet name

### DIFF
--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -81,13 +81,15 @@ class FlowsheetExport(BaseModel):
     model_objects: Dict[str, ModelExport] = {}
 
     # set name dynamically from object
-    @validator("name")
+    @validator("name", always=True)
     def validate_name(cls, v, values):
         if not v:
             try:
                 v = values["obj"].name
             except (KeyError, AttributeError):
-                v = "none"
+                pass
+            if not v:
+                v = "default"
         return v
 
     @validator("description", always=True)


### PR DESCRIPTION
## Fixes/Resolves:

Always set a default name for flowsheet (if none given)

See https://github.com/watertap-org/watertap-ui/issues/37

## Summary/Motivation:
Needed by https://github.com/watertap-org/watertap-ui/pull/36

## Changes proposed in this PR:
- a little logic in name validator

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
