### PR TITLE
Resolve near-silent errors when building flowsheet interfaces with Param objects

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ defaults:
 env:
   # --color=yes needed for colorized output to be shown in GHA logs
   # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py
-  PYTEST_ADDOPTS: "--color=yes --pyargs watertap"
+  PYTEST_ADDOPTS: "--color=yes --pyargs watertap.ui -v"
 
 jobs:
 
@@ -53,9 +53,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.7'
-          - '3.8'
-          - '3.9'
+          # - '3.7'
+          # - '3.8'
+          # - '3.9'
           - '3.10'
         os:
           - linux

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ defaults:
 env:
   # --color=yes needed for colorized output to be shown in GHA logs
   # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py
-  PYTEST_ADDOPTS: "--color=yes --pyargs watertap.ui -v"
+  PYTEST_ADDOPTS: "--color=yes --pyargs watertap"
 
 jobs:
 
@@ -53,9 +53,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          # - '3.7'
-          # - '3.8'
-          # - '3.9'
+          - '3.7'
+          - '3.8'
+          - '3.9'
           - '3.10'
         os:
           - linux

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -199,7 +199,7 @@ jobs:
         echo '::endgroup::'
     - name: Run pytest
       run: |
-        pytest --pyargs watertap
+        pytest
 
   macos:
     name: macOS setup (EXPERIMENTAL)
@@ -239,4 +239,4 @@ jobs:
         pyomo build-extensions || python -c "from pyomo.contrib.pynumero.asl import AmplInterface; exit(0) if AmplInterface.available() else exit(1)"
     - name: Run pytest
       run: |
-        pytest --pyargs watertap
+        pytest

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,12 +5,11 @@ coverage:
   status:
     patch:
       default:
