### PR TITLE
fsapi: Ensure references to parent components of exported Pyomo objects are kept valid

### DIFF
--- a/watertap/ui/tests/test_flowsheet_interfaces.py
+++ b/watertap/ui/tests/test_flowsheet_interfaces.py
@@ -2,6 +2,7 @@
 Essential tests targeting the flowsheet interfaces registered and discoverable
 through the standard mechanism (currently FlowsheetInterface.from_installed_packages()).
 """
+import gc
 
 
 import pytest
@@ -50,3 +51,12 @@ class TestFlowsheetInterface:
     def test_solve(self, solve_results):
         assert solve_results
         assert_optimal_termination(solve_results)
+
+
+@pytest.mark.parametrize("n_times", [2, 3], ids="{} times".format)
+def test_roundtrip_with_garbage_collection(fs_interface, n_times):
+    for attempt in range(n_times):
+        fs_interface.build()
+        data = fs_interface.dict()
+        fs_interface.load(data)
+        gc.collect()


### PR DESCRIPTION
## Fixes/Resolves:

- Errors showing up intermittently in `watertap-org/watertap-ui` REST API test suite as: `AttributeError: NoneType has no attribute "_units"` when converting units in `FlowsheetInterface.load()`

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
