### PR TITLE
Replace zero-order UV and UV AOP models costing methods

### DIFF
--- a/watertap/data/techno_economic/uv.yaml
+++ b/watertap/data/techno_economic/uv.yaml
@@ -1,18 +1,12 @@
 default:
   capital_cost:  #Cost parameters retrieved by fitting TWDB data in ALAMO (MADp modeler, max terms=4)
     cost_factor: None
-    uv_capital_a_parameter:
-      value: 54575.441224888216140698
-      units: USD_2014
-    uv_capital_b_parameter:
-      value: 12268.649303773354830582
-      units: USD_2014
-    uv_capital_c_parameter:
-      value: 0.19242621822957126230235e-3
-      units: USD_2014
-    uv_capital_d_parameter:
-      value: -12779.106944244096766283
-      units: USD_2014
+    reactor_cost:
+      value: 202.346
+      units: USD_2020/(m^3/hr)
+    lamp_cost:
+      value: 235.5
+      units: USD_2020/kW
   default_removal_frac_mass_comp:
     value: 0
     units: dimensionless

--- a/watertap/data/techno_economic/uv_aop.yaml
+++ b/watertap/data/techno_economic/uv_aop.yaml
@@ -7,18 +7,12 @@ default:         # default is for hydrogen peroxide
     aop_capital_b_parameter:
       value: 0.2277
       units: dimensionless
-    uv_capital_a_parameter:
-      value: 54575.441224888216140698
-      units: USD_2014
-    uv_capital_b_parameter:
-      value: 12268.649303773354830582
-      units: USD_2014
-    uv_capital_c_parameter:
-      value: 0.00019242621822957126230235
-      units: USD_2014
-    uv_capital_d_parameter:
-      value: -12779.106944244096766283
-      units: USD_2014
+    reactor_cost:
+      value: 202.346
+      units: USD_2020/(m^3/hr)
+    lamp_cost:
+      value: 235.5
+      units: USD_2020/kW
 
   default_removal_frac_mass_comp:
     value: 0
@@ -64,24 +58,18 @@ default:         # default is for hydrogen peroxide
 hydrogen_peroxide:
   capital_cost: #Cost parameters retrieved by fitting TWDB data in ALAMO (MADp modeler, max terms=4)
     cost_factor: None
-    uv_capital_a_parameter:
-      value: 54575.441224888216140698
-      units: USD_2014
-    uv_capital_b_parameter:
-      value: 12268.649303773354830582
-      units: USD_2014
-    uv_capital_c_parameter:
-      value: 0.19242621822957126230235e-3
-      units: USD_2014
-    uv_capital_d_parameter:
-      value: -12779.1069
-      units: USD_2014
     aop_capital_a_parameter:
       value: 1228000
       units: USD_2014
     aop_capital_b_parameter:
       value: 0.2277
       units: dimensionless
+    reactor_cost:
+      value: 202.346
+      units: USD_2020/(m^3/hr)
+    lamp_cost:
+      value: 235.5
+      units: USD_2020/kW
   default_removal_frac_mass_comp:
     value: 0
     units: dimensionless

--- a/watertap/examples/flowsheets/case_studies/municipal_treatment/tests/test_municipal_treatment.py
+++ b/watertap/examples/flowsheets/case_studies/municipal_treatment/tests/test_municipal_treatment.py
@@ -64,7 +64,7 @@ def test_municipal_treatment():
         m.fs.recharge_pump.properties[0].flow_mass_comp["tss"]
     ) == pytest.approx(1.656e-6, rel=1e-3)
 
-    assert value(m.fs.costing.LCOW) == pytest.approx(5.1682e-7, rel=1e-3)  # in M$/m**3
+    assert value(m.fs.costing.LCOW) == pytest.approx(5.0547e-7, rel=1e-3)  # in M$/m**3
     assert value(m.fs.costing.electricity_intensity) == pytest.approx(
         4.4812e-1, rel=1e-3
     )

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
@@ -98,7 +98,7 @@ def test_seawater_RO_desalination_pressure_exchanger():
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
 
-    assert value(m.LCOW) == pytest.approx(0.845200, rel=1e-5)
+    assert value(m.LCOW) == pytest.approx(0.8411, rel=1e-5)
 
 
 @pytest.mark.component