-        target: auto
-        threshold: 10%
+        target: 60%
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 0.1%
 codecov:
   require_ci_to_pass: false
   notify:

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs_ui.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs_ui.py
@@ -557,7 +557,7 @@ def export_variables(flowsheet=None, exports=None):
     )
     direct_capital_norm = (
         fs.HRCS.costing.direct_capital_cost
-        + fs.clarifier.costing.dirct_capital_cost
+        + fs.clarifier.costing.direct_capital_cost
         + fs.sep.costing.direct_capital_cost
         # In WaterTAPCosting package `capital_cost` doesn't have any adders
         + _base_curr(fs.mixer.costing.capital_cost)

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs_ui.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs_ui.py
@@ -720,7 +720,10 @@ def export_variables(flowsheet=None, exports=None):
     total_operating = (
         fs.costing.total_fixed_operating_cost
         + fs.costing.total_variable_operating_cost
-        + _base_curr(fs.watertap_costing.total_operating_cost)
+        + pyunits.convert(
+            fs.watertap_costing.total_operating_cost,
+            to_units=fs.costing.base_currency / pyunits.year,
+        )
     )
     exports.add(
         obj=total_operating,

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1690/amo_1690_ui.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1690/amo_1690_ui.py
@@ -261,17 +261,6 @@ def export_variables(flowsheet=None, exports=None):
         is_output=False,
     )
     exports.add(
-        obj=fs.me.energy_electric_flow_vol_inlet,
-        name="Electricity intensity",
-        ui_units=pyunits.kWh / pyunits.m**3,
-        display_units="kWh/m3",
-        rounding=2,
-        description="Specific electricity intensity relating the intensity to the volume of product",
-        is_input=True,
-        input_category="Membrane evaporator",
-        is_output=False,
-    )
-    exports.add(
         obj=fs.me.removal_frac_mass_comp[0, "ammonium_as_nitrogen"],
         name="NH4 removal",
         ui_units=pyunits.dimensionless,

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -141,8 +141,10 @@ class ModelExport(BaseModel):
     @validator("is_readonly", always=True, pre=True)
     def set_readonly_default(cls, v, values):
         if v is None:
+            v = True
             obj = cls._get_supported_obj(values, allow_none=False)
-            v = True if not obj.is_variable_type() else False
+            if obj.is_variable_type() or (obj.is_parameter_type() and obj.mutable):
+                v = False
         return v
 
     @validator("obj_key", always=True, pre=True)

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -103,6 +103,14 @@ class ModelExport(BaseModel):
         cls._ensure_supported_type(obj)
         return obj
 
+    # NOTE: IMPORTANT: all validators used to set a dynamic default value
+    # should have the `always=True` option, or the validator won't be called
+    # when the value for that field is not passed
+    # (which is precisely when we need the default value)
+    # additionally, `pre=True` should be given if the field can at any point
+    # have a value that doesn't match its type annotation
+    # (e.g. `None` for a strict (non-`Optional` `bool` field)
+
     # Get value from object
     @validator("value", always=True)
     def validate_value(cls, v, values):
@@ -120,7 +128,7 @@ class ModelExport(BaseModel):
         return v
 
     # set name dynamically from object
-    @validator("name")
+    @validator("name", always=True)
     def validate_name(cls, v, values):
         if not v:
             obj = cls._get_supported_obj(values, allow_none=False)

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -50,7 +50,7 @@ class ModelExport(BaseModel):
     _SupportedObjType = Union[
         pyo.Var,
         pyo.Expression,
-        # pyo.Param,
+        pyo.Param,
     ]
     "Used for type hints and as a shorthand in error messages (i.e. not for runtime checks)"
 
@@ -86,7 +86,7 @@ class ModelExport(BaseModel):
         is_valid = (
             obj.is_variable_type()
             or obj.is_expression_type()
-            # or obj.is_parameter_type()
+            or obj.is_parameter_type()
             # TODO: add support for numbers with pyo.numvalue.is_numeric_data()
         )
         if is_valid:

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -523,9 +523,15 @@ class FlowsheetInterface:
         Returns:
             Mapping with keys the module names and values FlowsheetInterface objects
         """
+        eps = metadata.entry_points()
         try:
-            entry_points = list(metadata.entry_points()[group_name])
-        except KeyError:
+            # this happens for Python 3.7 (via importlib_metadata) and Python 3.10+
+            entry_points = list(eps.select(group=group_name))
+        except AttributeError:
+            # this will happen on Python 3.8 and 3.9, where entry_points() has dict-like group selection
+            entry_points = list(eps[group_name])
+
+        if not entry_points:
             _log.error(f"No interfaces found for entry points group: {group_name}")
             return {}
 

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -286,7 +286,7 @@ class FlowsheetInterface:
         try:
             self.run_action(Actions.build, **kwargs)
         except Exception as err:
-            _log.error(f"Building flowsheet: {err}")
+            raise RuntimeError(f"Building flowsheet: {err!r}") from err
         return
 
     def solve(self, **kwargs):
@@ -304,7 +304,7 @@ class FlowsheetInterface:
         try:
             result = self.run_action(Actions.solve, **kwargs)
         except Exception as err:
-            raise RuntimeError(f"Solving flowsheet: {err}")
+            raise RuntimeError(f"Solving flowsheet: {err:r}") from err
         return result
 
     def dict(self) -> Dict:

--- a/watertap/ui/tests/test_fsapi.py
+++ b/watertap/ui/tests/test_fsapi.py
@@ -126,8 +126,17 @@ def test_build():
     assert len(data["model_objects"]) == 1
 
 
+@pytest.mark.parametrize(
+    "add_variant",
+    [
+        "obj_kwarg",
+        "model_export_arg",
+        "model_export_data_kwarg",
+        "model_export_dict_data_kwarg",
+    ],
+)
 @pytest.mark.unit
-def test_actions():
+def test_actions(add_variant: str):
     fsi = flowsheet_interface()
     built = False
     garbage = {"trash": True}
@@ -149,11 +158,21 @@ def test_actions():
     def fake_export(flowsheet=None, exports=None):
         with pytest.raises(Exception):
             exports.add(obj=garbage)
-        exports.add(obj=v1)  # form 1
-        exports.add(v1)  # form 2
-        exports.add(data=v1)  # form 3
-        ve1 = fsapi.ModelExport(obj=v1)
-        exports.add(data=ve1.dict())  # form 4
+
+        # NOTE we use exclusive variants here
+        # to avoid triggering the error when adding an object with the same obj_key
+        # which happens when multiple ModelExport are created from the same pyomo object
+        if add_variant == "obj_kwarg":
+            exports.add(obj=v1)  # form 1
+        elif add_variant == "model_export_kwarg":
+            ve1 = fsapi.ModelExport(obj=v1)
+            exports.add(ve1)  # form 2
+        elif add_variant == "model_export_data_kwarg":
+            ve1 = fsapi.ModelExport(obj=v1)
+            exports.add(data=ve1)  # form 3
+        elif add_variant == "model_export_dict_data_kwarg":
+            ve1 = fsapi.ModelExport(obj=v1)
+            exports.add(data=ve1.dict())  # form 4
         with pytest.raises(ValueError):
             exports.add(v1, v1)
 


### PR DESCRIPTION
## Fixes/Resolves: #796, #797

## Changes proposed in this PR:
- [x] Restore re-raising exceptions within `FlowsheetInterface.build()`
- [x] Ensure more explicit validation errors are emitted
- [x] Add support for `Param` objects
- [x] Revisit logic for determining `is_readonly` based on `obj` (from @bknueven)
- [x] Fix various issues that were likely present but ignored because of the `FlowsheetExport.add()` error handling issues
  
![image](https://user-images.githubusercontent.com/48035537/194154727-f5bc0b89-d56e-4798-863d-0f8c2d30ce4c.png)


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
