### PR TITLE
Adding more control for defined flows

### DIFF
--- a/watertap/costing/units/crystallizer.py
+++ b/watertap/costing/units/crystallizer.py
@@ -81,14 +81,14 @@ def build_crystallizer_cost_param_block(blk):
         units=pyo.units.dimensionless,
     )
 
-    blk.steam_unit_cost = pyo.Var(
+    blk.steam_cost = pyo.Var(
         initialize=0.004,
         units=pyo.units.USD_2018 / (pyo.units.meter**3),
         doc="Steam cost, Panagopoulos (2019)",
     )
 
     costing = blk.parent_block()
-    costing.defined_flows["steam"] = blk.steam_unit_cost
+    costing.add_defined_flow("steam", blk.steam_cost)
 
 
 def cost_crystallizer(blk, cost_type=CrystallizerCostType.default):

--- a/watertap/costing/units/ion_exchange.py
+++ b/watertap/costing/units/ion_exchange.py
@@ -36,7 +36,7 @@ def build_hcl_cost_param_block(blk):
     )
 
     costing = blk.parent_block()
-    costing.defined_flows["HCl"] = blk.cost / blk.purity
+    costing.add_defined_flow("HCl", blk.cost / blk.purity)
 
 
 def build_naoh_cost_param_block(blk):
@@ -56,7 +56,7 @@ def build_naoh_cost_param_block(blk):
     )
 
     costing = blk.parent_block()
-    costing.defined_flows["NaOH"] = blk.cost / blk.purity
+    costing.add_defined_flow("NaOH", blk.cost / blk.purity)
 
 
 def build_meoh_cost_param_block(blk):
@@ -76,7 +76,7 @@ def build_meoh_cost_param_block(blk):
     )
 
     costing = blk.parent_block()
-    costing.defined_flows["MeOH"] = blk.cost / blk.purity
+    costing.add_defined_flow("MeOH", blk.cost / blk.purity)
 
 
 def build_nacl_cost_param_block(blk):
@@ -96,7 +96,7 @@ def build_nacl_cost_param_block(blk):
     )
 
     costing = blk.parent_block()
-    costing.defined_flows["NaCl"] = blk.cost / blk.purity
+    costing.add_defined_flow("NaCl", blk.cost / blk.purity)
 
 
 def build_ion_exhange_cost_param_block(blk):

--- a/watertap/costing/units/mixer.py
+++ b/watertap/costing/units/mixer.py
@@ -101,7 +101,7 @@ def build_naocl_cost_param_block(blk):
     )
 
     costing = blk.parent_block()
-    costing.defined_flows["NaOCl"] = blk.cost / blk.purity
+    costing.add_defined_flow("NaOCl", blk.cost / blk.purity)
 
 
 @register_costing_parameter_block(
@@ -148,7 +148,7 @@ def build_caoh2_cost_param_block(blk):
     )
 
     costing = blk.parent_block()
-    costing.defined_flows["CaOH2"] = blk.cost / blk.purity
+    costing.add_defined_flow("CaOH2", blk.cost / blk.purity)
 
 
 def build_caoh2_mixer_cost_param_block(blk):

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -60,10 +60,16 @@ class _DefinedFlowsDict(MutableMapping, dict):
     __iter__ = dict.__iter__
     __len__ = dict.__len__
 
-    def __setitem__(self, key, value):
+    def _setitem(self, key, value):
         if key in self and self[key] is not value:
             raise KeyError(f"{key} has already been defined as a flow")
         dict.__setitem__(self, key, value)
+
+    def __setitem__(self, key, value):
+        raise KeyError(
+            "Please use the `WaterTAPCosting.add_defined_flow` "
+            "method to add defined flows."
+        )
 
     def __delitem__(self, key):
         raise KeyError("defined flows cannot be removed")
@@ -134,13 +140,13 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             units=pyo.units.year**-1,
         )
 
