### PR TITLE
Remove idaes solver directives

### DIFF
--- a/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/chemistry/tests/test_posttreatment.py
+++ b/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/chemistry/tests/test_posttreatment.py
@@ -69,7 +69,6 @@ def test_ideal_naocl_chlorination():
 
 
 @pytest.mark.component
-@pytest.mark.requires_idaes_solver
 def test_ideal_naocl_chlorination_full_block():
     model = run_chlorination_block_example(fix_free_chlorine=True)
     assert model.fs.ideal_naocl_mixer_unit.dosing_rate.value == pytest.approx(

--- a/watertap/unit_models/tests/test_electrodialysis_1D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_1D.py
@@ -640,7 +640,6 @@ class TestElectrodialysis_withNeutralSPecies:
         m.fs.unit.inlet_concentrate.flow_mol_phase_comp[0, "Liq", "N"].fix(7.38e-5)
         assert degrees_of_freedom(m) == 0
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_initialization_scaling(self, electrodialysis_1d_cell3):
         m = electrodialysis_1d_cell3
@@ -670,7 +669,6 @@ class TestElectrodialysis_withNeutralSPecies:
         # check to make sure DOF does not change
         assert degrees_of_freedom(m) == 0
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, electrodialysis_1d_cell3):
         m = electrodialysis_1d_cell3
@@ -682,7 +680,6 @@ class TestElectrodialysis_withNeutralSPecies:
         }
         assert not badly_scaled_var_values
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solution(self, electrodialysis_1d_cell3):
         m = electrodialysis_1d_cell3
@@ -712,7 +709,6 @@ class TestElectrodialysis_withNeutralSPecies:
             m.fs.unit.outlet_concentrate.flow_mol_phase_comp[0, "Liq", "N"]
         ) == pytest.approx(7.496e-05, rel=5e-3)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_performance_contents(self, electrodialysis_1d_cell3):
         m = electrodialysis_1d_cell3

--- a/watertap/unit_models/tests/test_gac.py
+++ b/watertap/unit_models/tests/test_gac.py
@@ -185,7 +185,6 @@ class TestGACSimplified:
         )
         assert badly_scaled_var_lst == []
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve_simplified(self, gac_frame_simplified):
         ms = gac_frame_simplified
@@ -351,7 +350,6 @@ class TestGACRobust:
         )
         assert badly_scaled_var_lst == []
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve_robust(self, gac_frame_robust):
         mr = gac_frame_robust
@@ -382,7 +380,6 @@ class TestGACRobust:
         mr = gac_frame_robust
         mr.fs.unit.report()
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing_robust(self, gac_frame_robust):
         mr = gac_frame_robust
@@ -427,7 +424,6 @@ class TestGACRobust:
             mr.fs.unit.costing.fixed_operating_cost
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing_modular_contactors_robust(self, gac_frame_robust):
         mr = gac_frame_robust
@@ -458,7 +454,6 @@ class TestGACRobust:
             mr.fs.unit.costing.capital_cost
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing_max_gac_ref_robust(self, gac_frame_robust):
         mr = gac_frame_robust
@@ -605,11 +600,10 @@ class TestGACMulti:
     def test_var_scaling_init_multi(self, gac_frame_multi):
         mm = gac_frame_multi
         badly_scaled_var_lst = list(
-            badly_scaled_var_generator(mm, large=1e2, small=1e-2, zero=1e-8)
+            badly_scaled_var_generator(mm, large=1e2, small=1e-3, zero=1e-8)
         )
         assert badly_scaled_var_lst == []
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve_multi(self, gac_frame_multi):
         mm = gac_frame_multi

--- a/watertap/unit_models/tests/test_ion_exchange_0D.py
+++ b/watertap/unit_models/tests/test_ion_exchange_0D.py
@@ -361,13 +361,11 @@ class TestIonExchangeNoInert:
         unscaled_var_list = list(unscaled_variables_generator(m.fs.unit))
         assert len(unscaled_var_list) == 0
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_initialize(self, IX_frame_no_inert):
         m = IX_frame_no_inert
         initialization_tester(m)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, IX_frame_no_inert):
         m = IX_frame_no_inert
@@ -376,7 +374,6 @@ class TestIonExchangeNoInert:
         # Check for optimal solution
         assert_optimal_termination(results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_conservation(self, IX_frame_no_inert):
         m = IX_frame_no_inert
@@ -393,7 +390,6 @@ class TestIonExchangeNoInert:
             <= 1e-6
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solution(self, IX_frame_no_inert):
         m = IX_frame_no_inert
@@ -707,13 +703,11 @@ class TestIonExchangeWithInert:
         unscaled_var_list = list(unscaled_variables_generator(m.fs.unit))
         assert len(unscaled_var_list) == 0
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_initialize(self, IX_frame_with_inert):
         m = IX_frame_with_inert
         initialization_tester(m)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, IX_frame_with_inert):
         m = IX_frame_with_inert
