### PR TITLE
Initialization mixin

### DIFF
--- a/watertap/core/__init__.py
+++ b/watertap/core/__init__.py
@@ -11,6 +11,7 @@
 #
 ###############################################################################
 
+from .initialization_mixin import InitializationMixin
 from .membrane_channel_base import (
     ConcentrationPolarizationType,
     MassTransferCoefficient,

--- a/watertap/core/initialization_mixin.py
+++ b/watertap/core/initialization_mixin.py
@@ -1,0 +1,27 @@
+###############################################################################
+# WaterTAP Copyright (c) 2021, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National
+# Laboratory, National Renewable Energy Laboratory, and National Energy
+# Technology Laboratory (subject to receipt of any required approvals from
+# the U.S. Dept. of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#
+###############################################################################
+
+from idaes.core.util.exceptions import InitializationError
+
+
+class InitializationMixin:
+    """
+    Class for catching `InitializationError` in UnitModel.initialize
+    """
+
+    def initialize(self, *args, **kwargs):
+        try:
+            return super().initialize(*args, **kwargs)
+        except InitializationError:
+            for blk in self._initialization_order:
+                blk.activate()

--- a/watertap/unit_models/boron_removal.py
+++ b/watertap/unit_models/boron_removal.py
@@ -42,13 +42,15 @@ from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 __author__ = "Austin Ladshaw"
 
 _log = idaeslog.getLogger(__name__)
 
 # Name of the unit model
 @declare_process_block_class("BoronRemoval")
-class BoronRemovalData(UnitModelBlockData):
+class BoronRemovalData(InitializationMixin, UnitModelBlockData):
     """
     0D Boron Removal model for after 1st Stage of RO
 

--- a/watertap/unit_models/coag_floc_model.py
+++ b/watertap/unit_models/coag_floc_model.py
@@ -41,13 +41,15 @@ from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 __author__ = "Austin Ladshaw"
 
 _log = idaeslog.getLogger(__name__)
 
 # Name of the unit model
 @declare_process_block_class("CoagulationFlocculation")
-class CoagulationFlocculationData(UnitModelBlockData):
+class CoagulationFlocculationData(InitializationMixin, UnitModelBlockData):
     """
     Zero order Coagulation-Flocculation model based on Jar Tests
     """

--- a/watertap/unit_models/crystallizer.py
+++ b/watertap/unit_models/crystallizer.py
@@ -40,6 +40,7 @@ from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
 
 _log = idaeslog.getLogger(__name__)
 
@@ -47,7 +48,7 @@ __author__ = "Oluwamayowa Amusat"
 
 # when using this file the name "Filtration" is what is imported
 @declare_process_block_class("Crystallization")
-class CrystallizationData(UnitModelBlockData):
+class CrystallizationData(InitializationMixin, UnitModelBlockData):
     """
     Zero order crystallization model
     """

--- a/watertap/unit_models/cstr_injection.py
+++ b/watertap/unit_models/cstr_injection.py
@@ -38,11 +38,13 @@ from idaes.core.util.config import (
 )
 import idaes.core.util.unit_costing as costing
 
+from watertap.core import InitializationMixin
+
 __author__ = "Andrew Lee, Vibhav Dabadghao"
 
 
 @declare_process_block_class("CSTR_Injection")
-class CSTR_InjectionData(UnitModelBlockData):
+class CSTR_InjectionData(InitializationMixin, UnitModelBlockData):
     """
     CSTR Unit Model with Injection Class
     """

--- a/watertap/unit_models/electrodialysis_0D.py
+++ b/watertap/unit_models/electrodialysis_0D.py
@@ -47,6 +47,8 @@ import idaes.logger as idaeslog
 from idaes.core.util.constants import Constants
 from enum import Enum
 
+from watertap.core import InitializationMixin
+
 __author__ = " Xiangyu Bi, Austin Ladshaw,"
 
 _log = idaeslog.getLogger(__name__)
@@ -65,7 +67,7 @@ class ElectricalOperationMode(Enum):
 
 # Name of the unit model
 @declare_process_block_class("Electrodialysis0D")
-class Electrodialysis0DData(UnitModelBlockData):
+class Electrodialysis0DData(InitializationMixin, UnitModelBlockData):
     """
     0D Electrodialysis Model
     """

--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -49,6 +49,8 @@ import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 from enum import Enum
 
+from watertap.core import InitializationMixin
+
 __author__ = "Xiangyu Bi, Austin Ladshaw"
 
 _log = idaeslog.getLogger(__name__)
@@ -67,7 +69,7 @@ class ElectricalOperationMode(Enum):
 
 # Name of the unit model
 @declare_process_block_class("Electrodialysis1D")
-class Electrodialysis1DData(UnitModelBlockData):
+class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
     """
     1D Electrodialysis Model
     """

--- a/watertap/unit_models/gac.py
+++ b/watertap/unit_models/gac.py
@@ -38,6 +38,8 @@ from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 __author__ = "Hunter Barber"
 
 _log = idaeslog.getLogger(__name__)
@@ -58,7 +60,7 @@ class SurfaceDiffusionCoefficientType(Enum):
 
 # ---------------------------------------------------------------------
 @declare_process_block_class("GAC")
-class GACData(UnitModelBlockData):
+class GACData(InitializationMixin, UnitModelBlockData):
     """
     Initial Granular Activated Carbon Model -
     currently should be used for only with ion_DSPMDE_prop_pack with

--- a/watertap/unit_models/ion_exchange_0D.py
+++ b/watertap/unit_models/ion_exchange_0D.py
@@ -41,6 +41,8 @@ from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 __author__ = "Kurban Sitterley"
 
 _log = idaeslog.getLogger(__name__)
@@ -61,7 +63,7 @@ class RegenerantChem(StrEnum):
 
 
 @declare_process_block_class("IonExchange0D")
-class IonExchangeODData(UnitModelBlockData):
+class IonExchangeODData(InitializationMixin, UnitModelBlockData):
     """
     Zero order ion exchange model
     """

--- a/watertap/unit_models/mvc/components/complete_condenser.py
+++ b/watertap/unit_models/mvc/components/complete_condenser.py
@@ -12,7 +12,7 @@
 ###############################################################################
 
 # Import Pyomo libraries
-from pyomo.environ import Suffix
+from pyomo.environ import Suffix, check_optimal_termination
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
 # Import IDAES cores
@@ -27,15 +27,18 @@ from idaes.core import (
 )
 from idaes.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.exceptions import InitializationError
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
+
+from watertap.core import InitializationMixin
 
 _log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("Condenser")
-class CompressorData(UnitModelBlockData):
+class CompressorData(InitializationMixin, UnitModelBlockData):
     """
     Condenser model for MVC
     """
@@ -267,13 +270,18 @@ class CompressorData(UnitModelBlockData):
 
         # ---------------------------------------------------------------------
         if hold_state:
-            return flags
+            pass
         else:
             # Release Inlet state
             blk.control_volume.release_state(flags, outlvl=outlvl)
             init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
         if has_guessed_heat:
             blk.control_volume.heat.unfix()
+
+        if not check_optimal_termination(res):
+            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+
+        return flags
 
     def _get_performance_contents(self, time_point=0):
         var_dict = {"Heat duty": self.control_volume.heat[time_point]}

--- a/watertap/unit_models/mvc/components/compressor.py
+++ b/watertap/unit_models/mvc/components/compressor.py
@@ -15,6 +15,7 @@
 from pyomo.environ import (
     Var,
     Suffix,
+    check_optimal_termination,
     units as pyunits,
 )
 from pyomo.common.config import ConfigBlock, ConfigValue, In
@@ -31,15 +32,18 @@ from idaes.core import (
 )
 from idaes.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.exceptions import InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
+
+from watertap.core import InitializationMixin
 
 
 _log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("Compressor")
-class CompressorData(UnitModelBlockData):
+class CompressorData(InitializationMixin, UnitModelBlockData):
     """
     Compressor model for MVC
     """
@@ -196,7 +200,7 @@ class CompressorData(UnitModelBlockData):
         self.properties_isentropic_out = self.config.property_package.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of isentropic outlet",
-            **tmp_dict
+            **tmp_dict,
         )
 
         # Add ports - oftentimes users interact with these rather than the state blocks
