### PR TITLE
Ion exchange ZO TDS removal yaml update

### DIFF
--- a/watertap/data/techno_economic/ion_exchange.yaml
+++ b/watertap/data/techno_economic/ion_exchange.yaml
@@ -5,10 +5,9 @@ default:  # TODO: should have removal rates for (e.g.) sulfate, nitrate, arsenic
   default_removal_frac_mass_comp:
     value: 0
     units: dimensionless
-    reference: 'EPA model: https://www.epa.gov/sdwa/drinking-water-treatment-technology-unit-cost-models'
   removal_frac_mass_comp:
     tds:
-      value: 0.9
+      value: 0
       units: dimensionless
       constituent_longform: Total Dissolved Solids (TDS)
   NaCl_dose:
@@ -41,10 +40,9 @@ anion_exchange:  # TODO: add some differentiation between default, anion, and ca
   default_removal_frac_mass_comp:
     value: 0
     units: dimensionless
-    reference: 'EPA model: https://www.epa.gov/sdwa/drinking-water-treatment-technology-unit-cost-models'
   removal_frac_mass_comp:
     tds:
-      value: 0.9
+      value: 0
       units: dimensionless
       constituent_longform: Total Dissolved Solids (TDS)
   NaCl_dose:
@@ -74,10 +72,9 @@ cation_exchange:
   default_removal_frac_mass_comp:
     value: 0
     units: dimensionless
-    reference: 'EPA model: https://www.epa.gov/sdwa/drinking-water-treatment-technology-unit-cost-models'
   removal_frac_mass_comp:
     tds:
-      value: 0.9
+      value: 0
       units: dimensionless
       constituent_longform: Total Dissolved Solids (TDS)
   NaCl_dose:
@@ -111,7 +108,7 @@ clinoptilolite: #AMO subtype
     ammonium_as_nitrogen:
       value: 0.999
       units: dimensionless
-      constituent_longform: Total Dissolved Solids (TDS)
+      constituent_longform: Ammonium as Nitrogen
   NaCl_dose:  # keep from default
     value: 0    # unsure if applicable
     units: kg/m^3
@@ -128,4 +125,4 @@ clinoptilolite: #AMO subtype
       units: USD_2020/m^3
   nitrogen_clay_ratio:
     units: dimensionless
-    value: .040
+    value: 0.040

--- a/watertap/examples/flowsheets/case_studies/municipal_treatment/municipal_treatment.py
+++ b/watertap/examples/flowsheets/case_studies/municipal_treatment/municipal_treatment.py
@@ -210,6 +210,7 @@ def set_operating_conditions(m):
 
     # anion exchange
     m.fs.anion_exchange.load_parameters_from_database(use_default_removal=True)
+    m.fs.anion_exchange.removal_frac_mass_comp[0, "tds"].fix(0.9)
 
     # chlorination
     m.fs.chlorination.load_parameters_from_database(use_default_removal=True)

--- a/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
@@ -123,13 +123,13 @@ class TestIonExchangeZO_w_default_removal:
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
-        assert pytest.approx(10.00410, rel=1e-5) == value(
+        assert pytest.approx(10.005, rel=1e-5) == value(
             model.fs.unit.properties_treated[0].flow_vol
         )
-        assert pytest.approx(9.99590e-3, rel=1e-5) == value(
+        assert pytest.approx(0.099950024, rel=1e-5) == value(
             model.fs.unit.properties_treated[0].conc_mass_comp["tds"]
         )
-        assert pytest.approx(0.39984, rel=1e-5) == value(
+        assert pytest.approx(0.3998, rel=1e-5) == value(
             model.fs.unit.properties_treated[0].conc_mass_comp["foo"]
         )
         assert pytest.approx(2899.6, rel=1e-5) == value(model.fs.unit.electricity[0])


### PR DESCRIPTION
## Fixes/Resolves:

Default TDS removal for ZO IX should not be 90%; should be user-defined with default of 0.

## Summary/Motivation:

Change default TDS removal for ZO ion exchange model to 0.

## Changes proposed in this PR:
- `removal_frac_mass_comp` for TDS changed from 0.9 to 0
- update test file 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
