### PR TITLE
Moving unit-costing parameters to their own block

### DIFF
--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -166,7 +166,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                 units=pyo.units.year**-1,
             )
             blk.reactor_cost = pyo.Var(
-                initialize=172.158,
+                initialize=202.346,
                 doc="UV reactor cost",
                 units=costing.base_currency / (pyo.units.m**3 / pyo.units.hr),
             )

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -88,7 +88,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         self.base_period = pyo.units.year
 
         # Build flowsheet level costing components
-        # This is package specific
+        # These are the global parameters
         self.utilization_factor = pyo.Var(
             initialize=0.9,
             doc="Plant capacity utilization [fraction of uptime]",
@@ -109,86 +109,6 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             doc="Capital annualization factor [fraction of investment cost/year]",
             units=pyo.units.year**-1,
         )
-        self.factor_membrane_replacement = pyo.Var(
-            initialize=0.2,
-            doc="Membrane replacement factor [fraction of membrane replaced/year]",
-            units=pyo.units.year**-1,
-        )
-        self.factor_uv_lamp_replacement = pyo.Var(
-            initialize=0.33278,
-            doc="UV replacement factor accounting for lamps, sleeves, ballasts and sensors [fraction of uv replaced/year]",
-            units=pyo.units.year**-1,
-        )
-        self.reverse_osmosis_membrane_cost = pyo.Var(
-            initialize=30,
-            doc="Membrane cost",
-            units=self.base_currency / (pyo.units.meter**2),
-        )
-        self.reverse_osmosis_high_pressure_membrane_cost = pyo.Var(
-            initialize=75,
-            doc="Membrane cost",
-            units=self.base_currency / (pyo.units.meter**2),
-        )
-        self.nanofiltration_membrane_cost = pyo.Var(
-            initialize=15,
-            doc="Membrane cost",
-            units=self.base_currency / (pyo.units.meter**2),
-        )
-        self.uv_reactor_cost = pyo.Var(
-            initialize=172.158,
-            doc="UV reactor cost",
-            units=self.base_currency / (pyo.units.m**3 / pyo.units.hr),
-        )
-        self.uv_lamp_cost = pyo.Var(
-            initialize=235.5,
-            doc="UV lamps, sleeves, ballasts and sensors cost",
-            units=self.base_currency / pyo.units.kW,
-        )
-        self.high_pressure_pump_cost = pyo.Var(
-            initialize=53 / 1e5 * 3600,
-            doc="High pressure pump cost",
-            units=self.base_currency / pyo.units.watt,
-        )
-        self.low_pressure_pump_cost = pyo.Var(
-            initialize=889,
-            doc="Low pressure pump cost",
-            units=self.base_currency / (pyo.units.liter / pyo.units.second),
-        )
-        self.erd_pressure_exchanger_cost = pyo.Var(
-            initialize=535,
-            doc="Pressure exchanger cost",
-            units=self.base_currency / (pyo.units.meter**3 / pyo.units.hours),
-        )
-        self.pressure_exchanger_cost = pyo.Var(
-            initialize=535,
-            doc="Pressure exchanger cost",
-            units=self.base_currency / (pyo.units.meter**3 / pyo.units.hours),
-        )
-        self.energy_recovery_device_linear_coefficient = pyo.Var(
-            initialize=3134.7,
-            doc="Energy recovery device linear coefficient",
-            units=self.base_currency,
-        )
-        self.energy_recovery_device_exponent = pyo.Var(
-            initialize=0.58,
-            doc="Energy recovery device exponent",
-            units=pyo.units.dimensionless,
-        )
-        self.mixer_unit_cost = pyo.Var(
-            initialize=361,
-            doc="Mixer cost",
-            units=self.base_currency / (pyo.units.liters / pyo.units.second),
-        )
-        self.naocl_mixer_unit_cost = pyo.Var(
-            initialize=5.08,
-            doc="NaOCl mixer cost",
-            units=self.base_currency / (pyo.units.m**3 / pyo.units.day),
-        )
-        self.caoh2_mixer_unit_cost = pyo.Var(
-            initialize=792.8 * 2.20462,
-            doc="Ca(OH)2 mixer cost",
-            units=self.base_currency / (pyo.units.kg / pyo.units.day),
-        )
 
         self.electricity_base_cost = pyo.Param(
             mutable=True,
@@ -196,94 +116,278 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             doc="Electricity cost",
             units=self.base_currency / pyo.units.kWh,
         )
