### PR TITLE
Isothermal 0DRO

### DIFF
--- a/watertap/core/membrane_channel1d.py
+++ b/watertap/core/membrane_channel1d.py
@@ -161,29 +161,6 @@ class MembraneChannel1DBlockData(MembraneChannelMixin, ControlVolume1DBlockData)
         super().add_state_blocks(has_phase_equilibrium=has_phase_equilibrium)
         self._add_interface_stateblock(has_phase_equilibrium)
 
-    def add_total_enthalpy_balances(self, **kwrags):
-        # make this a no-op for MC1D
-        return None
-
-    def add_isothermal_conditions(self, **kwargs):
-
-        super().add_isothermal_conditions(**kwargs)
-
-        ## ==========================================================================
-        # Feed-side isothermal conditions
-        @self.Constraint(
-            self.flowsheet().config.time,
-            self.length_domain,
-            doc="Isothermal assumption for feed channel",
-        )
-        def eq_feed_isothermal(b, t, x):
-            if self._skip_element(x):
-                return Constraint.Skip
-            return (
-                b.properties[t, b.length_domain.first()].temperature
-                == b.properties[t, x].temperature
-            )
-
     def _add_pressure_change(self, pressure_change_type=PressureChangeType.calculated):
         add_object_reference(self, "dP_dx", self.deltaP)
 

--- a/watertap/core/membrane_channel_base.py
+++ b/watertap/core/membrane_channel_base.py
@@ -322,7 +322,7 @@ class MembraneChannelMixin:
         if pressure_change_type == PressureChangeType.calculated:
             self._add_calculated_pressure_change()
 
-    def add_isothermal_conditions(self):
+    def add_interface_isothermal_conditions(self):
 
         # ==========================================================================
         # Bulk and interface connections on the feed-side
@@ -338,6 +338,23 @@ class MembraneChannelMixin:
             return (
                 b.properties[t, x].temperature
                 == b.properties_interface[t, x].temperature
+            )
+
+    def add_control_volume_isothermal_conditions(self):
+
+        ## ==========================================================================
+        # Feed-side isothermal conditions
+        @self.Constraint(
+            self.flowsheet().config.time,
+            self.length_domain,
+            doc="Isothermal assumption for feed channel",
+        )
+        def eq_feed_isothermal(b, t, x):
+            if x == b.length_domain.first():
+                return Constraint.Skip
+            return (
+                b.properties[t, b.length_domain.first()].temperature
+                == b.properties[t, x].temperature
             )
 
     def add_extensive_flow_to_interface(self):

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/default_configuration.yaml
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/default_configuration.yaml
@@ -102,7 +102,6 @@ fs.RO.feed_side.dP_dx[0.0,0.0]: -12678.679050434575
 fs.RO.feed_side.dP_dx[0.0,1.0]: -5318.296444828698
 fs.RO.feed_side.dh: 0.001691998543711759
 fs.RO.feed_side.deltaP[0.0]: -144220.12194869615
-fs.RO.feed_side.enthalpy_transfer[0.0]: -51702.861568992426
 fs.RO.feed_side.mass_transfer_term[0.0,Liq,H2O]: -0.49285444999999994
 fs.RO.feed_side.mass_transfer_term[0.0,Liq,NaCl]: -0.00016337190673426118
 fs.RO.feed_side.properties_in[0.0].conc_mass_phase_comp[Liq,H2O]: 985.7089

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
@@ -98,7 +98,7 @@ def test_seawater_RO_desalination_pressure_exchanger():
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
 
-    assert value(m.LCOW) == pytest.approx(0.8411, rel=1e-5)
+    assert value(m.LCOW) == pytest.approx(0.841078, rel=1e-5)
 
 
 @pytest.mark.component
@@ -180,4 +180,4 @@ def test_seawater_RO_desalination_pump_as_turbine():
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
 
-    assert value(m.LCOW) == pytest.approx(1.11162, rel=1e-5)
+    assert value(m.LCOW) == pytest.approx(1.111589, rel=1e-5)

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
@@ -109,7 +109,7 @@ class TestDyewithROFlowsheet:
             m.fs.dye_retentate.flow_mass_comp[0, "H2O"]
         )
 
