### PR TITLE
Move API flowsheets entry points loading functionality, definitions, and basic tests to this repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,8 @@ setup(
         # for watertap.ui.api_model (though may be generally useful)
         "pydantic",
         "numpy",
+        # for importlib.metadata.entry_points()
+        "importlib_metadata; python_version < '3.8' ",
     ],
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,8 @@ setup(
             "metab = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.metab.metab_ui",
             "RO = watertap.examples.flowsheets.case_studies.seawater_RO_desalination.seawater_RO_desalination",
             "suboxic_ASM = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.suboxic_activated_sludge_process.suboxic_ASM_ui",
+            "Magprex = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.amo_1575_magprex.magprex_ui",
+            "biomembrane_filtration = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.biomembrane_filtration.biomembrane_filtration_ui",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,11 @@ setup(
         # add edb CLI commands
         "console_scripts": [
             "edb = watertap.edb.commands:command_base",
-        ]
+        ],
+        "watertap.flowsheets": [
+            "metab = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.metab.metab_ui",
+            "RO = watertap.examples.flowsheets.case_studies.seawater_RO_desalination.seawater_RO_desalination",
+            "suboxic_ASM = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.suboxic_activated_sludge_process.suboxic_ASM_ui",
+        ],
     },
 )

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -13,7 +13,13 @@ import importlib
 from pathlib import Path
 import re
 from typing import Callable, Optional, Dict, Union, TypeVar
+from types import ModuleType
 from uuid import uuid4
+
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
 
 # third-party
 import idaes.logger as idaeslog
@@ -348,3 +354,92 @@ class FlowsheetInterface:
         u = pyo.units
         for key, mo in self.fs_exp.model_objects.items():
             mo.value = pyo.value(u.convert(mo.obj, to_units=mo.ui_units))
