### PR TITLE
Electrical carbon intensity in WaterTAP costing

### DIFF
--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -119,7 +119,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
 
         self.electrical_carbon_intensity = pyo.Param(
             mutable=True,
-            initialize=0.1,
+            initialize=0.475,
             doc="Grid carbon intensity [kgCO2_eq/kWh]",
             units=pyo.units.kg / pyo.units.kWh,
         )

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -117,7 +117,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             units=self.base_currency / pyo.units.kWh,
         )
 
-        self.carbon_intensity = pyo.Param(
+        self.electrical_carbon_intensity = pyo.Param(
             mutable=True,
             initialize=0.1,
             doc="Grid carbon intensity [kgCO2_eq/kWh]",
@@ -635,27 +635,27 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             ),
         )
 
-    def add_specific_carbon_intensity(
-        self, flow_rate, name="specific_carbon_intensity"
+    def add_specific_electrical_carbon_intensity(
+        self, flow_rate, name="specific_electrical_carbon_intensity"
     ):
         """
-        Add specific carbon intensity (kg_CO2eq/m**3) to costing block.
+        Add specific electrical carbon intensity (kg_CO2eq/m**3) to costing block.
         Args:
             flow_rate - flow rate of water (volumetric) to be used in
-                        calculating specific energy consumption
+                        calculating specific electrical carbon intensity
             name (optional) - the name of the Expression for the specific
-                              energy consumption (default: specific_energy_consumption)
+                              energy consumption (default: specific_electrical_carbon_intensity)
         """
 
         self.add_component(
             name,
             pyo.Expression(
                 expr=self.aggregate_flow_electricity
-                * self.carbon_intensity
+                * self.electrical_carbon_intensity
                 / pyo.units.convert(
                     flow_rate, to_units=pyo.units.m**3 / pyo.units.hr
                 ),
-                doc=f"Specific carbon intensity based on flow {flow_rate.name}",
+                doc=f"Specific electrical carbon intensity based on flow {flow_rate.name}",
             ),
         )
 

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -117,6 +117,13 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             units=self.base_currency / pyo.units.kWh,
         )
 
+        self.carbon_intensity = pyo.Param(
+            mutable=True,
+            initialize=0.1,
+            doc="Grid carbon intensity [kgCO2_eq/kWh]",
+            units=pyo.units.kg / pyo.units.kWh,
+        )
+
         def build_reverse_osmosis_cost_param_block(blk):
 
             costing = blk.parent_block()
@@ -625,6 +632,30 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
                     flow_rate, to_units=pyo.units.m**3 / pyo.units.hr
                 ),
                 doc=f"Specific energy consumption based on flow {flow_rate.name}",
+            ),
+        )
+
+    def add_specific_carbon_intensity(
+        self, flow_rate, name="specific_carbon_intensity"
+    ):
+        """
+        Add specific carbon intensity (kg_CO2eq/m**3) to costing block.
+        Args:
+            flow_rate - flow rate of water (volumetric) to be used in
+                        calculating specific energy consumption
+            name (optional) - the name of the Expression for the specific
+                              energy consumption (default: specific_energy_consumption)
+        """
+
+        self.add_component(
+            name,
+            pyo.Expression(
+                expr=self.aggregate_flow_electricity
+                * self.carbon_intensity
+                / pyo.units.convert(
+                    flow_rate, to_units=pyo.units.m**3 / pyo.units.hr
+                ),
+                doc=f"Specific carbon intensity based on flow {flow_rate.name}",
             ),
         )
 

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -157,7 +157,9 @@ def build(erd_type=ERDtype.pressure_exchanger):
     m.fs.costing.add_annual_water_production(m.fs.product.properties[0].flow_vol)
     m.fs.costing.add_LCOW(m.fs.product.properties[0].flow_vol)
     m.fs.costing.add_specific_energy_consumption(m.fs.product.properties[0].flow_vol)
-    m.fs.costing.add_specific_carbon_intensity(m.fs.product.properties[0].flow_vol)
+    m.fs.costing.add_specific_electrical_carbon_intensity(
+        m.fs.product.properties[0].flow_vol
+    )
 
     # connections
     if erd_type == ERDtype.pressure_exchanger:

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -157,6 +157,7 @@ def build(erd_type=ERDtype.pressure_exchanger):
     m.fs.costing.add_annual_water_production(m.fs.product.properties[0].flow_vol)
     m.fs.costing.add_LCOW(m.fs.product.properties[0].flow_vol)
     m.fs.costing.add_specific_energy_consumption(m.fs.product.properties[0].flow_vol)
+    m.fs.costing.add_specific_carbon_intensity(m.fs.product.properties[0].flow_vol)
 
     # connections
     if erd_type == ERDtype.pressure_exchanger:

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -413,7 +413,7 @@ class TestROwithTurbine:
         assert pytest.approx(2.42916, rel=1e-5) == value(
             fs.costing.specific_energy_consumption
         )
-        assert pytest.approx(0.242916, rel=1e-3) == value(
+        assert pytest.approx(1.15385, rel=1e-3) == value(
             fs.costing.specific_electrical_carbon_intensity
         )
         assert pytest.approx(0.54814, rel=1e-5) == value(fs.costing.LCOW)

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -413,6 +413,9 @@ class TestROwithTurbine:
         assert pytest.approx(2.42916, rel=1e-5) == value(
             fs.costing.specific_energy_consumption
         )
+        assert pytest.approx(0.242916, rel=1e-3) == value(
+            fs.costing.specific_carbon_intensity
+        )
         assert pytest.approx(0.54814, rel=1e-5) == value(fs.costing.LCOW)
 
     @pytest.mark.component

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -414,7 +414,7 @@ class TestROwithTurbine:
             fs.costing.specific_energy_consumption
         )
         assert pytest.approx(0.242916, rel=1e-3) == value(
-            fs.costing.specific_carbon_intensity
+            fs.costing.specific_electrical_carbon_intensity
         )
         assert pytest.approx(0.54814, rel=1e-5) == value(fs.costing.LCOW)
 


### PR DESCRIPTION
## Fixes/Resolves:
Accounts for the equivalent embedded carbon emissions associated with consuming electricity from an electric grid.

## Summary/Motivation:


## Changes proposed in this PR:
- `electrical_carbon_intensity` global parameter in WaterTAP costing.
- `add_specific_electrical_carbon_intensity` method normalizes the annual carbon emissions associated with electricity by the annual water production.
- Tested using the `RO_with_energy_recovery` flowsheet.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