-        assert pytest.approx(11.9714, rel=1e-5) == value(
+        assert pytest.approx(11.9716, rel=1e-5) == value(
             m.fs.permeate.flow_mass_phase_comp[0, "Liq", "H2O"]
         )
 
@@ -128,8 +128,8 @@ class TestDyewithROFlowsheet:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(0.653477, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(0.2701535, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(0.690498, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(0.284743, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
@@ -128,8 +128,8 @@ class TestDyewithROFlowsheet:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(0.690498, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(0.284743, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(0.653284, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(0.270094, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):

--- a/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/examples/test_full_example.py
+++ b/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/examples/test_full_example.py
@@ -43,7 +43,7 @@ def test_flowsheet_mvp_NF_bypass_twostage_1():
         m.fs.RO2.retentate.flow_mass_phase_comp[0, "Liq", "TDS"]
     ) == pytest.approx(2.605e-2, rel=1e-3)
     assert value(m.fs.desal_saturation.saturation_index) == pytest.approx(
-        0.4073, rel=1e-3
+        0.4082, rel=1e-3
     )
 
 

--- a/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
+++ b/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
@@ -114,7 +114,7 @@ class OsmoticallyAssistedReverseOsmosisBaseData(
         )
 
         # Add constraint for equal temperature between bulk and interface
-        self.feed_side.add_isothermal_conditions()
+        self.feed_side.add_interface_isothermal_conditions()
 
         # Add constraint for volumetric flow equality between interface and bulk
         self.feed_side.add_extensive_flow_to_interface()
@@ -155,7 +155,7 @@ class OsmoticallyAssistedReverseOsmosisBaseData(
         )
 
         # Add constraint for equal temperature between bulk and interface
-        self.permeate_side.add_isothermal_conditions()
+        self.permeate_side.add_interface_isothermal_conditions()
 
         # Add constraint for volumetric flow equality between interface and bulk
         self.permeate_side.add_extensive_flow_to_interface()

--- a/watertap/unit_models/reverse_osmosis_0D.py
+++ b/watertap/unit_models/reverse_osmosis_0D.py
@@ -86,23 +86,12 @@ class ReverseOsmosisData(ReverseOsmosisBaseData):
                 == b.mixed_permeate[t].flow_vol_phase["Liq"]
             )
 
-        # not in 1DRO
         @self.Expression(self.flowsheet().config.time, doc="Over pressure ratio")
         def over_pressure_ratio(b, t):
             return (
                 b.feed_side.properties_out[t].pressure_osm_phase["Liq"]
                 - b.permeate_side[t, 1.0].pressure_osm_phase["Liq"]
             ) / b.feed_side.properties_out[t].pressure
-
-        # not in 1DRO
-        @self.Constraint(
-            self.flowsheet().config.time, doc="Enthalpy transfer from feed to permeate"
-        )
-        def eq_connect_enthalpy_transfer(b, t):
-            return (
-                b.mixed_permeate[t].get_enthalpy_flow_terms("Liq")
-                == -b.feed_side.enthalpy_transfer[t]
-            )
 
         # mass transfer
         def mass_transfer_phase_comp_initialize(b, t, p, j):

--- a/watertap/unit_models/reverse_osmosis_base.py
+++ b/watertap/unit_models/reverse_osmosis_base.py
@@ -96,17 +96,14 @@ class ReverseOsmosisBaseData(InitializationMixin, UnitModelBlockData):
             balance_type=self.config.material_balance_type, has_mass_transfer=True
         )
 
-        self.feed_side.add_energy_balances(
-            balance_type=self.config.energy_balance_type, has_enthalpy_transfer=True
-        )
-
         self.feed_side.add_momentum_balances(
             balance_type=self.config.momentum_balance_type,
             pressure_change_type=self.config.pressure_change_type,
             has_pressure_change=self.config.has_pressure_change,
         )
 
-        self.feed_side.add_isothermal_conditions()
+        self.feed_side.add_control_volume_isothermal_conditions()
+        self.feed_side.add_interface_isothermal_conditions()
 
         self.feed_side.add_extensive_flow_to_interface()
 

--- a/watertap/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_0D.py
@@ -49,6 +49,7 @@ from idaes.core.util.scaling import (
 )
 
 from watertap.core import MembraneChannel0DBlock
+import idaes.logger as idaeslog
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -252,9 +253,9 @@ class TestReverseOsmosis:
         assert isinstance(m.fs.unit.feed_side, MembraneChannel0DBlock)
 
         # test statistics
-        assert number_variables(m) == 125
-        assert number_total_constraints(m) == 96
-        assert number_unused_variables(m) == 7  # vars from property package parameters
+        assert number_variables(m) == 121
+        assert number_total_constraints(m) == 92
+        assert number_unused_variables(m) == 13  # vars from property package parameters
 
     @pytest.mark.unit
     def test_dof(self, RO_frame):
@@ -282,7 +283,7 @@ class TestReverseOsmosis:
 
     @pytest.mark.component
     def test_initialize(self, RO_frame):
-        initialization_tester(RO_frame)
+        initialization_tester(RO_frame, outlvl=idaeslog.DEBUG)
 
     @pytest.mark.component
     def test_var_scaling(self, RO_frame):
@@ -418,9 +419,9 @@ class TestReverseOsmosis:
         m.fs.unit.feed_side.K[0, 1.0, "NaCl"].fix(kf)
 
         # test statistics
-        assert number_variables(m) == 127
-        assert number_total_constraints(m) == 98
-        assert number_unused_variables(m) == 7  # vars from property package parameters
+        assert number_variables(m) == 123
+        assert number_total_constraints(m) == 94
+        assert number_unused_variables(m) == 13  # vars from property package parameters
 
         # Test units
         assert_units_consistent(m.fs.unit)
@@ -450,7 +451,7 @@ class TestReverseOsmosis:
         assert len(unscaled_var_list) == 0
 
         # # test initialization
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         # test variable scaling
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
@@ -538,9 +539,9 @@ class TestReverseOsmosis:
         m.fs.unit.length.fix(length)
 
         # test statistics
-        assert number_variables(m) == 143
-        assert number_total_constraints(m) == 113
-        assert number_unused_variables(m) == 0  # vars from property package parameters
+        assert number_variables(m) == 139
+        assert number_total_constraints(m) == 109
+        assert number_unused_variables(m) == 6  # vars from property package parameters
 
         # Test units
         assert_units_consistent(m.fs.unit)
@@ -566,7 +567,7 @@ class TestReverseOsmosis:
         assert len(unscaled_var_list) == 0
 
         # test initialization
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         # test variable scaling
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
@@ -652,9 +653,9 @@ class TestReverseOsmosis:
         m.fs.unit.length.fix(16)
 
         # test statistics
-        assert number_variables(m) == 149
-        assert number_total_constraints(m) == 120
-        assert number_unused_variables(m) == 0  # vars from property package parameters
+        assert number_variables(m) == 145
+        assert number_total_constraints(m) == 116
+        assert number_unused_variables(m) == 6  # vars from property package parameters
 
         # Test units
         assert_units_consistent(m.fs.unit)
@@ -680,7 +681,7 @@ class TestReverseOsmosis:
         assert len(unscaled_var_list) == 0
 
         # test initialization
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         # test variable scaling
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
@@ -779,9 +780,9 @@ class TestReverseOsmosis:
         m.fs.unit.feed_side.dP_dx.fix(-membrane_pressure_drop / length)
 
         # test statistics
-        assert number_variables(m) == 144
-        assert number_total_constraints(m) == 114
-        assert number_unused_variables(m) == 0
+        assert number_variables(m) == 140
+        assert number_total_constraints(m) == 110
+        assert number_unused_variables(m) == 6
 
         # Test units
         assert_units_consistent(m.fs.unit)
@@ -807,7 +808,7 @@ class TestReverseOsmosis:
         assert len(unscaled_var_list) == 0
 
         # test initialization
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         # test variable scaling
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))

--- a/watertap/unit_models/tests/test_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_1D.py
@@ -51,6 +51,7 @@ from idaes.core.util.scaling import (
 )
 
 from watertap.core import MembraneChannel1DBlock
+import idaes.logger as idaeslog
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -302,7 +303,7 @@ class TestReverseOsmosis:
 
     @pytest.mark.component
     def test_initialize(self, RO_frame):
-        initialization_tester(RO_frame)
+        initialization_tester(RO_frame, outlvl=idaeslog.DEBUG)
 
     @pytest.mark.component
     def test_var_scaling(self, RO_frame):
@@ -450,7 +451,7 @@ class TestReverseOsmosis:
         assert len(unscaled_var_list) == 0
 
         # Test initialization
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         # Test variable scaling
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
@@ -576,7 +577,7 @@ class TestReverseOsmosis:
         assert len(unscaled_var_list) == 0
 
         # Test initialization
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
         # Check for poorly scaled variables
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
@@ -699,7 +700,7 @@ class TestReverseOsmosis:
         unscaled_var_list = list(unscaled_variables_generator(m))
         assert len(unscaled_var_list) == 0
 
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
@@ -823,7 +824,7 @@ class TestReverseOsmosis:
         unscaled_var_list = list(unscaled_variables_generator(m))
         assert len(unscaled_var_list) == 0
 
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
@@ -949,7 +950,7 @@ class TestReverseOsmosis:
         unscaled_var_list = list(unscaled_variables_generator(m))
         assert len(unscaled_var_list) == 0
 
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []
@@ -1076,7 +1077,7 @@ class TestReverseOsmosis:
         unscaled_var_list = list(unscaled_variables_generator(m))
         assert len(unscaled_var_list) == 0
 
-        initialization_tester(m)
+        initialization_tester(m, outlvl=idaeslog.DEBUG)
 
         badly_scaled_var_lst = list(badly_scaled_var_generator(m))
         assert badly_scaled_var_lst == []


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
Unify the treatment of the isothermal assumption between 0D and 1D RO unit models.

## Changes proposed in this PR:
- Remove call to `ControlVolume.add_energy_balances`
- Remove the `add_isothermal_conditions` from the MembraneChannel and replace with `add_interface_isothermal_conditions` and `add_control_volume_isothermal_conditions` for fined-grain control for OARO.
- Update 0DRO testing baselines (only variables & constraints changed)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
