### PR TITLE
Fix ReverseOsmosis0D model in documentation example

### DIFF
--- a/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
+++ b/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
@@ -56,7 +56,7 @@ However, when writing a script, it is recommended (and in some cases, required; 
 Example: Python file with recommended structure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doctest::
+.. testcode::
 
    # Import concrete model from Pyomo
    from pyomo.environ import ConcreteModel
@@ -115,7 +115,7 @@ Example: Python file with recommended structure
 Example: the same code without recommended structure (may cause errors on Windows)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doctest::
+.. code-block::
 
    # Import concrete model from Pyomo
    from pyomo.environ import ConcreteModel

--- a/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
+++ b/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
@@ -67,10 +67,10 @@ Example: Python file with recommended structure
    # Import utility tool for calculating scaling factors
    from idaes.core.util.scaling import calculate_scaling_factors
    # Import RO model
-   from watertap.unit_models.reverse_osmosis_0D import ReverseOsmosis0
-   # import the solver 
+   from watertap.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
+   # import the solver
    from idaes.core.solvers import get_solver
-   
+
 
    # Put all the model constructors, initialization, and solver in a separate function
    def main():
@@ -80,7 +80,7 @@ Example: Python file with recommended structure
        m.fs.properties = props.NaClParameterBlock()
        # Add an RO unit to the flowsheet.
        m.fs.unit = ReverseOsmosis0D(default={"property_package": m.fs.properties})
-       
+
        # Specify system variables.
        m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'NaCl'].fix(0.035)  # mass flow rate of NaCl
        m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'H2O'].fix(0.965)  # mass flow rate of water
@@ -90,27 +90,27 @@ Example: Python file with recommended structure
        m.fs.unit.A_comp.fix(4.2e-12)  # membrane water permeability
        m.fs.unit.B_comp.fix(3.5e-8)  # membrane salt permeability
        m.fs.unit.permeate.pressure[0].fix(101325)  # permeate pressure
-       
+
        # Set scaling factors for component mass flowrates.
        m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1, index=('Liq', 'H2O'))
        m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e2, index=('Liq', 'NaCl'))
-       
+
        # Calculate scaling factors.
        calculate_scaling_factors(m)
 
-       # Get default watertap solver 
+       # Get default watertap solver
        solver = get_solver()
-       
-       # Initialize the model passing default solver options 
-       m.fs.unit.initialize(optarg=solver.options)
-       
-       # Solve the model (using the tee=True option to display solver info)
-       results = solver.solve(m, tee=True)
 
-   # Call that function in the "__main__" for the script 
+       # Initialize the model passing default solver options
+       m.fs.unit.initialize(optarg=solver.options)
+
+       # Solve the model (using the tee=True option to display solver info)
+       solver.solve(m, tee=True)
+
+
+   # Call that function in the "__main__" for the script
    if __name__ == "__main__":
        main()
-
 
 Example: the same code without recommended structure (may cause errors on Windows)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -126,8 +126,8 @@ Example: the same code without recommended structure (may cause errors on Window
    # Import utility tool for calculating scaling factors
    from idaes.core.util.scaling import calculate_scaling_factors
    # Import RO model
-   from watertap.unit_models.reverse_osmosis_0D import ReverseOsmosis0
-   # import the solver 
+   from watertap.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
+   # import the solver
    from idaes.core.solvers import get_solver
 
    # Create a concrete model, flowsheet, and NaCl property parameter block.
@@ -136,7 +136,7 @@ Example: the same code without recommended structure (may cause errors on Window
    m.fs.properties = props.NaClParameterBlock()
    # Add an RO unit to the flowsheet.
    m.fs.unit = ReverseOsmosis0D(default={"property_package": m.fs.properties})
-   
+
    # Specify system variables.
    m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'NaCl'].fix(0.035)  # mass flow rate of NaCl
    m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'H2O'].fix(0.965)  # mass flow rate of water
@@ -146,23 +146,22 @@ Example: the same code without recommended structure (may cause errors on Window
    m.fs.unit.A_comp.fix(4.2e-12)  # membrane water permeability
    m.fs.unit.B_comp.fix(3.5e-8)  # membrane salt permeability
    m.fs.unit.permeate.pressure[0].fix(101325)  # permeate pressure
-   
+
    # Set scaling factors for component mass flowrates.
    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1, index=('Liq', 'H2O'))
    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e2, index=('Liq', 'NaCl'))
-   
+
    # Calculate scaling factors.
    calculate_scaling_factors(m)
 
-   # Get default watertap solver 
+   # Get default watertap solver
    solver = get_solver()
-   
-   # Initialize the model passing default solver options 
-   m.fs.unit.initialize(optarg=solver.options)
-   
-   # Solve the model (using the tee=True option to display solver info)
-   results = solver.solve(m, tee=True)
 
+   # Initialize the model passing default solver options
+   m.fs.unit.initialize(optarg=solver.options)
+
+   # Solve the model (using the tee=True option to display solver info)
+   solver.solve(m, tee=True)
 
 If code other than imports and constant/function/class definitions is run in the global scope (i.e. not defined inside a function), it is likely to cause errors when run on Windows.
 See `issue #387 <https://github.com/watertap-org/watertap/issues/387>`_ for more details.

--- a/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
+++ b/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
@@ -56,7 +56,7 @@ However, when writing a script, it is recommended (and in some cases, required; 
 Example: Python file with recommended structure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block::
+.. doctest::
 
    # Import concrete model from Pyomo
    from pyomo.environ import ConcreteModel
@@ -115,7 +115,7 @@ Example: Python file with recommended structure
 Example: the same code without recommended structure (may cause errors on Windows)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block::
+.. doctest::
 
    # Import concrete model from Pyomo
    from pyomo.environ import ConcreteModel


### PR DESCRIPTION
## Fixes/Resolves:

Fixes issue #741

## Summary/Motivation:

The example given in the WaterTAP documentation for [How to run models in a Python script](https://watertap.readthedocs.io/en/latest/how_to_guides/how_to_run_models_in_a_py_script.html) does not run. The reverse osmosis model is imported as `ReverseOsmosis0` but should be imported as `ReverseOsmosis0D`. This pull request uses the proper import statement for the example.

## Changes proposed in this PR:
- Replace `ReverseOsmosis0` with `ReverseOsmosis0D`
- Remove unnecessary spaces

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