-        self.naocl_cost = pyo.Param(
-            initialize=0.23, doc="NaOCl cost", units=self.base_currency / pyo.units.kg
-        )
-        self.naocl_purity = pyo.Param(
-            mutable=True,
-            initialize=0.15,
-            doc="NaOCl purity",
-            units=pyo.units.dimensionless,
-        )
-        self.caoh2_cost = pyo.Param(
-            mutable=True,
-            initialize=0.12,
-            doc="CaOH2 cost",
-            units=self.base_currency / pyo.units.kg,
-        )
-        self.caoh2_purity = pyo.Param(
-            mutable=True,
-            initialize=1,
-            doc="CaOH2 purity",
-            units=pyo.units.dimensionless,
+
+        def build_reverse_osmosis_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.factor_membrane_replacement = pyo.Var(
+                initialize=0.2,
+                doc="Membrane replacement factor [fraction of membrane replaced/year]",
+                units=pyo.units.year**-1,
+            )
+            blk.membrane_cost = pyo.Var(
+                initialize=30,
+                doc="Membrane cost",
+                units=costing.base_currency / (pyo.units.meter**2),
+            )
+            blk.high_pressure_membrane_cost = pyo.Var(
+                initialize=75,
+                doc="Membrane cost",
+                units=costing.base_currency / (pyo.units.meter**2),
+            )
+
+        self.reverse_osmosis = pyo.Block(rule=build_reverse_osmosis_cost_param_block)
+
+        def build_nanofiltration_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.factor_membrane_replacement = pyo.Var(
+                initialize=0.2,
+                doc="Membrane replacement factor [fraction of membrane replaced/year]",
+                units=pyo.units.year**-1,
+            )
+            blk.membrane_cost = pyo.Var(
+                initialize=15,
+                doc="Membrane cost",
+                units=costing.base_currency / (pyo.units.meter**2),
+            )
+
+        self.nanofiltration = pyo.Block(rule=build_nanofiltration_cost_param_block)
+
+        def build_uv_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.factor_lamp_replacement = pyo.Var(
+                initialize=0.33278,
+                doc="UV replacement factor accounting for lamps, sleeves, ballasts and sensors [fraction of uv replaced/year]",
+                units=pyo.units.year**-1,
+            )
+            blk.reactor_cost = pyo.Var(
+                initialize=172.158,
+                doc="UV reactor cost",
+                units=costing.base_currency / (pyo.units.m**3 / pyo.units.hr),
+            )
+            blk.lamp_cost = pyo.Var(
+                initialize=235.5,
+                doc="UV lamps, sleeves, ballasts and sensors cost",
+                units=costing.base_currency / pyo.units.kW,
+            )
+
+        self.ultraviolet = pyo.Block(rule=build_uv_cost_param_block)
+
+        def build_high_pressure_pump_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.cost = pyo.Var(
+                initialize=53 / 1e5 * 3600,
+                doc="High pressure pump cost",
+                units=costing.base_currency / pyo.units.watt,
+            )
+
+        self.high_pressure_pump = pyo.Block(
+            rule=build_high_pressure_pump_cost_param_block
         )
 
-        self.electrodialysis_cem_membrane_cost = pyo.Var(
-            initialize=43,
-            doc="Cost of CEM membrane used in Electrodialysis ($/CEM/area)",
-            units=self.base_currency / (pyo.units.meter**2),
-        )
-        self.electrodialysis_aem_membrane_cost = pyo.Var(
-            initialize=43,
-            doc="Cost of AEM membrane used in Electrodialysis ($/AEM/area)",
-            units=self.base_currency / (pyo.units.meter**2),
-        )
-        self.electrodialysis_flowspacer_cost = pyo.Var(
-            initialize=3,
-            doc="Cost of the spacers used in Electrodialysis ($/spacer/area)",
-            units=self.base_currency / (pyo.units.meter**2),
-        )
-        self.factor_electrodialysis_membrane_housing_replacement = pyo.Var(
-            initialize=0.2,
-            doc="Membrane housing replacement factor for CEM, AEM, and spacer replacements [fraction of membrane replaced/year]",
-            units=pyo.units.year**-1,
-        )
-        self.electrodialysis_electrode_cost = pyo.Var(
-            initialize=2000,
-            doc="Cost of the electrodes used in Electrodialysis ($/electrode/area)",
-            units=self.base_currency / (pyo.units.meter**2),
-        )
-        self.factor_electrodialysis_electrode_replacement = pyo.Var(
-            initialize=0.02,
-            doc="Electrode replacements [fraction of electrode replaced/year]",
-            units=pyo.units.year**-1,
+        def build_low_pressure_pump_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.cost = pyo.Var(
+                initialize=889,
+                doc="Low pressure pump cost",
+                units=costing.base_currency / (pyo.units.liter / pyo.units.second),
+            )
+
+        self.low_pressure_pump = pyo.Block(
+            rule=build_low_pressure_pump_cost_param_block
         )
 
-        self.fc_crystallizer_fob_unit_cost = pyo.Var(
-            initialize=675000,
-            doc="Forced circulation crystallizer reference free-on-board cost (Woods, 2007)",
-            units=pyo.units.USD_2007,
+        def build_energy_recovery_device_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.pressure_exchanger_cost = pyo.Var(
+                initialize=535,
+                doc="Pressure exchanger cost",
+                units=costing.base_currency / (pyo.units.meter**3 / pyo.units.hours),
+            )
+
+        self.energy_recovery_device = pyo.Block(
+            rule=build_energy_recovery_device_cost_param_block
         )
 
-        self.fc_crystallizer_ref_capacity = pyo.Var(
-            initialize=1,
-            doc="Forced circulation crystallizer reference crystal capacity (Woods, 2007)",
-            units=pyo.units.kg / pyo.units.s,
+        def build_pressure_exchanger_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.cost = pyo.Var(
+                initialize=535,
+                doc="Pressure exchanger cost",
+                units=costing.base_currency / (pyo.units.meter**3 / pyo.units.hours),
+            )
+
+        self.pressure_exchanger = pyo.Block(
+            rule=build_pressure_exchanger_cost_param_block
         )
 
-        self.fc_crystallizer_ref_exponent = pyo.Var(
-            initialize=0.53,
-            doc="Forced circulation crystallizer cost exponent factor (Woods, 2007)",
-            units=pyo.units.dimensionless,
-        )
+        def build_mixer_cost_param_block(blk):
 
-        self.fc_crystallizer_iec_percent = pyo.Var(
-            initialize=1.43,
-            doc="Forced circulation crystallizer installed equipment cost (Diab and Gerogiorgis, 2017)",
-            units=pyo.units.dimensionless,
-        )
+            costing = blk.parent_block()
 
-        self.fc_crystallizer_volume_cost = pyo.Var(
-            initialize=16320,
-            doc="Forced circulation crystallizer cost per volume (Yusuf et al., 2019)",
-            units=pyo.units.USD_2007,  ## TODO: Needs confirmation, but data is from Perry apparently
-        )
+            blk.unit_cost = pyo.Var(
+                initialize=361,
+                doc="Mixer cost",
+                units=costing.base_currency / (pyo.units.liters / pyo.units.second),
+            )
 
-        self.fc_crystallizer_vol_basis_exponent = pyo.Var(
-            initialize=0.47,
-            doc="Forced circulation crystallizer volume-based cost exponent (Yusuf et al., 2019)",
-            units=pyo.units.dimensionless,
-        )
+        self.mixer = pyo.Block(rule=build_mixer_cost_param_block)
+
+        def build_naocl_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.mixer_unit_cost = pyo.Var(
+                initialize=5.08,
+                doc="NaOCl mixer cost",
+                units=costing.base_currency / (pyo.units.m**3 / pyo.units.day),
+            )
+            blk.cost = pyo.Param(
+                initialize=0.23,
+                doc="NaOCl cost",
+                units=costing.base_currency / pyo.units.kg,
+            )
+            blk.purity = pyo.Param(
+                mutable=True,
+                initialize=0.15,
+                doc="NaOCl purity",
+                units=pyo.units.dimensionless,
+            )
+
+        self.naocl = pyo.Block(rule=build_naocl_cost_param_block)
+
+        def build_caoh2_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.mixer_unit_cost = pyo.Var(
+                initialize=792.8 * 2.20462,
+                doc="Ca(OH)2 mixer cost",
+                units=costing.base_currency / (pyo.units.kg / pyo.units.day),
+            )
+            blk.cost = pyo.Param(
+                mutable=True,
+                initialize=0.12,
+                doc="CaOH2 cost",
+                units=costing.base_currency / pyo.units.kg,
+            )
+            blk.purity = pyo.Param(
+                mutable=True,
+                initialize=1,
+                doc="CaOH2 purity",
+                units=pyo.units.dimensionless,
+            )
+
+        self.caoh2 = pyo.Block(rule=build_caoh2_cost_param_block)
+
+        def build_electrodialysis_cost_param_block(blk):
+
+            costing = blk.parent_block()
+
+            blk.cem_membrane_cost = pyo.Var(
+                initialize=43,
+                doc="Cost of CEM membrane used in Electrodialysis ($/CEM/area)",
+                units=costing.base_currency / (pyo.units.meter**2),
+            )
+            blk.aem_membrane_cost = pyo.Var(
+                initialize=43,
+                doc="Cost of AEM membrane used in Electrodialysis ($/AEM/area)",
+                units=costing.base_currency / (pyo.units.meter**2),
+            )
+            blk.flowspacer_cost = pyo.Var(
+                initialize=3,
+                doc="Cost of the spacers used in Electrodialysis ($/spacer/area)",
+                units=costing.base_currency / (pyo.units.meter**2),
+            )
+            blk.factor_membrane_housing_replacement = pyo.Var(
+                initialize=0.2,
+                doc="Membrane housing replacement factor for CEM, AEM, and spacer replacements [fraction of membrane replaced/year]",
+                units=pyo.units.year**-1,
+            )
+            blk.electrode_cost = pyo.Var(
+                initialize=2000,
+                doc="Cost of the electrodes used in Electrodialysis ($/electrode/area)",
+                units=costing.base_currency / (pyo.units.meter**2),
+            )
+            blk.factor_electrode_replacement = pyo.Var(
+                initialize=0.02,
+                doc="Electrode replacements [fraction of electrode replaced/year]",
+                units=pyo.units.year**-1,
+            )
+
+        self.electrodialysis = pyo.Block(rule=build_electrodialysis_cost_param_block)
+
+        def build_crystallizer_cost_param_block(blk):
+
+            blk.steam_pressure = pyo.Var(
+                initialize=3,
+                units=pyo.units.bar,
+                doc="Steam pressure (gauge) for crystallizer heating: 3 bar default based on Dutta example",
+            )
+
+            blk.efficiency_pump = pyo.Var(
+                initialize=0.7,
+                units=pyo.units.dimensionless,
+                doc="Crystallizer pump efficiency - assumed",
+            )
+
+            blk.pump_head_height = pyo.Var(
+                initialize=1,
+                units=pyo.units.m,
+                doc="Crystallizer pump head height -  assumed, unvalidated",
+            )
+
+            # Crystallizer operating cost information from literature
+            blk.fob_unit_cost = pyo.Var(
+                initialize=675000,
+                doc="Forced circulation crystallizer reference free-on-board cost (Woods, 2007)",
+                units=pyo.units.USD_2007,
+            )
+
+            blk.ref_capacity = pyo.Var(
+                initialize=1,
+                doc="Forced circulation crystallizer reference crystal capacity (Woods, 2007)",
+                units=pyo.units.kg / pyo.units.s,
+            )
+
+            blk.ref_exponent = pyo.Var(
+                initialize=0.53,
+                doc="Forced circulation crystallizer cost exponent factor (Woods, 2007)",
+                units=pyo.units.dimensionless,
+            )
+
+            blk.iec_percent = pyo.Var(
+                initialize=1.43,
+                doc="Forced circulation crystallizer installed equipment cost (Diab and Gerogiorgis, 2017)",
+                units=pyo.units.dimensionless,
+            )
+
+            blk.volume_cost = pyo.Var(
+                initialize=16320,
+                doc="Forced circulation crystallizer cost per volume (Yusuf et al., 2019)",
+                units=pyo.units.USD_2007,  ## TODO: Needs confirmation, but data is from Perry apparently
+            )
+
+            blk.vol_basis_exponent = pyo.Var(
+                initialize=0.47,
+                doc="Forced circulation crystallizer volume-based cost exponent (Yusuf et al., 2019)",
+                units=pyo.units.dimensionless,
+            )
+
+        self.crystallizer = pyo.Block(rule=build_crystallizer_cost_param_block)
 
         # Crystallizer operating cost information from literature
         self.steam_unit_cost = pyo.Var(
@@ -292,117 +396,103 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             doc="Steam cost, Panagopoulos (2019)",
         )
 
-        self.crystallizer_steam_pressure = pyo.Var(
-            initialize=3,
-            units=pyo.units.bar,
-            doc="Steam pressure (gauge) for crystallizer heating: 3 bar default based on Dutta example",
-        )
+        def build_gac_cost_param_block(blk):
 
-        self.crystallizer_efficiency_pump = pyo.Var(
-            initialize=0.7,
-            units=pyo.units.dimensionless,
-            doc="Crystallizer pump efficiency - assumed",
-        )
+            blk.num_contactors_op = pyo.Var(
+                initialize=1,
+                units=pyo.units.dimensionless,
+                doc="Number of GAC contactors in operation in parallel",
+            )
 
-        self.crystallizer_pump_head_height = pyo.Var(
-            initialize=1,
-            units=pyo.units.m,
-            doc="Crystallizer pump head height -  assumed, unvalidated",
-        )
+            blk.num_contactors_redundant = pyo.Var(
+                initialize=1,
+                units=pyo.units.dimensionless,
+                doc="Number of off-line redundant GAC contactors in parallel",
+            )
 
-        self.gac_num_contactors_op = pyo.Var(
-            initialize=1,
-            units=pyo.units.dimensionless,
-            doc="Number of GAC contactors in operation in parallel",
-        )
+            blk.contactor_cost_coeff_0 = pyo.Var(
+                initialize=10010.9,
+                units=pyo.units.USD_2020,
+                doc="GAC contactor polynomial cost coefficient 0",
+            )
 
-        self.gac_num_contactors_redundant = pyo.Var(
-            initialize=1,
-            units=pyo.units.dimensionless,
-            doc="Number of off-line redundant GAC contactors in parallel",
-        )
+            blk.contactor_cost_coeff_1 = pyo.Var(
+                initialize=2204.95,
+                units=pyo.units.USD_2020 * (pyo.units.m**3) ** -1,
+                doc="GAC contactor polynomial cost coefficient 1",
+            )
 
-        self.gac_contactor_cost_coeff_0 = pyo.Var(
-            initialize=10010.9,
-            units=pyo.units.USD_2020,
-            doc="GAC contactor polynomial cost coefficient 0",
-        )
+            blk.contactor_cost_coeff_2 = pyo.Var(
+                initialize=-15.9378,
+                units=pyo.units.USD_2020 * (pyo.units.m**3) ** -2,
+                doc="GAC contactor polynomial cost coefficient 2",
+            )
 
-        self.gac_contactor_cost_coeff_1 = pyo.Var(
-            initialize=2204.95,
-            units=pyo.units.USD_2020 * (pyo.units.m**3) ** -1,
-            doc="GAC contactor polynomial cost coefficient 1",
-        )
+            blk.contactor_cost_coeff_3 = pyo.Var(
+                initialize=0.110592,
+                units=pyo.units.USD_2020 * (pyo.units.m**3) ** -3,
+                doc="GAC contactor polynomial cost coefficient 3",
+            )
 
-        self.gac_contactor_cost_coeff_2 = pyo.Var(
-            initialize=-15.9378,
-            units=pyo.units.USD_2020 * (pyo.units.m**3) ** -2,
-            doc="GAC contactor polynomial cost coefficient 2",
-        )
+            blk.bed_mass_max_ref = pyo.Var(
+                initialize=18143.7,
+                units=pyo.units.kg,
+                doc="Reference maximum value of GAC mass needed for initial charge where "
+                "economy of scale no longer discounts the unit price",
+            )
 
-        self.gac_contactor_cost_coeff_3 = pyo.Var(
-            initialize=0.110592,
-            units=pyo.units.USD_2020 * (pyo.units.m**3) ** -3,
-            doc="GAC contactor polynomial cost coefficient 3",
-        )
+            blk.adsorbent_unit_cost_coeff = pyo.Var(
+                initialize=4.58342,
+                units=pyo.units.USD_2020 * pyo.units.kg**-1,
+                doc="GAC adsorbent exponential cost pre-exponential coefficient",
+            )
 
-        self.bed_mass_gac_max_ref = pyo.Var(
-            initialize=18143.7,
-            units=pyo.units.kg,
-            doc="Reference maximum value of GAC mass needed for initial charge where "
-            "economy of scale no longer discounts the unit price",
-        )
+            blk.adsorbent_unit_cost_exp_coeff = pyo.Var(
+                initialize=-1.25311e-5,
+                units=pyo.units.kg**-1,
+                doc="GAC adsorbent exponential cost parameter coefficient",
+            )
 
-        self.gac_adsorbent_unit_cost_coeff = pyo.Var(
-            initialize=4.58342,
-            units=pyo.units.USD_2020 * pyo.units.kg**-1,
-            doc="GAC adsorbent exponential cost pre-exponential coefficient",
-        )
+            blk.other_cost_coeff = pyo.Var(
+                initialize=16660.7,
+                units=pyo.units.USD_2020,
+                doc="GAC other cost power law coefficient",
+            )
 
-        self.gac_adsorbent_unit_cost_exp_coeff = pyo.Var(
-            initialize=-1.25311e-5,
-            units=pyo.units.kg**-1,
-            doc="GAC adsorbent exponential cost parameter coefficient",
-        )
+            blk.other_cost_exp = pyo.Var(
+                initialize=0.552207,
+                units=pyo.units.dimensionless,
+                doc="GAC other cost power law exponent",
+            )
 
-        self.gac_other_cost_coeff = pyo.Var(
-            initialize=16660.7,
-            units=pyo.units.USD_2020,
-            doc="GAC other cost power law coefficient",
-        )
+            blk.regen_frac = pyo.Var(
+                initialize=0.70,
+                units=pyo.units.dimensionless,
+                doc="Fraction of spent GAC adsorbent that can be regenerated for reuse",
+            )
 
-        self.gac_other_cost_exp = pyo.Var(
-            initialize=0.552207,
-            units=pyo.units.dimensionless,
-            doc="GAC other cost power law exponent",
-        )
+            blk.regen_unit_cost = pyo.Var(
+                initialize=4.28352,
+                units=pyo.units.USD_2020 * pyo.units.kg**-1,
+                doc="Unit cost to regenerate spent GAC adsorbent by an offsite regeneration facility",
+            )
 
-        self.gac_regen_frac = pyo.Var(
-            initialize=0.70,
-            units=pyo.units.dimensionless,
-            doc="Fraction of spent GAC adsorbent that can be regenerated for reuse",
-        )
+            blk.makeup_unit_cost = pyo.Var(
+                initialize=4.58223,
+                units=pyo.units.USD_2020 * pyo.units.kg**-1,
+                doc="Unit cost to makeup spent GAC adsorbent with fresh adsorbent",
+            )
 
-        self.gac_regen_unit_cost = pyo.Var(
-            initialize=4.28352,
-            units=pyo.units.USD_2020 * pyo.units.kg**-1,
-            doc="Unit cost to regenerate spent GAC adsorbent by an offsite regeneration facility",
-        )
-
-        self.gac_makeup_unit_cost = pyo.Var(
-            initialize=4.58223,
-            units=pyo.units.USD_2020 * pyo.units.kg**-1,
-            doc="Unit cost to makeup spent GAC adsorbent with fresh adsorbent",
-        )
+        self.gac = pyo.Block(rule=build_gac_cost_param_block)
 
         # fix the parameters
-        for var in self.component_objects(pyo.Var):
+        for var in self.component_objects(pyo.Var, descend_into=True):
             var.fix()
 
         # Define standard material flows and costs
         self.defined_flows["electricity"] = self.electricity_base_cost
-        self.defined_flows["NaOCl"] = self.naocl_cost / self.naocl_purity
-        self.defined_flows["CaOH2"] = self.caoh2_cost / self.caoh2_purity
+        self.defined_flows["NaOCl"] = self.naocl.cost / self.naocl.purity
+        self.defined_flows["CaOH2"] = self.caoh2.cost / self.caoh2.purity
         self.defined_flows["steam"] = self.steam_unit_cost
 
     def build_process_costs(self):
@@ -547,9 +637,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         """
         cost_uv_aop_bundle(
             blk,
-            blk.costing_package.uv_reactor_cost,
-            blk.costing_package.uv_lamp_cost,
-            blk.costing_package.factor_uv_lamp_replacement,
+            blk.costing_package.ultraviolet.reactor_cost,
+            blk.costing_package.ultraviolet.lamp_cost,
+            blk.costing_package.ultraviolet.factor_lamp_replacement,
         )
 
         t0 = blk.flowsheet().time.first()
@@ -571,8 +661,8 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         """
         cost_membrane(
             blk,
-            blk.costing_package.nanofiltration_membrane_cost,
-            blk.costing_package.factor_membrane_replacement,
+            blk.costing_package.nanofiltration.membrane_cost,
+            blk.costing_package.nanofiltration.factor_membrane_replacement,
         )
 
     @staticmethod
@@ -587,10 +677,10 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                 default = ROType.standard
         """
         if ro_type == ROType.standard:
-            membrane_cost = blk.costing_package.reverse_osmosis_membrane_cost
+            membrane_cost = blk.costing_package.reverse_osmosis.membrane_cost
         elif ro_type == ROType.high_pressure:
             membrane_cost = (
-                blk.costing_package.reverse_osmosis_high_pressure_membrane_cost
+                blk.costing_package.reverse_osmosis.high_pressure_membrane_cost
             )
         else:
             raise ConfigurationError(
@@ -598,7 +688,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                 f" {ro_type}. Argument must be a member of the ROType Enum."
             )
         cost_membrane(
-            blk, membrane_cost, blk.costing_package.factor_membrane_replacement
+            blk,
+            membrane_cost,
+            blk.costing_package.reverse_osmosis.factor_membrane_replacement,
         )
 
     @staticmethod
@@ -667,7 +759,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         make_capital_cost_var(blk)
         blk.capital_cost_constraint = pyo.Constraint(
             expr=blk.capital_cost
-            == blk.costing_package.high_pressure_pump_cost
+            == blk.costing_package.high_pressure_pump.cost
             * pyo.units.convert(blk.unit_model.work_mechanical[t0], pyo.units.W)
         )
         if cost_electricity_flow:
@@ -693,7 +785,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         t0 = blk.flowsheet().time.first()
         cost_by_flow_volume(
             blk,
-            blk.costing_package.low_pressure_pump_cost,
+            blk.costing_package.low_pressure_pump.cost,
             pyo.units.convert(
                 blk.unit_model.control_volume.properties_in[t0].flow_vol,
                 (pyo.units.m**3 / pyo.units.s),
@@ -722,7 +814,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         t0 = blk.flowsheet().time.first()
         cost_by_flow_volume(
             blk,
-            blk.costing_package.erd_pressure_exchanger_cost,
+            blk.costing_package.energy_recovery_device.pressure_exchanger_cost,
             pyo.units.convert(
                 blk.unit_model.control_volume.properties_in[t0].flow_vol,
                 (pyo.units.meter**3 / pyo.units.hours),
@@ -745,7 +837,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         """
         cost_by_flow_volume(
             blk,
-            blk.costing_package.pressure_exchanger_cost,
+            blk.costing_package.pressure_exchanger.cost,
             pyo.units.convert(
                 blk.unit_model.low_pressure_side.properties_in[0].flow_vol,
                 (pyo.units.meter**3 / pyo.units.hours),
@@ -788,7 +880,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         """
         cost_by_flow_volume(
             blk,
-            blk.costing_package.mixer_unit_cost,
+            blk.costing_package.mixer.unit_cost,
             pyo.units.convert(
                 blk.unit_model.mixed_state[0].flow_vol,
                 pyo.units.liter / pyo.units.second,
@@ -807,7 +899,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         """
         cost_by_flow_volume(
             blk,
-            blk.costing_package.naocl_mixer_unit_cost,
+            blk.costing_package.naocl.mixer_unit_cost,
             pyo.units.convert(
                 blk.unit_model.inlet_stream_state[0].flow_vol,
                 pyo.units.m**3 / pyo.units.day,
@@ -836,7 +928,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         )
         cost_by_flow_volume(
             blk,
-            blk.costing_package.caoh2_mixer_unit_cost
+            blk.costing_package.caoh2.mixer_unit_cost
             / blk.costing_package.factor_total_investment,
             blk.lime_kg_per_day,
         )
@@ -855,23 +947,23 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         t0 = blk.flowsheet().time.first()
 
         membrane_cost = (
-            blk.costing_package.electrodialysis_cem_membrane_cost
-            + blk.costing_package.electrodialysis_aem_membrane_cost
+            blk.costing_package.electrodialysis.cem_membrane_cost
+            + blk.costing_package.electrodialysis.aem_membrane_cost
         )
-        spacer_cost = 2.0 * blk.costing_package.electrodialysis_flowspacer_cost
-        electrode_cost = 2.0 * blk.costing_package.electrodialysis_electrode_cost
+        spacer_cost = 2.0 * blk.costing_package.electrodialysis.flowspacer_cost
+        electrode_cost = 2.0 * blk.costing_package.electrodialysis.electrode_cost
 
         cost_electrodialysis_stack(
             blk,
             membrane_cost,
             spacer_cost,
-            blk.costing_package.factor_electrodialysis_membrane_housing_replacement,
+            blk.costing_package.electrodialysis.factor_membrane_housing_replacement,
             electrode_cost,
-            blk.costing_package.factor_electrodialysis_electrode_replacement,
+            blk.costing_package.electrodialysis.factor_electrode_replacement,
         )
 
         # Changed this to grab power from performance table which is identified
-        #   by same key regardless of whether the Electrodialysis unit is 0D or 1D
+        # by same key regardless of whether the Electrodialysis unit is 0D or 1D
         if cost_electricity_flow:
             blk.costing_package.cost_flow(
                 pyo.units.convert(
@@ -909,8 +1001,8 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                     blk.unit_model.magma_circulation_flow_vol
                     * blk.unit_model.dens_mass_slurry
                     * Constants.acceleration_gravity
-                    * blk.costing_package.crystallizer_pump_head_height
-                    / blk.costing_package.crystallizer_efficiency_pump
+                    * blk.costing_package.crystallizer.pump_head_height
+                    / blk.costing_package.crystallizer.efficiency_pump
                 ),
                 to_units=pyo.units.kW,
             ),
@@ -938,16 +1030,16 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             expr=blk.capital_cost
             == pyo.units.convert(
                 (
-                    blk.costing_package.fc_crystallizer_iec_percent
-                    * blk.costing_package.fc_crystallizer_fob_unit_cost
+                    blk.costing_package.crystallizer.iec_percent
+                    * blk.costing_package.crystallizer.fob_unit_cost
                     * (
                         sum(
                             blk.unit_model.solids.flow_mass_phase_comp[0, "Sol", j]
                             for j in blk.unit_model.config.property_package.solute_set
                         )
-                        / blk.costing_package.fc_crystallizer_ref_capacity
+                        / blk.costing_package.crystallizer.ref_capacity
                     )
-                    ** blk.costing_package.fc_crystallizer_ref_exponent
+                    ** blk.costing_package.crystallizer.ref_exponent
                 ),
                 to_units=blk.costing_package.base_currency,
             )
@@ -963,7 +1055,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             expr=blk.capital_cost
             == pyo.units.convert(
                 (
-                    blk.costing_package.fc_crystallizer_volume_cost
+                    blk.costing_package.crystallizer.volume_cost
                     * (
                         (
                             pyo.units.convert(
@@ -977,7 +1069,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                         )
                         / pyo.units.ft**3
                     )
-                    ** blk.costing_package.fc_crystallizer_vol_basis_exponent
+                    ** blk.costing_package.crystallizer.vol_basis_exponent
                 ),
                 to_units=blk.costing_package.base_currency,
             )
@@ -1029,30 +1121,30 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         blk.contactor_cost_constraint = pyo.Constraint(
             expr=blk.contactor_cost
             == (
-                blk.costing_package.gac_num_contactors_op
-                + blk.costing_package.gac_num_contactors_redundant
+                blk.costing_package.gac.num_contactors_op
+                + blk.costing_package.gac.num_contactors_redundant
             )
             * pyo.units.convert(
                 (
-                    blk.costing_package.gac_contactor_cost_coeff_3
+                    blk.costing_package.gac.contactor_cost_coeff_3
                     * (
                         blk.unit_model.bed_volume
-                        / blk.costing_package.gac_num_contactors_op
+                        / blk.costing_package.gac.num_contactors_op
                     )
                     ** 3
-                    + blk.costing_package.gac_contactor_cost_coeff_2
+                    + blk.costing_package.gac.contactor_cost_coeff_2
                     * (
                         blk.unit_model.bed_volume
-                        / blk.costing_package.gac_num_contactors_op
+                        / blk.costing_package.gac.num_contactors_op
                     )
                     ** 2
-                    + blk.costing_package.gac_contactor_cost_coeff_1
+                    + blk.costing_package.gac.contactor_cost_coeff_1
                     * (
                         blk.unit_model.bed_volume
-                        / blk.costing_package.gac_num_contactors_op
+                        / blk.costing_package.gac.num_contactors_op
                     )
                     ** 1
-                    + blk.costing_package.gac_contactor_cost_coeff_0
+                    + blk.costing_package.gac.contactor_cost_coeff_0
                 ),
                 to_units=blk.costing_package.base_currency,
             )
@@ -1060,7 +1152,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         blk.bed_mass_gac_ref_constraint = pyo.Constraint(
             expr=blk.bed_mass_gac_ref
             == smooth_min(
-                blk.costing_package.bed_mass_gac_max_ref / pyo.units.kg,
+                blk.costing_package.gac.bed_mass_max_ref / pyo.units.kg,
                 pyo.units.convert(blk.unit_model.bed_mass_gac, to_units=pyo.units.kg)
                 / pyo.units.kg,
             )
@@ -1069,10 +1161,10 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         blk.adsorbent_unit_cost_constraint = pyo.Constraint(
             expr=blk.adsorbent_unit_cost
             == pyo.units.convert(
-                blk.costing_package.gac_adsorbent_unit_cost_coeff
+                blk.costing_package.gac.adsorbent_unit_cost_coeff
                 * pyo.exp(
                     blk.bed_mass_gac_ref
-                    * blk.costing_package.gac_adsorbent_unit_cost_exp_coeff
+                    * blk.costing_package.gac.adsorbent_unit_cost_exp_coeff
                 ),
                 to_units=blk.costing_package.base_currency * pyo.units.kg**-1,
             )
@@ -1085,19 +1177,19 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             expr=blk.other_process_cost
             == pyo.units.convert(
                 (
-                    blk.costing_package.gac_other_cost_coeff
-                    * ((pyo.units.m**3) ** -blk.costing_package.gac_other_cost_exp)
+                    blk.costing_package.gac.other_cost_coeff
+                    * ((pyo.units.m**3) ** -blk.costing_package.gac.other_cost_exp)
                     * (
                         (
-                            blk.costing_package.gac_num_contactors_op
-                            + blk.costing_package.gac_num_contactors_redundant
+                            blk.costing_package.gac.num_contactors_op
+                            + blk.costing_package.gac.num_contactors_redundant
                         )
                         * (
                             blk.unit_model.bed_volume
-                            / blk.costing_package.gac_num_contactors_op
+                            / blk.costing_package.gac.num_contactors_op
                         )
                     )
-                    ** blk.costing_package.gac_other_cost_exp
+                    ** blk.costing_package.gac.other_cost_exp
                 ),
                 to_units=blk.costing_package.base_currency,
             )
@@ -1126,9 +1218,9 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             expr=blk.gac_regen_cost
             == pyo.units.convert(
                 (
-                    blk.costing_package.gac_regen_unit_cost
+                    blk.costing_package.gac.regen_unit_cost
                     * (
-                        blk.costing_package.gac_regen_frac
+                        blk.costing_package.gac.regen_frac
                         * blk.unit_model.gac_mass_replace_rate
                     )
                 ),
@@ -1140,10 +1232,10 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             expr=blk.gac_makeup_cost
             == pyo.units.convert(
                 (
-                    blk.costing_package.gac_makeup_unit_cost
+                    blk.costing_package.gac.makeup_unit_cost
                     * (
-                        (1 - blk.costing_package.gac_regen_frac)
-                        * blk.unit_model.gac_mass_replace_rate
+                        (1 - blk.costing_package.gac.regen_frac)
+                        * blk.unit_model.gac.mass_replace_rate
                     )
                 ),
                 to_units=blk.costing_package.base_currency
@@ -1164,7 +1256,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         Out:
             Steam thermal capacity (latent heat of condensation * density) in kJ/m3
         """
-        pressure_sat = blk.costing_package.crystallizer_steam_pressure
+        pressure_sat = blk.costing_package.crystallizer.steam_pressure
         # 1. Compute saturation temperature of steam: computed from El-Dessouky expression
         tsat_constants = [
             42.6776 * pyo.units.K,
@@ -1349,7 +1441,7 @@ def cost_by_flow_volume(blk, flow_cost, flow_to_cost):
     Generic function for costing by flow volume.
 
     Args:
-        flow_cost - The cost of the pump in [currency]/([volume]/[time])
+        flow_cost - The cost of the device in [currency]/([volume]/[time])
         flow_to_cost - The flow costed in [volume]/[time]
     """
     make_capital_cost_var(blk)
@@ -1359,7 +1451,7 @@ def cost_by_flow_volume(blk, flow_cost, flow_to_cost):
     )
 
 
-def cost_uv_aop_bundle(blk, reactor_cost, lamp_cost, factor_uv_lamp_replacement):
+def cost_uv_aop_bundle(blk, reactor_cost, lamp_cost, factor_lamp_replacement):
     """
     Generic function for costing a UV system.
 
@@ -1371,7 +1463,7 @@ def cost_uv_aop_bundle(blk, reactor_cost, lamp_cost, factor_uv_lamp_replacement)
     make_fixed_operating_cost_var(blk)
     blk.reactor_cost = pyo.Expression(expr=reactor_cost)
     blk.lamp_cost = pyo.Expression(expr=lamp_cost)
-    blk.factor_uv_lamp_replacement = pyo.Expression(expr=factor_uv_lamp_replacement)
+    blk.factor_lamp_replacement = pyo.Expression(expr=factor_lamp_replacement)
 
     flow_in = pyo.units.convert(
         blk.unit_model.control_volume.properties_in[0].flow_vol,
@@ -1388,5 +1480,5 @@ def cost_uv_aop_bundle(blk, reactor_cost, lamp_cost, factor_uv_lamp_replacement)
     )
     blk.fixed_operating_cost_constraint = pyo.Constraint(
         expr=blk.fixed_operating_cost
-        == blk.factor_uv_lamp_replacement * blk.lamp_cost * electricity_demand
+        == blk.factor_lamp_replacement * blk.lamp_cost * electricity_demand
     )

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -1235,7 +1235,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                     blk.costing_package.gac.makeup_unit_cost
                     * (
                         (1 - blk.costing_package.gac.regen_frac)
-                        * blk.unit_model.gac.mass_replace_rate
+                        * blk.unit_model.gac_mass_replace_rate
                     )
                 ),
                 to_units=blk.costing_package.base_currency

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -153,12 +153,12 @@ def build(
     m.fs.costing.factor_total_investment.fix(2)
     m.fs.costing.factor_maintenance_labor_chemical.fix(0.03)
     m.fs.costing.factor_capital_annualization.fix(0.1)
-    m.fs.costing.factor_membrane_replacement.fix(0.15)
     m.fs.costing.electricity_base_cost.set_value(0.07)
-    m.fs.costing.reverse_osmosis_membrane_cost.fix(30)
-    m.fs.costing.reverse_osmosis_high_pressure_membrane_cost.fix(50)
-    m.fs.costing.high_pressure_pump_cost.fix(53 / 1e5 * 3600)
-    m.fs.costing.erd_pressure_exchanger_cost.fix(535)
+    m.fs.costing.reverse_osmosis.factor_membrane_replacement.fix(0.15)
+    m.fs.costing.reverse_osmosis.membrane_cost.fix(30)
+    m.fs.costing.reverse_osmosis.high_pressure_membrane_cost.fix(50)
+    m.fs.costing.high_pressure_pump.cost.fix(53 / 1e5 * 3600)
+    m.fs.costing.energy_recovery_device.pressure_exchanger_cost.fix(535)
 
     m.fs.NumberOfStages = Param(initialize=number_of_stages)
     m.fs.Stages = RangeSet(m.fs.NumberOfStages)
@@ -568,7 +568,7 @@ def cost_high_pressure_pump_lsrro(blk, cost_electricity_flow=True):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.high_pressure_pump_cost
+        == blk.costing_package.high_pressure_pump.cost
         * pyunits.watt
         / (pyunits.m**3 * pyunits.pascal / pyunits.s)
         * blk.unit_model.outlet.pressure[t0]

--- a/watertap/unit_models/tests/test_crystallizer.py
+++ b/watertap/unit_models/tests/test_crystallizer.py
@@ -585,7 +585,7 @@ class TestCrystallization:
     @pytest.mark.component
     def test_solution2_operatingcost_steampressure(self, Crystallizer_frame_2):
         m = Crystallizer_frame_2
-        m.fs.costing.crystallizer_steam_pressure.fix(5)
+        m.fs.costing.crystallizer.steam_pressure.fix(5)
         b = m.fs.unit
         b.crystal_growth_rate.fix(5e-8)
         b.souders_brown_constant.fix(0.0244)

--- a/watertap/unit_models/tests/test_electrodialysis_0D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_0D.py
@@ -274,17 +274,18 @@ class TestElectrodialysisVoltageConst:
         #       and not be here after everything else (see next test)
         m.fs.costing = WaterTAPCosting()
 
-        # Set costing var
-        m.fs.costing.electrodialysis_aem_membrane_cost.set_value(45)
-        m.fs.costing.electrodialysis_cem_membrane_cost.set_value(41)
-        m.fs.costing.factor_electrodialysis_membrane_housing_replacement.set_value(0.2)
-
         m.fs.unit.costing = UnitModelCostingBlock(
             default={
                 "flowsheet_costing_block": m.fs.costing,
                 "costing_method_arguments": {},
             },
         )
+
+        # Set costing var
+        m.fs.costing.electrodialysis.aem_membrane_cost.set_value(45)
+        m.fs.costing.electrodialysis.cem_membrane_cost.set_value(41)
+        m.fs.costing.electrodialysis.factor_membrane_housing_replacement.set_value(0.2)
+
         m.fs.costing.cost_process()
 
         assert_units_consistent(m)

--- a/watertap/unit_models/tests/test_electrodialysis_0D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_0D.py
@@ -274,17 +274,17 @@ class TestElectrodialysisVoltageConst:
         #       and not be here after everything else (see next test)
         m.fs.costing = WaterTAPCosting()
 
+        # Set costing var
+        m.fs.costing.electrodialysis.aem_membrane_cost.set_value(45)
+        m.fs.costing.electrodialysis.cem_membrane_cost.set_value(41)
+        m.fs.costing.electrodialysis.factor_membrane_housing_replacement.set_value(0.2)
+
         m.fs.unit.costing = UnitModelCostingBlock(
             default={
                 "flowsheet_costing_block": m.fs.costing,
                 "costing_method_arguments": {},
             },
         )
-
-        # Set costing var
-        m.fs.costing.electrodialysis.aem_membrane_cost.set_value(45)
-        m.fs.costing.electrodialysis.cem_membrane_cost.set_value(41)
-        m.fs.costing.electrodialysis.factor_membrane_housing_replacement.set_value(0.2)
 
         m.fs.costing.cost_process()
 

--- a/watertap/unit_models/tests/test_gac.py
+++ b/watertap/unit_models/tests/test_gac.py
@@ -406,8 +406,8 @@ class TestGACRobust:
         assert check_optimal_termination(results)
 
         # Check for known cost solution of default twin alternating contactors
-        assert value(mr.fs.costing.gac_num_contactors_op) == 1
-        assert value(mr.fs.costing.gac_num_contactors_redundant) == 1
+        assert value(mr.fs.costing.gac.num_contactors_op) == 1
+        assert value(mr.fs.costing.gac.num_contactors_redundant) == 1
         assert pytest.approx(56900.93523, rel=1e-5) == value(
             mr.fs.unit.costing.contactor_cost
         )
@@ -448,14 +448,14 @@ class TestGACRobust:
         )
         mr.fs.costing.cost_process()
 
-        mr.fs.costing.gac_num_contactors_op.fix(4)
-        mr.fs.costing.gac_num_contactors_redundant.fix(2)
+        mr.fs.costing.gac.num_contactors_op.fix(4)
+        mr.fs.costing.gac.num_contactors_redundant.fix(2)
 
         results = solver.solve(mr)
 
         # Check for known cost solution when changing volume scale of vessels in parallel
-        assert value(mr.fs.costing.gac_num_contactors_op) == 4
-        assert value(mr.fs.costing.gac_num_contactors_redundant) == 2
+        assert value(mr.fs.costing.gac.num_contactors_op) == 4
+        assert value(mr.fs.costing.gac.num_contactors_redundant) == 2
         assert pytest.approx(89035.16691, rel=1e-5) == value(
             mr.fs.unit.costing.contactor_cost
         )
@@ -493,10 +493,10 @@ class TestGACRobust:
 
         # Check for bed_mass_gac_cost_ref to be overwritten if bed_mass_gac is greater than bed_mass_gac_cost_max_ref
         assert value(mr.fs.unit.bed_mass_gac) > value(
-            mr.fs.costing.bed_mass_gac_max_ref
+            mr.fs.costing.gac.bed_mass_max_ref
         )
         assert value(mr.fs.unit.costing.bed_mass_gac_ref) == (
-            pytest.approx(value(mr.fs.costing.bed_mass_gac_max_ref), 1e-5)
+            pytest.approx(value(mr.fs.costing.gac.bed_mass_max_ref), 1e-5)
         )
 
 


### PR DESCRIPTION
## Fixes/Resolves: Work towards #676 

## Summary/Motivation:
The WaterTAP costing package has too many parameters crowding the namespace. This puts the parameters for each unit on their own block.

## Changes proposed in this PR:
- Reorganize costing parameters in WaterTAP Costing Package
- Touch a few affected tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