@@ -314,6 +318,9 @@ class CompressorData(UnitModelBlockData):
         # Release Inlet state
         blk.control_volume.release_state(flags, outlvl=outlvl)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
+
+        if not check_optimal_termination(res):
+            raise InitializationError(f"Unit model {blk.name} failed to initialize")
 
     def _get_performance_contents(self, time_point=0):
         var_dict = {}

--- a/watertap/unit_models/mvc/components/evaporator.py
+++ b/watertap/unit_models/mvc/components/evaporator.py
@@ -12,7 +12,14 @@
 ###############################################################################
 
 # Import Pyomo libraries
-from pyomo.environ import Block, Var, Suffix, units as pyunits, ExternalFunction
+from pyomo.environ import (
+    Block,
+    Var,
+    Suffix,
+    units as pyunits,
+    ExternalFunction,
+    check_optimal_termination,
+)
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
 # Import IDAES cores
@@ -25,17 +32,19 @@ from idaes.core import (
 )
 from idaes.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
-from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.exceptions import ConfigurationError, InitializationError
 from idaes.core.util.functions import functions_lib
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
+
+from watertap.core import InitializationMixin
 
 
 _log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("Evaporator")
-class EvaporatorData(UnitModelBlockData):
+class EvaporatorData(InitializationMixin, UnitModelBlockData):
     """
     Evaporator model for MVC
     """
