### PR TITLE
Extend tests for registered flowsheet interfaces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,6 @@ setup(
         ],
         "watertap.flowsheets": [
             "metab = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.metab.metab_ui",
-            "RO = watertap.examples.flowsheets.case_studies.seawater_RO_desalination.seawater_RO_desalination",
             "suboxic_ASM = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.suboxic_activated_sludge_process.suboxic_ASM_ui",
             "Magprex = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.amo_1575_magprex.magprex_ui",
             "biomembrane_filtration = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.biomembrane_filtration.biomembrane_filtration_ui",

--- a/watertap/ui/tests/test_flowsheet_interfaces.py
+++ b/watertap/ui/tests/test_flowsheet_interfaces.py
@@ -1,3 +1,12 @@
+"""
+Essential tests targeting the flowsheet interfaces registered and discoverable
+through the standard mechanism (currently FlowsheetInterface.from_installed_packages()).
+"""
+
+
+import pytest
+from pyomo.environ import assert_optimal_termination
+
 from ..fsapi import FlowsheetInterface
 
 
@@ -16,6 +25,28 @@ class TestFlowsheetInterface:
     def test_basic_type(self, fs_interface):
         assert isinstance(fs_interface, FlowsheetInterface)
 
-    def test_build(self, fs_interface):
+    @pytest.fixture
+    def data_post_build(self, fs_interface) -> dict:
         fs_interface.build()
-        assert fs_interface.dict()
+        return fs_interface.dict()
+
+    def test_build(self, data_post_build):
+        data = data_post_build
+        assert data
+        assert "model_objects" in data
+
+    @pytest.fixture
+    def model_objects(self, data_post_build):
+        return data_post_build["model_objects"]
+
+    def test_model_objects(self, model_objects):
+        assert len(model_objects) > 0
+
+    @pytest.fixture
+    def solve_results(self, fs_interface, data_post_build):
+        res = fs_interface.solve()
+        return res
+
+    def test_solve(self, solve_results):
+        assert solve_results
+        assert_optimal_termination(solve_results)


### PR DESCRIPTION
## Fixes/Resolves:

- Test failures in watertap-org/watertap-ui

## Summary/Motivation:
- Extend tests targeting registered flowsheet interfaces to ensure that all actions are implemented as expected
- Unregister flowsheets that do not fulfill these criteria (namely `seawater_RO`)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
