### PR TITLE
Reverse Osmosis example pump-as-turbine configuration 

### DIFF
--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -71,7 +71,7 @@ def main(erd_type="pressure_exchanger"):
     return m
 
 
-def build(erd_type):
+def build(erd_type="pressure_exchanger"):
     # flowsheet set up
     m = ConcreteModel()
     m.erd_type = erd_type

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -10,12 +10,14 @@
 # "https://github.com/watertap-org/watertap/"
 #
 ###############################################################################
+import os
 from pyomo.environ import (
     ConcreteModel,
     value,
     Constraint,
     Expression,
     Objective,
+    Var,
     Param,
     TransformationFactory,
     units as pyunits,
@@ -40,58 +42,83 @@ from watertap.unit_models.reverse_osmosis_0D import (
     PressureChangeType,
 )
 from watertap.unit_models.pressure_exchanger import PressureExchanger
-from watertap.unit_models.pressure_changer import Pump
+from watertap.unit_models.pressure_changer import Pump, EnergyRecoveryDevice
 from watertap.core.util.initialization import assert_degrees_of_freedom
 from watertap.costing import WaterTAPCosting
 
 
-def main():
+def main(erd_type="pressure_exchanger"):
     # set up solver
     solver = get_solver()
 
     # build, set, and initialize
-    m = build()
-    set_operating_conditions(m, water_recovery=0.5, over_pressure=0.3, solver=solver)
+    m = build(erd_type=erd_type)
+    set_operating_conditions(m)
     initialize_system(m, solver=solver)
 
     # simulate and display
-    solve(m, solver=solver)
-    print("\n***---Simulation results---***")
-    display_system(m)
-    display_design(m)
-    display_state(m)
+    # solve(m, solver=solver)
 
     # optimize and display
     optimize_set_up(m)
-    optimize(m, solver=solver)
-    print("\n***---Optimization results---***")
+    solve(m, solver=solver)
+
+    print("\n***---Simulation results---***")
     display_system(m)
     display_design(m)
-    display_state(m)
+    if erd_type == "pressure_exchanger":
+        display_state(m)
+    else:
+        pass
+
+    return m
 
 
-def build():
+def build(erd_type):
     # flowsheet set up
     m = ConcreteModel()
+    m.erd_type = erd_type
     m.fs = FlowsheetBlock(default={"dynamic": False})
     m.fs.properties = props.NaClParameterBlock()
     m.fs.costing = WaterTAPCosting()
 
     # unit models
     m.fs.feed = Feed(default={"property_package": m.fs.properties})
-    m.fs.S1 = Separator(
-        default={"property_package": m.fs.properties, "outlet_list": ["P1", "PXR"]}
-    )
     m.fs.P1 = Pump(default={"property_package": m.fs.properties})
-    m.fs.PXR = PressureExchanger(default={"property_package": m.fs.properties})
-    m.fs.P2 = Pump(default={"property_package": m.fs.properties})
-    m.fs.M1 = Mixer(
-        default={
-            "property_package": m.fs.properties,
-            "momentum_mixing_type": MomentumMixingType.equality,  # booster pump will match pressure
-            "inlet_list": ["P1", "P2"],
-        }
-    )
+
+    if erd_type == "pressure_exchanger":
+        m.fs.S1 = Separator(
+            default={"property_package": m.fs.properties, "outlet_list": ["P1", "PXR"]}
+        )
+        m.fs.PXR = PressureExchanger(default={"property_package": m.fs.properties})
+        m.fs.P2 = Pump(default={"property_package": m.fs.properties})
+        m.fs.M1 = Mixer(
+            default={
+                "property_package": m.fs.properties,
+                "momentum_mixing_type": MomentumMixingType.equality,  # booster pump will match pressure
+                "inlet_list": ["P1", "P2"],
+            }
+        )
+        # add costing for PXR config
+        m.fs.P2.costing = UnitModelCostingBlock(
+            default={"flowsheet_costing_block": m.fs.costing}
+        )
+        m.fs.PXR.costing = UnitModelCostingBlock(
+            default={"flowsheet_costing_block": m.fs.costing}
+        )
+    elif erd_type == "pump_as_turbine":
+        m.fs.ERD = EnergyRecoveryDevice(default={"property_package": m.fs.properties})
+        # add costing for ERD config
+        m.fs.ERD.costing = UnitModelCostingBlock(
+            default={"flowsheet_costing_block": m.fs.costing}
+        )
+    else:
+        raise NotImplementedError(
+            "erd_type was {}, but can only "
+            "be pressure_exchanger or pump_as_turbine"
+            "".format(erd_type)
+        )
+
     m.fs.RO = ReverseOsmosis0D(
         default={
             "property_package": m.fs.properties,
@@ -104,38 +131,44 @@ def build():
     m.fs.product = Product(default={"property_package": m.fs.properties})
     m.fs.disposal = Product(default={"property_package": m.fs.properties})
 
-    # costing
+    # costing for all configurations
     m.fs.P1.costing = UnitModelCostingBlock(
         default={"flowsheet_costing_block": m.fs.costing}
     )
-    m.fs.P2.costing = UnitModelCostingBlock(
-        default={"flowsheet_costing_block": m.fs.costing}
-    )
-
     m.fs.RO.costing = UnitModelCostingBlock(
         default={"flowsheet_costing_block": m.fs.costing}
     )
-    m.fs.PXR.costing = UnitModelCostingBlock(
-        default={"flowsheet_costing_block": m.fs.costing}
-    )
+
     m.fs.costing.cost_process()
     m.fs.costing.add_annual_water_production(m.fs.product.properties[0].flow_vol)
     m.fs.costing.add_LCOW(m.fs.product.properties[0].flow_vol)
     m.fs.costing.add_specific_energy_consumption(m.fs.product.properties[0].flow_vol)
 
     # connections
-    m.fs.s01 = Arc(source=m.fs.feed.outlet, destination=m.fs.S1.inlet)
-    m.fs.s02 = Arc(source=m.fs.S1.P1, destination=m.fs.P1.inlet)
-    m.fs.s03 = Arc(source=m.fs.P1.outlet, destination=m.fs.M1.P1)
-    m.fs.s04 = Arc(source=m.fs.M1.outlet, destination=m.fs.RO.inlet)
-    m.fs.s05 = Arc(source=m.fs.RO.permeate, destination=m.fs.product.inlet)
-    m.fs.s06 = Arc(source=m.fs.RO.retentate, destination=m.fs.PXR.high_pressure_inlet)
-    m.fs.s07 = Arc(
-        source=m.fs.PXR.high_pressure_outlet, destination=m.fs.disposal.inlet
-    )
-    m.fs.s08 = Arc(source=m.fs.S1.PXR, destination=m.fs.PXR.low_pressure_inlet)
-    m.fs.s09 = Arc(source=m.fs.PXR.low_pressure_outlet, destination=m.fs.P2.inlet)
-    m.fs.s10 = Arc(source=m.fs.P2.outlet, destination=m.fs.M1.P2)
+    if erd_type == "pressure_exchanger":
+        m.fs.s01 = Arc(source=m.fs.feed.outlet, destination=m.fs.S1.inlet)
+        m.fs.s02 = Arc(source=m.fs.S1.P1, destination=m.fs.P1.inlet)
+        m.fs.s03 = Arc(source=m.fs.P1.outlet, destination=m.fs.M1.P1)
+        m.fs.s04 = Arc(source=m.fs.M1.outlet, destination=m.fs.RO.inlet)
+        m.fs.s05 = Arc(source=m.fs.RO.permeate, destination=m.fs.product.inlet)
+        m.fs.s06 = Arc(
+            source=m.fs.RO.retentate, destination=m.fs.PXR.high_pressure_inlet
+        )
+        m.fs.s07 = Arc(
+            source=m.fs.PXR.high_pressure_outlet, destination=m.fs.disposal.inlet
+        )
+        m.fs.s08 = Arc(source=m.fs.S1.PXR, destination=m.fs.PXR.low_pressure_inlet)
+        m.fs.s09 = Arc(source=m.fs.PXR.low_pressure_outlet, destination=m.fs.P2.inlet)
+        m.fs.s10 = Arc(source=m.fs.P2.outlet, destination=m.fs.M1.P2)
+    elif erd_type == "pump_as_turbine":
+        m.fs.s01 = Arc(source=m.fs.feed.outlet, destination=m.fs.P1.inlet)
+        m.fs.s02 = Arc(source=m.fs.P1.outlet, destination=m.fs.RO.inlet)
+        m.fs.s03 = Arc(source=m.fs.RO.permeate, destination=m.fs.product.inlet)
+        m.fs.s04 = Arc(source=m.fs.RO.retentate, destination=m.fs.ERD.inlet)
+        m.fs.s05 = Arc(source=m.fs.ERD.outlet, destination=m.fs.disposal.inlet)
+    else:
+        # this case should be caught in the previous conditional
+        pass
     TransformationFactory("network.expand_arcs").apply_to(m)
 
     # scaling
@@ -146,14 +179,20 @@ def build():
     )
     # set unit model values
     iscale.set_scaling_factor(m.fs.P1.control_volume.work, 1e-3)
-    iscale.set_scaling_factor(m.fs.P2.control_volume.work, 1e-3)
-    iscale.set_scaling_factor(m.fs.PXR.low_pressure_side.work, 1e-3)
-    iscale.set_scaling_factor(m.fs.PXR.high_pressure_side.work, 1e-3)
-    # touch properties used in specifying and initializing the model
+    iscale.set_scaling_factor(m.fs.RO.area, 1e-2)
     m.fs.feed.properties[0].flow_vol_phase["Liq"]
     m.fs.feed.properties[0].mass_frac_phase_comp["Liq", "NaCl"]
-    m.fs.S1.mixed_state[0].mass_frac_phase_comp
-    m.fs.S1.PXR_state[0].flow_vol_phase["Liq"]
+    if erd_type == "pressure_exchanger":
+        iscale.set_scaling_factor(m.fs.P2.control_volume.work, 1e-3)
+        iscale.set_scaling_factor(m.fs.PXR.low_pressure_side.work, 1e-3)
+        iscale.set_scaling_factor(m.fs.PXR.high_pressure_side.work, 1e-3)
+        # touch properties used in specifying and initializing the model
+        m.fs.S1.mixed_state[0].mass_frac_phase_comp
+        m.fs.S1.PXR_state[0].flow_vol_phase["Liq"]
+    elif erd_type == "pump_as_turbine":
+        iscale.set_scaling_factor(m.fs.ERD.control_volume.work, 1e-3)
+    else:
+        pass
     # unused scaling factors needed by IDAES base costing module
     # calculate and propagate scaling factors
     iscale.calculate_scaling_factors(m)
@@ -161,7 +200,13 @@ def build():
     return m
 
 
-def set_operating_conditions(m, water_recovery=0.5, over_pressure=0.3, solver=None):
+def set_operating_conditions(
+    m,
+    water_recovery=0.5,
+    over_pressure=0.3,
+    solver=None,
+):
+
     if solver is None:
         solver = get_solver()
 
@@ -183,22 +228,26 @@ def set_operating_conditions(m, water_recovery=0.5, over_pressure=0.3, solver=No
 
     # pump 1, high pressure pump, 2 degrees of freedom (efficiency and outlet pressure)
     m.fs.P1.efficiency_pump.fix(0.80)  # pump efficiency [-]
-    operating_pressure = calculate_operating_pressure(
-        feed_state_block=m.fs.feed.properties[0],
-        over_pressure=over_pressure,
-        water_recovery=water_recovery,
-        NaCl_passage=0.01,
-        solver=solver,
-    )
-    m.fs.P1.control_volume.properties_out[0].pressure.fix(operating_pressure)
+    # operating_pressure = calculate_operating_pressure(
+    #     feed_state_block=m.fs.feed.properties[0],
+    #     over_pressure=over_pressure,
+    #     water_recovery=water_recovery,
+    #     NaCl_passage=0.01,
+    #     solver=solver,
+    # )
+    m.fs.P1.control_volume.properties_out[0].pressure.fix(56e5)
+    if m.erd_type == "pressure_exchanger":
+        # pressure exchanger
+        m.fs.PXR.efficiency_pressure_exchanger.fix(
+            0.95
+        )  # pressure exchanger efficiency [-]
 
-    # pressure exchanger
-    m.fs.PXR.efficiency_pressure_exchanger.fix(
-        0.95
-    )  # pressure exchanger efficiency [-]
+        # pump 2, booster pump, 1 degree of freedom (efficiency, pressure must match high pressure pump)
+        m.fs.P2.efficiency_pump.fix(0.80)
 
-    # pump 2, booster pump, 1 degree of freedom (efficiency, pressure must match high pressure pump)
-    m.fs.P2.efficiency_pump.fix(0.80)
+    elif m.erd_type == "pump_as_turbine":
+        m.fs.ERD.efficiency_pump.fix(0.95)
+        m.fs.ERD.control_volume.properties_out[0].pressure.fix(101325)
 
     # mixer, no degrees of freedom
 
@@ -222,11 +271,11 @@ def set_operating_conditions(m, water_recovery=0.5, over_pressure=0.3, solver=No
     m.fs.RO.feed_side.properties_in[0].pressure = value(
         m.fs.P1.control_volume.properties_out[0].pressure
     )
-    m.fs.RO.area.fix(50)  # guess area for RO initialization
-    m.fs.RO.initialize(optarg=solver.options)
-
-    # unfix guessed area, and fix water recovery
-    m.fs.RO.area.unfix()
+    # m.fs.RO.area.fix(50)  # guess area for RO initialization
+    # m.fs.RO.initialize(optarg=solver.options)
+    #
+    # # unfix guessed area, and fix water recovery
+    # m.fs.RO.area.unfix()
     m.fs.RO.recovery_mass_phase_comp[0, "Liq", "H2O"].fix(water_recovery)
 
     # check degrees of freedom
@@ -307,65 +356,79 @@ def initialize_system(m, solver=None):
     # ---initialize feed block---
     m.fs.feed.initialize(optarg=optarg)
 
-    # ---initialize splitter and pressure exchanger---
-    # pressure exchanger high pressure inlet
-    propagate_state(m.fs.s06)  # propagate to PXR high pressure inlet from RO retentate
-    m.fs.PXR.high_pressure_side.properties_in.initialize(optarg=optarg)
+    if m.erd_type == "pressure_exchanger":
+        # ---initialize splitter and pressure exchanger---
+        # pressure exchanger high pressure inlet
+        propagate_state(
+            m.fs.s06
+        )  # propagate to PXR high pressure inlet from RO retentate
+        m.fs.PXR.high_pressure_side.properties_in.initialize(optarg=optarg)
 
-    # splitter inlet
-    propagate_state(m.fs.s01)  # propagate to splitter inlet from feed
-    m.fs.S1.mixed_state.initialize(
-        optarg=optarg
-    )  # initialize inlet state block to solve for mass fraction
-    # splitter outlet to PXR, enforce same volumetric flow as PXR high pressure inlet
-    m.fs.S1.PXR_state.calculate_state(
-        var_args={
-            (
-                "flow_vol_phase",
-                "Liq",
-            ): value(  # same volumetric flow rate as PXR high pressure inlet
-                m.fs.PXR.high_pressure_side.properties_in[0].flow_vol_phase["Liq"]
-            ),
-            ("mass_frac_phase_comp", ("Liq", "NaCl")): value(
-                m.fs.S1.mixed_state[0].mass_frac_phase_comp["Liq", "NaCl"]
-            ),  # same as splitter inlet
-            ("pressure", None): value(
-                m.fs.S1.mixed_state[0].pressure
-            ),  # same as splitter inlet
-            ("temperature", None): value(m.fs.S1.mixed_state[0].temperature),
-        },  # same as splitter inlet
-    )
-    # splitter initialization
-    m.fs.S1.PXR_state[0].flow_mass_phase_comp[
-        "Liq", "NaCl"
-    ].fix()  # fix the single degree of freedom for unit
-    m.fs.S1.initialize(optarg=optarg)
-    m.fs.S1.PXR_state[0].flow_mass_phase_comp[
-        "Liq", "NaCl"
-    ].unfix()  # unfix for flowsheet simulation and optimization
+        # splitter inlet
+        propagate_state(m.fs.s01)  # propagate to splitter inlet from feed
+        m.fs.S1.mixed_state.initialize(
+            optarg=optarg
+        )  # initialize inlet state block to solve for mass fraction
+        # splitter outlet to PXR, enforce same volumetric flow as PXR high pressure inlet
+        m.fs.S1.PXR_state.calculate_state(
+            var_args={
+                (
+                    "flow_vol_phase",
+                    "Liq",
+                ): value(  # same volumetric flow rate as PXR high pressure inlet
+                    m.fs.PXR.high_pressure_side.properties_in[0].flow_vol_phase["Liq"]
+                ),
+                ("mass_frac_phase_comp", ("Liq", "NaCl")): value(
+                    m.fs.S1.mixed_state[0].mass_frac_phase_comp["Liq", "NaCl"]
+                ),  # same as splitter inlet
+                ("pressure", None): value(
+                    m.fs.S1.mixed_state[0].pressure
+                ),  # same as splitter inlet
+                ("temperature", None): value(m.fs.S1.mixed_state[0].temperature),
+            },  # same as splitter inlet
+        )
+        # splitter initialization
+        m.fs.S1.PXR_state[0].flow_mass_phase_comp[
+            "Liq", "NaCl"
+        ].fix()  # fix the single degree of freedom for unit
+        m.fs.S1.initialize(optarg=optarg)
+        m.fs.S1.PXR_state[0].flow_mass_phase_comp[
+            "Liq", "NaCl"
+        ].unfix()  # unfix for flowsheet simulation and optimization
 
-    # pressure exchanger low pressure inlet
-    propagate_state(m.fs.s08)
+        # pressure exchanger low pressure inlet
+        propagate_state(m.fs.s08)
 
-    # pressure exchanger initialization
-    m.fs.PXR.initialize(optarg=optarg)
+        # pressure exchanger initialization
+        m.fs.PXR.initialize(optarg=optarg)
 
-    # ---initialize pump 1---
-    propagate_state(m.fs.s02)
-    m.fs.P1.initialize(optarg=optarg)
+        # ---initialize pump 1---
+        propagate_state(m.fs.s02)
+        m.fs.P1.initialize(optarg=optarg)
 
-    # ---initialize pump 2---
-    propagate_state(m.fs.s09)
-    m.fs.P2.control_volume.properties_out[0].pressure.fix(
-        value(m.fs.P2.control_volume.properties_out[0].pressure)
-    )
-    m.fs.P2.initialize(optarg=optarg)
-    m.fs.P2.control_volume.properties_out[0].pressure.unfix()
+        # ---initialize pump 2---
+        propagate_state(m.fs.s09)
+        m.fs.P2.control_volume.properties_out[0].pressure.fix(
+            value(m.fs.P2.control_volume.properties_out[0].pressure)
+        )
+        m.fs.P2.initialize(optarg=optarg)
+        m.fs.P2.control_volume.properties_out[0].pressure.unfix()
 
-    # ---initialize mixer---
-    propagate_state(m.fs.s03)
-    propagate_state(m.fs.s10)
-    m.fs.M1.initialize(optarg=optarg, outlvl=idaeslog.INFO)
+        # ---initialize mixer---
+        propagate_state(m.fs.s03)
+        propagate_state(m.fs.s10)
+        m.fs.M1.initialize(optarg=optarg, outlvl=idaeslog.INFO)
+
+    elif m.erd_type == "pump_as_turbine":
+        propagate_state(m.fs.s05)
+        m.fs.ERD.initialize(optarg=optarg)
+        propagate_state(m.fs.s01)
+        m.fs.P1.initialize(optarg=optarg)
+        propagate_state(m.fs.s02)
+        # m.fs.RO.initialize(optarg=optarg)
+
+    else:
+        pass
 
     m.fs.costing.initialize()
 
@@ -380,9 +443,12 @@ def optimize_set_up(m):
     m.fs.P1.control_volume.properties_out[0].pressure.setlb(10e5)
     m.fs.P1.control_volume.properties_out[0].pressure.setub(80e5)
     m.fs.P1.deltaP.setlb(0)
-    m.fs.P2.control_volume.properties_out[0].pressure.setlb(10e5)
-    m.fs.P2.control_volume.properties_out[0].pressure.setub(80e5)
-    m.fs.P2.deltaP.setlb(0)
+    if m.erd_type == "pressure_exchanger":
+        m.fs.P2.control_volume.properties_out[0].pressure.setlb(10e5)
+        m.fs.P2.control_volume.properties_out[0].pressure.setub(80e5)
+        m.fs.P2.deltaP.setlb(0)
+    else:
+        pass
 
     # RO
     m.fs.RO.area.setlb(1)
@@ -410,11 +476,6 @@ def optimize_set_up(m):
 
     # ---checking model---
     assert_degrees_of_freedom(m, 1)
-
-
-def optimize(m, solver=None, check_termination=True):
-    # --solve---
-    return solve(m, solver=solver, check_termination=check_termination)
 
 
 def display_system(m):
@@ -456,8 +517,6 @@ def display_design(m):
     print("Membrane area %.1f m2" % (m.fs.RO.area.value))
 
     print("---design variables---")
-    print("Separator")
-    print("Split fraction %.2f" % (m.fs.S1.split_fraction[0, "PXR"].value * 100))
     print(
         "Pump 1\noutlet pressure: %.1f bar\npower %.2f kW"
         % (
@@ -465,13 +524,26 @@ def display_design(m):
             m.fs.P1.work_mechanical[0].value / 1e3,
         )
     )
-    print(
-        "Pump 2\noutlet pressure: %.1f bar\npower %.2f kW"
-        % (
-            m.fs.P2.outlet.pressure[0].value / 1e5,
-            m.fs.P2.work_mechanical[0].value / 1e3,
+    if m.erd_type == "pressure_exchanger":
+        print("Separator")
+        print("Split fraction %.2f" % (m.fs.S1.split_fraction[0, "PXR"].value * 100))
+        print(
+            "Pump 2\noutlet pressure: %.1f bar\npower %.2f kW"
+            % (
+                m.fs.P2.outlet.pressure[0].value / 1e5,
+                m.fs.P2.work_mechanical[0].value / 1e3,
+            )
         )
-    )
+    elif m.erd_type == "pump_as_turbine":
+        print(
+            "ERD\ninlet pressure: %.1f bar\npower recovered %.2f kW"
+            % (
+                m.fs.ERD.inlet.pressure[0].value / 1e5,
+                -1 * m.fs.ERD.work_mechanical[0].value / 1e3,
+            )
+        )
+    else:
+        pass
 
 
 def display_state(m):
@@ -502,4 +574,5 @@ def display_state(m):
 
 
 if __name__ == "__main__":
-    main()
+    # m = main(erd_type="pressure_exchanger")
+    m = main(erd_type="pump_as_turbine")

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -80,8 +80,8 @@ def main(erd_type=ERDtype.pressure_exchanger):
 def build(erd_type=ERDtype.pressure_exchanger):
     # flowsheet set up
     m = ConcreteModel()
-    m.fs.erd_type = erd_type
     m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.erd_type = erd_type
     m.fs.properties = props.NaClParameterBlock()
     m.fs.costing = WaterTAPCosting()
 

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -472,6 +472,11 @@ def optimize_set_up(m):
     assert_degrees_of_freedom(m, 1)
 
 
+def optimize(m, solver=None, check_termination=True):
+    # --solve---
+    return solve(m, solver=solver, check_termination=check_termination)
+
+
 def display_system(m):
     print("---system metrics---")
     feed_flow_mass = sum(

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -24,6 +24,7 @@ from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recover
     set_operating_conditions,
     initialize_system,
     solve,
+    optimize,
 )
 
 from watertap.tools.parameter_sweep_input_parser import (
@@ -100,7 +101,7 @@ def run_parameter_sweep(
         outputs,
         csv_results_file_name=csv_results_file_name,
         h5_results_file_name=h5_results_file_name,
-        optimize_function=solve,
+        optimize_function=optimize,
         optimize_kwargs={"solver": solver, "check_termination": False},
         num_samples=num_samples,
         seed=seed,

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -24,7 +24,6 @@ from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recover
     set_operating_conditions,
     initialize_system,
     solve,
-    optimize,
 )
 
 from watertap.tools.parameter_sweep_input_parser import (
@@ -101,7 +100,7 @@ def run_parameter_sweep(
         outputs,
         csv_results_file_name=csv_results_file_name,
         h5_results_file_name=h5_results_file_name,
-        optimize_function=optimize,
+        optimize_function=solve,
         optimize_kwargs={"solver": solver, "check_termination": False},
         num_samples=num_samples,
         seed=seed,

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -40,14 +40,13 @@ from idaes.core.util.scaling import (
 import watertap.property_models.NaCl_prop_pack as props
 from watertap.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
 from watertap.unit_models.pressure_exchanger import PressureExchanger
-from watertap.unit_models.pressure_changer import Pump
+from watertap.unit_models.pressure_changer import Pump, EnergyRecoveryDevice
 from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import (
     build,
     set_operating_conditions,
     initialize_system,
     solve,
     optimize_set_up,
-    optimize,
     display_system,
     display_state,
     display_design,
@@ -57,10 +56,10 @@ from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recover
 solver = get_solver()
 
 # -----------------------------------------------------------------------------
-class TestEnergyRecoverySystem:
+class TestROwithPX:
     @pytest.fixture(scope="class")
     def system_frame(self):
-        m = build()
+        m = build(erd_type="pressure_exchanger")
 
         return m
 
@@ -195,7 +194,7 @@ class TestEnergyRecoverySystem:
         assert m.fs.RO.width.is_fixed()
         assert value(m.fs.RO.width) == 5
         assert not m.fs.RO.area.is_fixed()
-        assert value(m.fs.RO.area) == pytest.approx(50, rel=1e-3)
+        assert value(m.fs.RO.area) == pytest.approx(99.081, rel=1e-3)
 
         # check degrees of freedom
         assert degrees_of_freedom(m) == 0
@@ -297,11 +296,11 @@ Levelized cost of water: 0.44 $/m3
 Operating pressure 74.9 bar
 Membrane area 60.2 m2
 ---design variables---
-Separator
-Split fraction 50.53
 Pump 1
 outlet pressure: 74.9 bar
 power 4.57 kW
+Separator
+Split fraction 50.53
 Pump 2
 outlet pressure: 74.9 bar
 power 0.30 kW
@@ -336,7 +335,7 @@ PXR HP out: 0.528 kg/s, 67389 ppm, 1.0 bar
         m = system_frame
 
         optimize_set_up(m)
-        optimize(m, solver=solver)
+        solve(m, solver=solver)
 
         # check decision variables
         assert value(m.fs.RO.inlet.pressure[0]) == pytest.approx(5.708e6, rel=1e-3)
@@ -349,3 +348,67 @@ PXR HP out: 0.528 kg/s, 67389 ppm, 1.0 bar
             2.110, rel=1e-3
         )
         assert value(m.fs.costing.LCOW) == pytest.approx(0.4111, rel=1e-3)
+
+
+class TestROwithTurbine:
+    @pytest.fixture(scope="class")
+    def system_frame(self):
+        m = build(erd_type="pump_as_turbine")
+
+        return m
+
+    @pytest.mark.unit
+    def test_build(self, system_frame):
+        m = system_frame
+        fs = m.fs
+        assert isinstance(fs.ERD, EnergyRecoveryDevice)
+        # arcs
+        arc_dict = {
+            fs.s01: (fs.feed.outlet, fs.P1.inlet),
+            fs.s02: (fs.P1.outlet, fs.RO.inlet),
+            fs.s03: (fs.RO.permeate, fs.product.inlet),
+            fs.s04: (fs.RO.retentate, fs.ERD.inlet),
+            fs.s05: (fs.ERD.outlet, fs.disposal.inlet),
+        }
+        for arc, port_tpl in arc_dict.items():
+            assert arc.source is port_tpl[0]
+            assert arc.destination is port_tpl[1]
+
+    @pytest.mark.component
+    def test_units(self, system_frame):
+        assert_units_consistent(system_frame)
+
+    @pytest.mark.component
+    def test_set_operating_conditions(self, system_frame):
+        m = system_frame
+        set_operating_conditions(m)
+        assert m.fs.ERD.efficiency_pump[0].is_fixed()
+        assert pytest.approx(0.95, rel=1e-5) == value(m.fs.ERD.efficiency_pump[0])
+        assert pytest.approx(101325, rel=1e-5) == value(
+            m.fs.ERD.control_volume.properties_out[0].pressure
+        )
+
+        assert degrees_of_freedom(m) == 0
+
+    @pytest.mark.component
+    def test_initialize_system(self, system_frame):
+        m = system_frame
+        initialize_system(m, solver=solver)
+        assert pytest.approx(60.1545, rel=1e-5) == value(m.fs.RO.area)
+
+    @pytest.mark.component
+    def test_optimize_setup(self, system_frame):
+        m = system_frame
+        optimize_set_up(m)
+        solve(m, solver=solver)
+        assert degrees_of_freedom(m) == 1
+
+    @pytest.mark.component
+    def test_solution(self, system_frame):
+        m = system_frame
+        fs = m.fs
+        assert pytest.approx(120.154, rel=1e-5) == value(fs.RO.area)
+        assert pytest.approx(2.42916, rel=1e-5) == value(
+            fs.costing.specific_energy_consumption
+        )
+        assert pytest.approx(0.54814, rel=1e-5) == value(fs.costing.LCOW)

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -414,3 +414,8 @@ class TestROwithTurbine:
             fs.costing.specific_energy_consumption
         )
         assert pytest.approx(0.54814, rel=1e-5) == value(fs.costing.LCOW)
+
+    @pytest.mark.component
+    def test_config_error(self, system_frame):
+        with pytest.raises(Exception):
+            build(erd_type="not_a_configuration")

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -47,9 +47,11 @@ from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recover
     initialize_system,
     solve,
     optimize_set_up,
+    optimize,
     display_system,
     display_state,
     display_design,
+    ERDtype,
 )
 
 
@@ -335,7 +337,7 @@ PXR HP out: 0.528 kg/s, 67389 ppm, 1.0 bar
         m = system_frame
 
         optimize_set_up(m)
-        solve(m, solver=solver)
+        optimize(m, solver=solver)
 
         # check decision variables
         assert value(m.fs.RO.inlet.pressure[0]) == pytest.approx(5.708e6, rel=1e-3)
@@ -353,7 +355,7 @@ PXR HP out: 0.528 kg/s, 67389 ppm, 1.0 bar
 class TestROwithTurbine:
     @pytest.fixture(scope="class")
     def system_frame(self):
-        m = build(erd_type="pump_as_turbine")
+        m = build(erd_type=ERDtype.pump_as_turbine)
 
         return m
 


### PR DESCRIPTION
## Fixes/Resolves:

Replicates the pump-as-turbine configuration from the seawater reverse osmosis treatment train into a process-only flowsheet.

## Summary/Motivation:
Allows for the use of an alternative and simpler system configuration of reverse osmosis, separate from the full treatment train that is modeled in the `seawater_RO_desalination.py` case study

## Changes proposed in this PR:
- Add option to specify `erd_type` as `pump_as_turbine` or `pressure_exchanger` (default)
- Modify `build`, `set_operating_conditions`, `initialize_system`, and `display` to consider `erd_type = pump_as_turbine`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