-        self.electricity_base_cost = pyo.Param(
+        self.electricity_cost = pyo.Param(
             mutable=True,
             initialize=0.07,
             doc="Electricity cost",
             units=pyo.units.USD_2018 / pyo.units.kWh,
         )
-        self.defined_flows["electricity"] = self.electricity_base_cost
+        self.add_defined_flow("electricity", self.electricity_cost)
 
         self.electrical_carbon_intensity = pyo.Param(
             mutable=True,
@@ -151,6 +157,36 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
 
         # fix the parameters
         self.fix_all_vars()
+
+    def add_defined_flow(self, flow_name, flow_cost):
+        """
+        This method adds a defined flow to the costing block.
+
+        NOTE: Use this method to add `defined_flows` to the costing block
+              to ensure updates to `flow_cost` get propagated in the model.
+              See https://github.com/IDAES/idaes-pse/pull/1014 for details.
+
+        Args:
+            flow_name: string containing the name of the flow to register
+            flow_cost: Pyomo expression that represents the flow unit cost
+
+        Returns:
+            None
+        """
+        flow_cost_name = flow_name + "_cost"
+        current_flow_cost = self.component(flow_cost_name)
+        if current_flow_cost is None:
+            self.add_component(flow_cost_name, pyo.Expression(expr=flow_cost))
+            self.defined_flows._setitem(flow_name, self.component(flow_cost_name))
+        elif current_flow_cost is flow_cost:
+            self.defined_flows._setitem(flow_name, current_flow_cost)
+        else:
+            # if we get here then there's an attribute named
+            # flow_cost_name on the block, which is an error
+            raise RuntimeError(
+                f"Attribute {flow_cost_name} already exists "
+                f"on the costing block, but is not {flow_cost}"
+            )
 
     def cost_flow(self, flow_expr, flow_type):
         """

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_ui.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_ui.py
@@ -318,7 +318,7 @@ def export_variables(flowsheet=None, exports=None):
         is_output=False,
     )
     # System costs
-    v = fs.ro_costing.electricity_base_cost
+    v = fs.ro_costing.electricity_cost
     exports.add(
         obj=v,
         name="Electricity cost",

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
@@ -405,7 +405,7 @@ def add_costing(m):
         flowsheet_costing_block=m.fs.ro_costing,
         costing_method_arguments={"cost_electricity_flow": True},
     )
-    m.fs.ro_costing.electricity_base_cost = value(m.fs.zo_costing.electricity_cost)
+    m.fs.ro_costing.electricity_cost = value(m.fs.zo_costing.electricity_cost)
     m.fs.ro_costing.base_currency = pyunits.USD_2020
     # Aggregate unit level costs and calculate overall process costs
     m.fs.zo_costing.cost_process()

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
@@ -128,8 +128,8 @@ class TestDyewithROFlowsheet:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(0.653284, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(0.270094, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(0.690498, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(0.284743, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -292,7 +292,7 @@ def build(
     m.fs.costing.factor_total_investment.fix(2)
     m.fs.costing.factor_maintenance_labor_chemical.fix(0.03)
     m.fs.costing.factor_capital_annualization.fix(0.1)
-    m.fs.costing.electricity_base_cost.set_value(0.07)
+    m.fs.costing.electricity_cost.set_value(0.07)
     m.fs.costing.reverse_osmosis.factor_membrane_replacement.fix(0.15)
     m.fs.costing.reverse_osmosis.membrane_cost.fix(30)
     m.fs.costing.reverse_osmosis.high_pressure_membrane_cost.fix(50)


### PR DESCRIPTION
## Fixes/Resolves: Part of #676

## Summary/Motivation:
In the WaterTAP costing package, some variables and mutable parameters, while settable, do not have any impact on the underlying Pyomo model. A fix is coming in IDAES, (see the discussion on IDAES/idaes-pse#1014), but in the meantime WaterTAP can side-step this issue.

## Changes proposed in this PR:
- Register defined flow costs on the WaterTAPCosting package through `add_defined_flow`.
- Add additional safeguards to the `defined_flow` dictionary so values cannot be set by `__setitem__` directly.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
