### PR TITLE
Add windows MPI test

### DIFF
--- a/.github/workflows/mpi4py-test.yml
+++ b/.github/workflows/mpi4py-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os-version }}
     defaults:
       run:
         shell: bash -l {0}
@@ -20,6 +20,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8]
+        os:
+          - linux
+          - win64
+          # - macos
+        include:
+          - os: linux
+            os-version: ubuntu-20.04
+          - os: win64
+            os-version: windows-2019
+          # - os: macos
+          #   os-version: macos-10.15
 
     steps:
     - uses: actions/checkout@v2
@@ -34,10 +45,8 @@ jobs:
         python -m pip install --progress-bar off --upgrade pip
         pip install --progress-bar off -r requirements-dev.txt
         idaes get-extensions --verbose
-        # make ipopt (and other idaes extensions) accessable
-        echo "$HOME/.idaes/bin" >> $GITHUB_PATH
     - name: Conda info
       run: conda info
     - name: Test parallel pytest
       run: |
-        mpirun -n 2 pytest watertap/tools/tests/test_parameter_sweep.py --no-cov
+        mpiexec -n 2 pytest watertap/tools/tests/test_parameter_sweep.py --no-cov

--- a/.github/workflows/mpi4py-test.yml
+++ b/.github/workflows/mpi4py-test.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        conda install --quiet --yes mpi4py
+        conda install --quiet --yes -c conda-forge mpi4py
         python -m pip install --progress-bar off --upgrade pip
         pip install --progress-bar off -r requirements-dev.txt
         idaes get-extensions --verbose

--- a/docs/technical_reference/tools/parameter_sweep.rst
+++ b/docs/technical_reference/tools/parameter_sweep.rst
@@ -72,7 +72,7 @@ using two threads.
 
 .. code:: bash
 
-   mpirun -n 2 python parameter_sweep_script.py
+   mpiexec -n 2 python parameter_sweep_script.py
 
 For advanced users, the parameter sweep tool can optionally take a MPI communicator
 as an argument.


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
Users have expressed a desire to use the parallel capabilities of the parameter sweep tool on Windows machines.

## Changes proposed in this PR:
- Add parameter sweep Windows MPI test
- Slight update to parameter sweep documentation for Windows

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