@@ -180,4 +180,4 @@ def test_seawater_RO_desalination_pump_as_turbine():
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
 
-    assert value(m.LCOW) == pytest.approx(1.115729, rel=1e-5)
+    assert value(m.LCOW) == pytest.approx(1.11162, rel=1e-5)

--- a/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
@@ -313,36 +313,38 @@ def test_costing():
 
     m.fs.costing = ZeroOrderCosting()
 
-    m.fs.unit1 = UVAOPZO(default={"property_package": m.fs.params, "database": m.db})
+    m.fs.unit = UVAOPZO(default={"property_package": m.fs.params, "database": m.db})
 
-    m.fs.unit1.inlet.flow_mass_comp[0, "H2O"].fix(10000)
-    m.fs.unit1.inlet.flow_mass_comp[0, "viruses_enteric"].fix(1)
-    m.fs.unit1.inlet.flow_mass_comp[0, "toc"].fix(2)
-    m.fs.unit1.inlet.flow_mass_comp[0, "cryptosporidium"].fix(3)
-    m.fs.unit1.load_parameters_from_database(use_default_removal=True)
+    m.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(10000)
+    m.fs.unit.inlet.flow_mass_comp[0, "viruses_enteric"].fix(1)
+    m.fs.unit.inlet.flow_mass_comp[0, "toc"].fix(2)
+    m.fs.unit.inlet.flow_mass_comp[0, "cryptosporidium"].fix(3)
+    m.fs.unit.load_parameters_from_database(use_default_removal=True)
 
-    assert degrees_of_freedom(m.fs.unit1) == 0
+    assert degrees_of_freedom(m.fs.unit) == 0
 
-    m.fs.unit1.costing = UnitModelCostingBlock(
+    m.fs.unit.costing = UnitModelCostingBlock(
         default={"flowsheet_costing_block": m.fs.costing}
     )
 
-    assert isinstance(m.fs.unit1.chemical_flow_mass, Var)
+    assert isinstance(m.fs.unit.chemical_flow_mass, Var)
     assert isinstance(m.fs.costing.uv_aop, Block)
-    assert isinstance(m.fs.costing.uv_aop.uv_capital_a_parameter, Var)
-    assert isinstance(m.fs.costing.uv_aop.uv_capital_b_parameter, Var)
-    assert isinstance(m.fs.costing.uv_aop.uv_capital_c_parameter, Var)
-    assert isinstance(m.fs.costing.uv_aop.uv_capital_d_parameter, Var)
+    assert isinstance(m.fs.costing.uv_aop.reactor_cost, Var)
+    assert isinstance(m.fs.costing.uv_aop.lamp_cost, Var)
     assert isinstance(m.fs.costing.uv_aop.aop_capital_a_parameter, Var)
     assert isinstance(m.fs.costing.uv_aop.aop_capital_b_parameter, Var)
 
-    assert isinstance(m.fs.unit1.costing.capital_cost, Var)
-    assert isinstance(m.fs.unit1.costing.capital_cost_constraint, Constraint)
+    assert isinstance(m.fs.unit.costing.capital_cost, Var)
+    assert isinstance(m.fs.unit.costing.capital_cost_constraint, Constraint)
 
     assert_units_consistent(m.fs)
-    assert degrees_of_freedom(m.fs.unit1) == 0
+    assert degrees_of_freedom(m.fs.unit) == 0
+    initialization_tester(m)
+    results = solver.solve(m)
+    check_optimal_termination(results)
+    assert pytest.approx(18.5857, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
 
-    assert m.fs.unit1.electricity[0] in m.fs.costing._registered_flows["electricity"]
+    assert m.fs.unit.electricity[0] in m.fs.costing._registered_flows["electricity"]
     assert str(m.fs.costing._registered_flows["hydrogen_peroxide"][0]) == str(
-        m.fs.unit1.chemical_flow_mass[0]
+        m.fs.unit.chemical_flow_mass[0]
     )


### PR DESCRIPTION
## Fixes/Resolves:

Resolve the uv costing with the issue #447 

## Summary/Motivation:

Replace uv and uv-aop costing method

## Changes proposed in this PR:
- Change costing method
- Change test files

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
