### PR TITLE
Fixing deprecation warnings in seawater alkalinity tests

### DIFF
--- a/watertap/examples/chemistry/tests/test_seawater_alkalinity.py
+++ b/watertap/examples/chemistry/tests/test_seawater_alkalinity.py
@@ -105,6 +105,9 @@ from pyomo.environ import log10
 
 __author__ = "Austin Ladshaw"
 
+EPS = 1e-20
+
+
 # Configuration dictionary
 thermo_config = {
     "components": {
@@ -122,6 +125,7 @@ thermo_config = {
                 "temperature_crit": (647, pyunits.K),
                 # Comes from Perry's Handbook:  p. 2-98
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.459, pyunits.kmol * pyunits.m**-3),
                     "2": (0.30542, pyunits.dimensionless),
                     "3": (647.13, pyunits.K),
@@ -195,6 +199,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (1.00784, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.459, pyunits.kmol * pyunits.m**-3),
                     "2": (0.30542, pyunits.dimensionless),
                     "3": (647.13, pyunits.K),
@@ -227,6 +232,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (17.008, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.459, pyunits.kmol * pyunits.m**-3),
                     "2": (0.30542, pyunits.dimensionless),
                     "3": (647.13, pyunits.K),
@@ -259,6 +265,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (22.989769, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.252, pyunits.kmol * pyunits.m**-3),
                     "2": (0.347, pyunits.dimensionless),
                     "3": (1595.8, pyunits.K),
@@ -288,6 +295,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (35.453, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (4.985, pyunits.kmol * pyunits.m**-3),
                     "2": (0.36, pyunits.dimensionless),
                     "3": (1464.06, pyunits.K),
@@ -320,6 +328,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (62.03, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.4495, pyunits.kmol * pyunits.m**-3),
                     "2": (0.427, pyunits.dimensionless),
                     "3": (429.69, pyunits.K),
@@ -352,6 +361,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (61.0168, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.4495, pyunits.kmol * pyunits.m**-3),
                     "2": (0.427, pyunits.dimensionless),
                     "3": (429.69, pyunits.K),
@@ -384,6 +394,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (60.01, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.4495, pyunits.kmol * pyunits.m**-3),
                     "2": (0.427, pyunits.dimensionless),
                     "3": (429.69, pyunits.K),
@@ -416,6 +427,7 @@ thermo_config = {
             "parameter_data": {
                 "mw": (84.007, pyunits.g / pyunits.mol),
                 "dens_mol_liq_comp_coeff": {
+                    "eqn_type": 1,
                     "1": (5.252, pyunits.kmol * pyunits.m**-3),
                     "2": (0.347, pyunits.dimensionless),
                     "3": (1595.8, pyunits.K),
@@ -706,10 +718,10 @@ class TestSeawaterAlkalinity:
             has_pressure_change=False,
         )
 
-        model.fs.unit.inlet.mole_frac_comp[0, "H_+"].fix(0.0)
-        model.fs.unit.inlet.mole_frac_comp[0, "OH_-"].fix(0.0)
-        model.fs.unit.inlet.mole_frac_comp[0, "HCO3_-"].fix(0.0)
-        model.fs.unit.inlet.mole_frac_comp[0, "CO3_2-"].fix(0.0)
+        model.fs.unit.inlet.mole_frac_comp[0, "H_+"].fix(EPS)
+        model.fs.unit.inlet.mole_frac_comp[0, "OH_-"].fix(EPS)
+        model.fs.unit.inlet.mole_frac_comp[0, "HCO3_-"].fix(EPS)
+        model.fs.unit.inlet.mole_frac_comp[0, "CO3_2-"].fix(EPS)
 
         total_nacl_inlet = 0.55  # mol/L
         total_carbonate_inlet = 0.00206  # mol/L
@@ -758,10 +770,10 @@ class TestSeawaterAlkalinity:
             has_pressure_change=False,
         )
 
-        model.fs.unit.inlet.mole_frac_comp[0, "H_+"].fix(0.0)
-        model.fs.unit.inlet.mole_frac_comp[0, "OH_-"].fix(0.0)
-        model.fs.unit.inlet.mole_frac_comp[0, "HCO3_-"].fix(0.0)
-        model.fs.unit.inlet.mole_frac_comp[0, "CO3_2-"].fix(0.0)
+        model.fs.unit.inlet.mole_frac_comp[0, "H_+"].fix(EPS)
+        model.fs.unit.inlet.mole_frac_comp[0, "OH_-"].fix(EPS)
+        model.fs.unit.inlet.mole_frac_comp[0, "HCO3_-"].fix(EPS)
+        model.fs.unit.inlet.mole_frac_comp[0, "CO3_2-"].fix(EPS)
 
         total_nacl_inlet = 0.55  # mol/L
         total_carbonate_inlet = 0.00206  # mol/L


### PR DESCRIPTION
## Partial Resolves #586 

## Summary/Motivation:
This Pr fixes an issue where a deprecation warning was being emitted due to a missing argument when using the Perry's module for modular properties.

## Changes proposed in this PR:
- Add missing argument in config dictionaries
- Also changed some mole fractions that were being set to 0 to `EPS=1e-20` to resolve a deprecation warning from Pyomo

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
