### PR TITLE
fixing getting started links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ WaterTAP is developed as part of the [National Alliance for Water Innovation](ht
 
 ## Getting started
 
-To quickly install and start using WaterTAP, head over to the [Getting Started](https://watertap.readthedocs.io/en/latest/getting_started/install.html#general-installation) section of the documentation.
+To quickly install and start using WaterTAP, head over to the [Getting Started](https://watertap.readthedocs.io/en/stable/getting_started/install.html#general-installation) section of the documentation.
 
 ## Documentation
 
 The WaterTAP documentation is available online at <https://watertap.readthedocs.io>.
 ## Developer notes
 
-Refer to the [Getting Started for Developers](https://watertap.readthedocs.io/en/latest/getting_started/install.html#for-watertap-developers) section of the documentation.
+Refer to the [Getting Started for Developers](https://watertap.readthedocs.io/en/stable/getting_started/install.html#for-watertap-developers) section of the documentation.
 
 ## Cite this work
 


### PR DESCRIPTION
## Fixes/Resolves:

This addresses #844 by changing the links to use "stable" rather than "latest".

## Summary/Motivation:

Using "stable" points to the docs as built from the most recent tagged release, whereas "latest" points to the most recent build from the main branch.  For our readme, I think it better to point to "stable" rather than "latest".  Of course if we re-org the docs, this will still break the links, so we'll still need to fix them when that happens.

I also, when doing this, changed our ReadTheDocs config so that the default (when the short url is used) is to point to "stable" (which will be the most recent tagged release) rather than "latest" (which is whatever is on the main branch at the time).

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