@@ -722,7 +716,6 @@ class TestIonExchangeWithInert:
         # Check for optimal solution
         assert_optimal_termination(results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_conservation(self, IX_frame_with_inert):
         m = IX_frame_with_inert
@@ -750,7 +743,6 @@ class TestIonExchangeWithInert:
                 <= 1e-6
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solution(self, IX_frame_with_inert):
         m = IX_frame_with_inert

--- a/watertap/unit_models/tests/test_ion_exchange_0D.py
+++ b/watertap/unit_models/tests/test_ion_exchange_0D.py
@@ -366,6 +366,7 @@ class TestIonExchangeNoInert:
         m = IX_frame_no_inert
         initialization_tester(m)
 
+    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, IX_frame_no_inert):
         m = IX_frame_no_inert
@@ -374,6 +375,7 @@ class TestIonExchangeNoInert:
         # Check for optimal solution
         assert_optimal_termination(results)
 
+    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_conservation(self, IX_frame_no_inert):
         m = IX_frame_no_inert
@@ -390,6 +392,7 @@ class TestIonExchangeNoInert:
             <= 1e-6
         )
 
+    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solution(self, IX_frame_no_inert):
         m = IX_frame_no_inert

--- a/watertap/unit_models/tests/test_uv_aop.py
+++ b/watertap/unit_models/tests/test_uv_aop.py
@@ -239,7 +239,6 @@ class TestUV:
             pyunits.convert(m.fs.unit.electricity_demand[0], to_units=pyunits.kW)
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing(self, UV_frame):
         m = UV_frame
@@ -457,7 +456,6 @@ class TestUV_standard:
             pyunits.convert(m.fs.unit.electricity_demand[0], to_units=pyunits.kW)
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing(self, UV_frame):
         m = UV_frame
@@ -699,7 +697,6 @@ class TestUV_with_multiple_comps:
             pyunits.convert(m.fs.unit.electricity_demand[0], to_units=pyunits.kW)
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing(self, UV_frame):
         m = UV_frame
@@ -928,7 +925,6 @@ class TestUV_detailed:
             pyunits.convert(m.fs.unit.electricity_demand[0], to_units=pyunits.kW)
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing(self, UV_frame):
         m = UV_frame
@@ -1152,7 +1148,6 @@ class TestUVAOP:
             pyunits.convert(m.fs.unit.electricity_demand[0], to_units=pyunits.kW)
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing(self, UV_frame):
         m = UV_frame

--- a/watertap/unit_models/zero_order/tests/test_autothermal_hydrothermal_liquefaction_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_autothermal_hydrothermal_liquefaction_zo.py
@@ -181,7 +181,6 @@ class TestATHTLZO:
                 )
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
 

--- a/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
@@ -179,7 +179,6 @@ class TestElectroNPZO:
                 )
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
 

--- a/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
+++ b/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
@@ -249,7 +249,6 @@ class TestGasSpargedMembraneZO:
                     <= 1e-6
                 )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
 

--- a/watertap/unit_models/zero_order/tests/test_hydrothermal_gasification_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_hydrothermal_gasification_zo.py
@@ -176,7 +176,6 @@ class TestHTGZO:
                 )
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
 

--- a/watertap/unit_models/zero_order/tests/test_mabr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mabr_zo.py
@@ -165,7 +165,6 @@ class TestMABRZO:
                 )
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
         model.fs.unit.report()

--- a/watertap/unit_models/zero_order/tests/test_metab_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_metab_zo.py
@@ -87,7 +87,6 @@ class TestMetabZO_hydrogen:
     def test_initialize(self, model):
         initialization_tester(model)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
@@ -95,7 +94,6 @@ class TestMetabZO_hydrogen:
         # Check for optimal solution
         assert_optimal_termination(results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
@@ -109,7 +107,6 @@ class TestMetabZO_hydrogen:
             model.fs.unit.properties_treated[0].flow_mass_comp["cod"]
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, model):
@@ -126,7 +123,6 @@ class TestMetabZO_hydrogen:
                 )
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_report(self, model):
@@ -182,7 +178,6 @@ class TestMetabZO_methane:
     def test_initialize(self, model):
         initialization_tester(model)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
@@ -190,7 +185,6 @@ class TestMetabZO_methane:
         # Check for optimal solution
         assert_optimal_termination(results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
@@ -204,7 +198,6 @@ class TestMetabZO_methane:
             model.fs.unit.properties_treated[0].flow_mass_comp["cod"]
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, model):
@@ -221,7 +214,6 @@ class TestMetabZO_methane:
                 )
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_report(self, model):
@@ -300,7 +292,6 @@ class TestMetabZO_hydrogen_cost:
     def test_initialize(self, model):
         initialization_tester(model)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
@@ -308,7 +299,6 @@ class TestMetabZO_hydrogen_cost:
         # Check for optimal solution
         assert_optimal_termination(results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_cost_solution(self, model):
@@ -406,7 +396,6 @@ class TestMetabZO_methane_cost:
     def test_initialize(self, model):
         initialization_tester(model)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
@@ -414,7 +403,6 @@ class TestMetabZO_methane_cost:
         # Check for optimal solution
         assert_optimal_termination(results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_cost_solution(self, model):

--- a/watertap/unit_models/zero_order/tests/test_supercritical_salt_precipitation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_supercritical_salt_precipitation_zo.py
@@ -167,7 +167,6 @@ class TestSaltPrecipitationZO:
                 )
             )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_report(self, model):
 


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
We're skipping several test which pass without an IDAES solver.

## Changes proposed in this PR:
- Remove `requires_idaes_solver` where not needed

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