+
+    @classmethod
+    def from_installed_packages(
+        cls, group_name: str = "watertap.flowsheets"
+    ) -> Dict[str, "FlowsheetInterface"]:
+        """Get all flowsheet interfaces defined as entry points within the Python packages installed in the environment.
+
+        This uses the importlib ``metadata.entry_points()`` function to fetch the
+        list of flowsheets declared as part of a Python package distribution's entry_points section under the group ``group_name``.
+
+        To set up a flowsheet interface for discovery, locate your Python package distribution's file (normally
+        setup.py, pyproject.toml, or equivalent) and add an entry in the ``entry_points`` section.
+
+        For example, to add a flowsheet defined in :file:`watertap/examples/flowsheets/my_flowsheet.py`
+        so that it can be discovered with the name ``my_flowsheet`` wherever the ``watertap`` package is installed,
+        the following should be added to WaterTAP's :file:`setup.py`::
+
+           setup(
+               name="watertap",
+               # other setup() sections
+               entry_points={
+                   "watertap.flowsheets": [
+                        # other flowsheet entry points
+                        "my_flowsheet = watertap.examples.flowsheets:my_flowsheet",
+                   ]
+               }
+           )
+
+        Args:
+            group_name: The entry_points group from which the flowsheet interface modules will be populated.
+
+        Returns:
+            Mapping with keys the module names and values FlowsheetInterface objects
+        """
+        try:
+            entry_points = list(metadata.entry_points()[group_name])
+        except KeyError:
+            _log.error(f"No interfaces found for entry points group: {group_name}")
+            return {}
+
+        interfaces = {}
+        _log.debug(f"Loading {len(entry_points)} entry points")
+        for ep in entry_points:
+            _log.debug(f"ep = {ep}")
+            module_name = ep.value
+            try:
+                module = ep.load()
+            except ImportError as err:
+                _log.error(f"Cannot import module '{module_name}': {err}")
+                continue
+            interface = cls.from_module(module)
+            if interface:
+                interfaces[module_name] = interface
+
+        return interfaces
+
+    @classmethod
+    def from_module(
+        cls, module: Union[str, ModuleType]
+    ) -> Optional["FlowsheetInterface"]:
+        """Get a a flowsheet interface for module.
+
+        Args:
+            module: The module
+
+        Returns:
+            A flowsheet interface or None if it failed
+        """
+        if not isinstance(module, ModuleType):
+            module = importlib.import_module(module)
+
+        # Get function that creates the FlowsheetInterface
+        func = getattr(module, cls.UI_HOOK, None)
+        if func is None:
+            _log.warning(
+                f"Interface for module '{module}' is missing UI hook function: "
+                f"{cls.UI_HOOK}()"
+            )
+            return None
+        # Call the function that creates the FlowsheetInterface
+        try:
+            interface = func()
+        except Exception as err:
+            _log.error(
+                f"Cannot get FlowsheetInterface object for module '{module}': {err}"
+            )
+            return None
+        # Return created FlowsheetInterface
+        return interface

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -361,11 +361,12 @@ class FlowsheetInterface:
     ) -> Dict[str, "FlowsheetInterface"]:
         """Get all flowsheet interfaces defined as entry points within the Python packages installed in the environment.
 
-        This uses the importlib ``metadata.entry_points()`` function to fetch the
-        list of flowsheets declared as part of a Python package distribution's entry_points section under the group ``group_name``.
+        This uses the :func:`importlib.metadata.entry_points` function to fetch the
+        list of flowsheets declared as part of a Python package distribution's `entry points <https://docs.python.org/3/library/importlib.metadata.html#entry-points>`_
+        under the group ``group_name``.
 
         To set up a flowsheet interface for discovery, locate your Python package distribution's file (normally
-        setup.py, pyproject.toml, or equivalent) and add an entry in the ``entry_points`` section.
+        :file:`setup.py`, :file:`pyproject.toml`, or equivalent) and add an entry in the ``entry_points`` section.
 
         For example, to add a flowsheet defined in :file:`watertap/examples/flowsheets/my_flowsheet.py`
         so that it can be discovered with the name ``my_flowsheet`` wherever the ``watertap`` package is installed,
@@ -377,7 +378,7 @@ class FlowsheetInterface:
                entry_points={
                    "watertap.flowsheets": [
                         # other flowsheet entry points
-                        "my_flowsheet = watertap.examples.flowsheets:my_flowsheet",
+                        "my_flowsheet = watertap.examples.flowsheets.my_flowsheet",
                    ]
                }
            )

--- a/watertap/ui/tests/test_flowsheet_interfaces.py
+++ b/watertap/ui/tests/test_flowsheet_interfaces.py
@@ -1,0 +1,21 @@
+from ..fsapi import FlowsheetInterface
+
+
+def pytest_generate_tests(metafunc):
+    if "fs_interface" in metafunc.fixturenames:
+        by_name = dict(FlowsheetInterface.from_installed_packages())
+        metafunc.parametrize(
+            "fs_interface",
+            list(by_name.values()),
+            ids=list(by_name.keys()),
+            scope="class",
+        )
+
+
+class TestFlowsheetInterface:
+    def test_basic_type(self, fs_interface):
+        assert isinstance(fs_interface, FlowsheetInterface)
+
+    def test_build(self, fs_interface):
+        fs_interface.build()
+        assert fs_interface.dict()


### PR DESCRIPTION
## Fixes/Resolves:

(replace this with the issue # fixed or resolved, if no issue exists then a brief statement of what this PR does)

## Summary/Motivation:

- It makes more sense for the flowsheets entry points (both discovery/loading logic and entry point definitions) to live in this repository (rather than `watertap-ui`)
- This also allows some tests to be run here (i.e. independently and complementary to those exercising the REST API and/or the UI layer) ensuring that at least the basic `fsapi` functionality works when adding new flowsheets

## Changes proposed in this PR:
- Move functionality to load `FlowsheetInterface` objects from entry points to this repository as `classmethods` of the class itself
- Move flowsheets entry point definitions to this repository
- Add basic tests validating all discovered flowsheet interfaces

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
