### PR TITLE
Require do_xxx methods for API

### DIFF
--- a/examples/ui/api_example.py
+++ b/examples/ui/api_example.py
@@ -1,16 +1,20 @@
 from watertap.ui.fsapi import FlowsheetInterface
+from idaes.core.solvers import get_solver
 
 
 def export_to_ui():
     return FlowsheetInterface(
-        do_export=export_variables, do_build=build_flowsheet, do_solve=solve_flowsheet
+        name="foo",
+        do_export=export_variables,
+        do_build=build_flowsheet,
+        do_solve=solve_flowsheet,
     )
 
 
 def export_variables(flowsheet=None, exports=None):
     for n in 1, 2:
         t = getattr(flowsheet, f"Tank{n}")
-        exports.add(obj=t.inlet.flow_vol[0], name="Tank {n} inlet flowrate")
+        exports.add(obj=t.inlet.flow_vol[0], name=f"Tank {n} inlet flowrate")
     # ..etc..
 
 
@@ -20,7 +24,9 @@ def build_flowsheet():
 
 
 def solve_flowsheet(flowsheet=None):
-    return flowsheet.solve()
+    solver = get_solver()
+    # results = solver.solve(flowsheet)
+    return {}
 
 
 def example_flowsheet():
@@ -94,7 +100,9 @@ def example_flowsheet():
     m.fs.Tank2.volume.fix(1.0)
     m.fs.Tank2.heat_duty.fix(0.0)
 
-    # # Initialize Units
+    return m
+
+    # Initialize Units
     # m.fs.Tank1.initialize()
     # m.fs.Tank2.initialize(state_args={
     #         "flow_vol": 1.0,
@@ -105,5 +113,4 @@ def example_flowsheet():
     #                           "Ethanol": 0.0},
     #         "temperature": 303.15,
     #         "pressure": 101325.0})
-
-    return m
+    #

--- a/examples/ui/api_example.py
+++ b/examples/ui/api_example.py
@@ -2,7 +2,9 @@ from watertap.ui.fsapi import FlowsheetInterface
 
 
 def export_to_ui():
-    return FlowsheetInterface(do_export=export_variables, do_build=build_flowsheet)
+    return FlowsheetInterface(
+        do_export=export_variables, do_build=build_flowsheet, do_solve=solve_flowsheet
+    )
 
 
 def export_variables(flowsheet=None, exports=None):

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -187,18 +187,17 @@ class FlowsheetInterface:
         else:
             self.fs_exp = fs
         self._actions = {}
-        if do_export:
-            self.add_action(Actions.export, do_export)
-        else:
-            raise ValueError("'do_export' argument is required")
-        if do_build:
-            self.add_action(Actions.build, do_build)
-        else:
-            raise ValueError("'do_build' argument is required")
-        if do_solve:
-            self.add_action(Actions.solve, do_solve)
-        else:
-            raise ValueError("'do_solve' argument is required")
+        for arg, name in (
+            (do_export, "export"),
+            (do_build, "build"),
+            (do_solve, "solve"),
+        ):
+            if arg:
+                if not callable(arg):
+                    raise TypeError(f"'do_{name}' argument must be callable")
+                self.add_action(getattr(Actions, name), arg)
+            else:
+                raise ValueError(f"'do_{name}' argument is required")
 
     def build(self, **kwargs):
         """Build flowsheet

--- a/watertap/ui/tests/test_fsapi.py
+++ b/watertap/ui/tests/test_fsapi.py
@@ -77,19 +77,25 @@ def flowsheet_interface(exports=True):
     )
 
 
+def noop(*args, **kwargs):
+    return
+
+
 @pytest.mark.unit
 def test_create_interface():
-    fsi = flowsheet_interface(exports=False)
+    with pytest.raises(ValueError):
+        _ = flowsheet_interface(exports=False)
     fsi = flowsheet_interface()
-    fs2 = fsapi.FlowsheetInterface(fs=fsi.fs_exp)
+    fs2 = fsapi.FlowsheetInterface(
+        fs=fsi.fs_exp, do_build=noop, do_export=noop, do_solve=noop
+    )
     assert fs2.fs_exp == fsi.fs_exp
 
 
 @pytest.mark.unit
 def test_build_noexport():
-    fsi = flowsheet_interface(exports=False)
-    with pytest.raises(KeyError):
-        fsi.build(erd_type="pressure_exchanger")
+    with pytest.raises(ValueError):
+        flowsheet_interface(exports=False)
 
 
 @pytest.mark.unit
@@ -185,5 +191,4 @@ def test_find():
     assert len(result) == 1  # expect only 1 module (1 was bad)
     interface = list(result.values())[0]  # get the module function
     interface.build()  # make sure the module exported properly
-    with pytest.raises(KeyError):
-        interface.solve()
+    interface.solve()

--- a/watertap/ui/tests/test_fsapi.py
+++ b/watertap/ui/tests/test_fsapi.py
@@ -192,3 +192,22 @@ def test_find():
     interface = list(result.values())[0]  # get the module function
     interface.build()  # make sure the module exported properly
     interface.solve()
+
+
+@pytest.mark.unit
+def test_require_methods():
+    fsi = flowsheet_interface()
+    methods = ("do_export", "do_build", "do_solve")
+    kwargs = {m: noop for m in methods}
+    # make one method 'bad' at a time
+    for meth in methods:
+        # missing
+        badkw = kwargs.copy()
+        del badkw[meth]
+        with pytest.raises(ValueError):
+            _ = fsapi.FlowsheetInterface(fsi, **badkw)
+        # not callable
+        badkw = kwargs.copy()
+        badkw[meth] = 1
+        with pytest.raises(TypeError):
+            _ = fsapi.FlowsheetInterface(fsi, **badkw)


### PR DESCRIPTION
## Fixes/Resolves:

See https://github.com/watertap-org/watertap-ui/issues/37

## Summary/Motivation:
Needed for https://github.com/watertap-org/watertap-ui/pull/36

## Changes proposed in this PR:
- fail immediately if `do_build`, `do_export`, or `do_solve` are not provided when building the flowsheet interface

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