@@ -218,7 +227,7 @@ class EvaporatorData(UnitModelBlockData):
         self.properties_feed = self.config.property_package_feed.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of feed inlet",
-            **tmp_dict
+            **tmp_dict,
         )
 
         # Brine state block
@@ -226,7 +235,7 @@ class EvaporatorData(UnitModelBlockData):
         self.properties_brine = self.config.property_package_feed.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of brine outlet",
-            **tmp_dict
+            **tmp_dict,
         )
 
         # Vapor state block
@@ -237,7 +246,7 @@ class EvaporatorData(UnitModelBlockData):
         self.properties_vapor = self.config.property_package_vapor.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of vapor outlet",
-            **tmp_dict
+            **tmp_dict,
         )
 
         # Add block for condenser constraints
@@ -464,6 +473,9 @@ class EvaporatorData(UnitModelBlockData):
             blk.connection_to_condenser.activate()
 
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
+
+        if not check_optimal_termination(res):
+            raise InitializationError(f"Unit model {blk.name} failed to initialize")
 
     def _get_performance_contents(self, time_point=0):
         var_dict = {

--- a/watertap/unit_models/nanofiltration_0D.py
+++ b/watertap/unit_models/nanofiltration_0D.py
@@ -40,12 +40,14 @@ from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 
 _log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("NanoFiltration0D")
-class NanoFiltrationData(UnitModelBlockData):
+class NanoFiltrationData(InitializationMixin, UnitModelBlockData):
     """
     Standard NF Unit Model Class:
     - zero dimensional model

--- a/watertap/unit_models/nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/nanofiltration_DSPMDE_0D.py
@@ -53,6 +53,8 @@ from watertap.core.util.initialization import check_dof
 
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 
 _log = idaeslog.getLogger(__name__)
 
@@ -77,7 +79,7 @@ class ConcentrationPolarizationType(Enum):
 
 
 @declare_process_block_class("NanofiltrationDSPMDE0D")
-class NanofiltrationData(UnitModelBlockData):
+class NanofiltrationData(InitializationMixin, UnitModelBlockData):
     """
     Nanofiltration model based on Donnan Steric Pore Model with Dielectric Exclusion (DSPM-DE).
 

--- a/watertap/unit_models/nanofiltration_ZO.py
+++ b/watertap/unit_models/nanofiltration_ZO.py
@@ -41,12 +41,14 @@ from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 
 _log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("NanofiltrationZO")
-class NanofiltrationData(UnitModelBlockData):
+class NanofiltrationData(InitializationMixin, UnitModelBlockData):
     """
     Zero order nanofiltration model based on specified water flux and ion rejection.
     Default data from Table 9 in Labban et al. (2017) https://doi.org/10.1016/j.memsci.2016.08.062

--- a/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
+++ b/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
@@ -35,6 +35,8 @@ from watertap.core.membrane_channel_base import (
     ConcentrationPolarizationType,
 )
 
+from watertap.core import InitializationMixin
+
 
 def _add_has_full_reporting(config_obj):
     config_obj.declare(
@@ -53,7 +55,9 @@ def _add_has_full_reporting(config_obj):
     )
 
 
-class OsmoticallyAssistedReverseOsmosisBaseData(UnitModelBlockData):
+class OsmoticallyAssistedReverseOsmosisBaseData(
+    InitializationMixin, UnitModelBlockData
+):
     """
     Osmotically Assisted Reverse Osmosis base class
 

--- a/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
+++ b/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
@@ -475,7 +475,6 @@ class OsmoticallyAssistedReverseOsmosisBaseData(UnitModelBlockData):
         outlvl=idaeslog.NOTSET,
         solver=None,
         optarg=None,
-        raise_on_failure=True,
     ):
         """
         General wrapper for RO initialization routines
@@ -543,7 +542,7 @@ class OsmoticallyAssistedReverseOsmosisBaseData(UnitModelBlockData):
 
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
-        if not check_optimal_termination(res) and raise_on_failure:
+        if not check_optimal_termination(res):
             raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def _get_stream_table_contents(self, time_point=0):

--- a/watertap/unit_models/pressure_changer.py
+++ b/watertap/unit_models/pressure_changer.py
@@ -23,6 +23,8 @@ import idaes.core.util.scaling as iscale
 
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
+
 _log = idaeslog.getLogger(__name__)
 
 
@@ -33,7 +35,7 @@ class VariableEfficiency(Enum):
 
 
 @declare_process_block_class("Pump")
-class PumpIsothermalData(PumpData):
+class PumpIsothermalData(InitializationMixin, PumpData):
     """
     Standard Isothermal Pump Unit Model Class
     """

--- a/watertap/unit_models/pressure_exchanger.py
+++ b/watertap/unit_models/pressure_exchanger.py
@@ -40,11 +40,13 @@ from idaes.core.util.initialization import revert_state_vars
 from idaes.core.util.tables import create_stream_table_dataframe
 import idaes.core.util.scaling as iscale
 
+from watertap.core import InitializationMixin
+
 _log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("PressureExchanger")
-class PressureExchangerData(UnitModelBlockData):
+class PressureExchangerData(InitializationMixin, UnitModelBlockData):
     """
     Standard Pressure Exchanger Unit Model Class:
     - steady state only

--- a/watertap/unit_models/reverse_osmosis_base.py
+++ b/watertap/unit_models/reverse_osmosis_base.py
@@ -32,6 +32,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.tables import create_stream_table_dataframe
 import idaes.logger as idaeslog
 
+from watertap.core import InitializationMixin
 from watertap.core.membrane_channel_base import (
     validate_membrane_config_args,
     CONFIG_Template,
@@ -56,7 +57,7 @@ def _add_has_full_reporting(config_obj):
     )
 
 
-class ReverseOsmosisBaseData(UnitModelBlockData):
+class ReverseOsmosisBaseData(InitializationMixin, UnitModelBlockData):
     """
     Reverse Osmosis base class
     """

--- a/watertap/unit_models/reverse_osmosis_base.py
+++ b/watertap/unit_models/reverse_osmosis_base.py
@@ -487,7 +487,6 @@ class ReverseOsmosisBaseData(UnitModelBlockData):
         outlvl=idaeslog.NOTSET,
         solver=None,
         optarg=None,
-        raise_on_failure=True,
     ):
         """
         General wrapper for RO initialization routines
@@ -569,7 +568,7 @@ class ReverseOsmosisBaseData(UnitModelBlockData):
         self.feed_side.release_state(source_flags, outlvl)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
-        if not check_optimal_termination(res) and raise_on_failure:
+        if not check_optimal_termination(res):
             raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def _get_stream_table_contents(self, time_point=0):

--- a/watertap/unit_models/uv_aop.py
+++ b/watertap/unit_models/uv_aop.py
@@ -46,6 +46,8 @@ import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 from idaes.core.util.misc import add_object_reference
 
+from watertap.core import InitializationMixin
+
 _log = idaeslog.getLogger(__name__)
 
 # ---------------------------------------------------------------------
@@ -55,7 +57,7 @@ class UVDoseType(Enum):
 
 
 @declare_process_block_class("Ultraviolet0D")
-class Ultraviolet0DData(UnitModelBlockData):
+class Ultraviolet0DData(InitializationMixin, UnitModelBlockData):
     """
     Standard UV Unit Model Class:
     - zero dimensional model

--- a/watertap/unit_models/zero_order/feed_zo.py
+++ b/watertap/unit_models/zero_order/feed_zo.py
@@ -29,6 +29,8 @@ import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
 from idaes.core.util.exceptions import InitializationError
 
+from watertap.core import InitializationMixin
+
 # Some more inforation about this module
 __author__ = "Andrew Lee"
 
@@ -37,7 +39,7 @@ _log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("FeedZO")
-class FeedZOData(FeedData):
+class FeedZOData(InitializationMixin, FeedData):
     """
     Zero-Order feed block.
     """


### PR DESCRIPTION
## Fixes/Resolves: #838

## Summary/Motivation:
Better to `try/except` if we expect an initialization failure for a unit. This PR enables this on every unit where we currently catch initialization failures (and adds some additional units which catch initialization failures).

## Changes proposed in this PR:
- Add mixin for overwriting `initialize` method.
- Applying mixin to appropriate unit model classes.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
