### PR TITLE
Unifying meaning of total_capital_cost across costing packages

### DIFF
--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -181,13 +181,10 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         super().cost_flow(flow_expr, flow_type)
 
     def build_process_costs(self):
-        self.total_capital_cost = pyo.Expression(
-            expr=self.aggregate_capital_cost, doc="Total capital cost"
-        )
-        self.total_investment_cost = pyo.Var(
+        self.total_capital_cost = pyo.Var(
             initialize=1e3,
             domain=pyo.NonNegativeReals,
-            doc="Total investment cost",
+            doc="Total capital cost",
             units=self.base_currency,
         )
         self.maintenance_labor_chemical_operating_cost = pyo.Var(
@@ -203,13 +200,13 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
             units=self.base_currency / self.base_period,
         )
 
-        self.total_investment_cost_constraint = pyo.Constraint(
-            expr=self.total_investment_cost
-            == self.factor_total_investment * self.total_capital_cost
+        self.total_capital_cost_constraint = pyo.Constraint(
+            expr=self.total_capital_cost
+            == self.factor_total_investment * self.aggregate_capital_cost
         )
         self.maintenance_labor_chemical_operating_cost_constraint = pyo.Constraint(
             expr=self.maintenance_labor_chemical_operating_cost
-            == self.factor_maintenance_labor_chemical * self.total_investment_cost
+            == self.factor_maintenance_labor_chemical * self.total_capital_cost
         )
 
         self.total_operating_cost_constraint = pyo.Constraint(
@@ -222,7 +219,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
 
     def initialize_build(self):
         calculate_variable_from_constraint(
-            self.total_investment_cost, self.total_investment_cost_constraint
+            self.total_capital_cost, self.total_capital_cost_constraint
         )
         calculate_variable_from_constraint(
             self.maintenance_labor_chemical_operating_cost,
@@ -253,7 +250,7 @@ class WaterTAPCostingData(FlowsheetCostingBlockData):
         LCOW_constraint = pyo.Constraint(
             expr=LCOW
             == (
-                self.total_investment_cost * self.factor_capital_annualization
+                self.total_capital_cost * self.factor_capital_annualization
                 + self.total_operating_cost
             )
             / (

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/default_configuration.yaml
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/default_configuration.yaml
@@ -232,7 +232,7 @@ fs.S1.split_fraction[0.0,P1]: 0.49475489729022726
 fs.S1.split_fraction[0.0,PXR]: 0.5052451027097727
 fs.costing.LCOW: 0.46090440122852394
 fs.costing.aggregate_capital_cost: 12709.589772436626
-fs.costing.total_investment_cost: 25419.179544873252
+fs.costing.total_capital_cost: 25419.179544873252
 fs.costing.maintenance_labor_chemical_operating_cost: 762.5753863461975
 fs.costing.total_operating_cost: 3942.7469500005436
 fs.disposal.properties[0.0].flow_mass_phase_comp[Liq,H2O]: 0.49285444999999994

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -121,7 +121,7 @@ class TestROwithPX:
             assert isinstance(getattr(c_blk, "capital_cost"), Var)
 
         var_str_list = [
-            "total_investment_cost",
+            "total_capital_cost",
             "maintenance_labor_chemical_operating_cost",
             "total_operating_cost",
         ]

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
@@ -704,7 +704,7 @@ def add_costing(m):
             pyunits.convert(
                 m.fs.zo_costing.total_capital_cost, to_units=pyunits.USD_2018
             )
-            + m.fs.ro_costing.total_investment_cost
+            + m.fs.ro_costing.total_capital_cost
         )
 
     @m.Expression()

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs.py
@@ -229,7 +229,7 @@ def add_costing(m):
         return pyunits.convert(
             m.fs.costing.total_capital_cost, to_units=m.fs.costing.base_currency
         ) + pyunits.convert(
-            m.fs.watertap_costing.total_investment_cost,
+            m.fs.watertap_costing.total_capital_cost,
             to_units=m.fs.costing.base_currency,
         )
 

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_ui.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_ui.py
@@ -629,7 +629,7 @@ def export_variables(flowsheet=None, exports=None):
         output_category="Capital costs",
     )
     exports.add(
-        obj=fs.ro_costing.total_investment_cost,
+        obj=fs.ro_costing.total_capital_cost,
         name="RO system costs",
         ui_units=fs.zo_costing.base_currency,
         display_units="$",

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
@@ -483,7 +483,7 @@ def add_costing(m):
         return pyunits.convert(
             m.fs.zo_costing.total_capital_cost, to_units=pyunits.USD_2020
         ) + pyunits.convert(
-            m.fs.ro_costing.total_investment_cost, to_units=pyunits.USD_2020
+            m.fs.ro_costing.total_capital_cost, to_units=pyunits.USD_2020
         )
 
     @m.fs.Expression(doc="Total operating cost of the treatment train")
@@ -673,9 +673,7 @@ def display_costing(m):
     )
 
     ro_capex = value(
-        pyunits.convert(
-            m.fs.ro_costing.total_investment_cost, to_units=pyunits.USD_2020
-        )
+        pyunits.convert(m.fs.ro_costing.total_capital_cost, to_units=pyunits.USD_2020)
     )
 
     opex = value(

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/swine_wwt/swine_wwt.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/swine_wwt/swine_wwt.py
@@ -484,7 +484,7 @@ def add_costing(m):
         return pyunits.convert(
             m.fs.costing.total_capital_cost, to_units=m.fs.costing.base_currency
         ) + pyunits.convert(
-            m.fs.watertap_costing.total_investment_cost,
+            m.fs.watertap_costing.total_capital_cost,
             to_units=m.fs.costing.base_currency,
         )
 

--- a/watertap/examples/flowsheets/electrodialysis/tests/test_electrodialysis_1stack.py
+++ b/watertap/examples/flowsheets/electrodialysis/tests/test_electrodialysis_1stack.py
@@ -92,7 +92,7 @@ class TestElectrodialysisVoltageConst:
         assert isinstance(m.fs.EDstack.costing.fixed_operating_cost, Var)
 
         var_str_list = [
-            "total_investment_cost",
+            "total_capital_cost",
             "maintenance_labor_chemical_operating_cost",
             "total_operating_cost",
         ]

--- a/watertap/examples/flowsheets/full_treatment_train/analysis/multi_sweep.py
+++ b/watertap/examples/flowsheets/full_treatment_train/analysis/multi_sweep.py
@@ -244,7 +244,7 @@ def run_analysis(case_num, nx, RO_type, output_directory=None, interp_nan_output
         outputs["Ca Removal"] = m.fs.removal_Ca
         outputs["Mg Removal"] = m.fs.removal_Mg
         outputs["Annual Water Production"] = m.fs.costing.annual_water_production
-        outputs["capital_cost_total"] = m.fs.costing.total_capital_cost
+        outputs["capital_cost_total"] = m.fs.costing.aggregate_capital_cost
         outputs["operating_cost_total"] = m.fs.costing.total_operating_cost
 
         output_filename = base_path + f"output/fs_softening/results_{case_num}.csv"

--- a/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/costing.py
+++ b/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/costing.py
@@ -207,14 +207,14 @@ def display_costing(m):
     # UNITS FOR ALL COST COMPONENTS [=] $/m3 of permeate water produced
     cost_dict = {
         "LCOW": m.fs.costing.LCOW,  # Total LCOW
-        "Total CAPEX": m.fs.costing.total_investment_cost
+        "Total CAPEX": m.fs.costing.total_capital_cost
         * crf
         / m.fs.costing.annual_water_production,  # Direct + Indirect CAPEX
-        "Direct CAPEX": m.fs.costing.total_capital_cost
+        "Direct CAPEX": m.fs.costing.aggregate_capital_cost
         * crf
         / m.fs.costing.annual_water_production,  # Direct CAPEX for all system components
         "Indirect CAPEX": (
-            m.fs.costing.total_investment_cost - m.fs.costing.total_capital_cost
+            m.fs.costing.total_capital_cost - m.fs.costing.aggregate_capital_cost
         )
         * crf
         / m.fs.costing.annual_water_production,  # Indirect CAPEX for miscellaneous items

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -424,7 +424,7 @@ def build(
 
     m.fs.costing.indirect_capex_lcow = Expression(
         expr=m.fs.costing.factor_capital_annualization
-        * (m.fs.costing.total_investment_cost - m.fs.costing.total_capital_cost)
+        * (m.fs.costing.total_capital_cost - m.fs.costing.aggregate_capital_cost)
         / m.fs.costing.annual_water_production
     )
 
@@ -1195,7 +1195,7 @@ def display_system(m):
     )
     print(
         f"Indirect Capital Cost ($/m3): "
-        f"{value(m.fs.costing.factor_capital_annualization*(m.fs.costing.total_investment_cost - m.fs.costing.total_capital_cost) / m.fs.costing.annual_water_production)}"
+        f"{value(m.fs.costing.factor_capital_annualization*(m.fs.costing.total_capital_cost - m.fs.costing.aggregate_capital_cost) / m.fs.costing.annual_water_production)}"
     )
     electricity_cost = value(
         m.fs.costing.aggregate_flow_costs["electricity"]

--- a/watertap/examples/flowsheets/lsrro/multi_sweep.py
+++ b/watertap/examples/flowsheets/lsrro/multi_sweep.py
@@ -115,7 +115,7 @@ def run_case(number_of_stages, nx, output_filename=None):
 
     outputs["Total Membrane Area"] = m.fs.total_membrane_area
     outputs["Total Capex LCOW"] = (
-        m.fs.costing.total_investment_cost
+        m.fs.costing.total_capital_cost
         * m.fs.costing.factor_capital_annualization
         / m.fs.costing.annual_water_production
     )

--- a/watertap/unit_models/tests/test_crystallizer.py
+++ b/watertap/unit_models/tests/test_crystallizer.py
@@ -451,7 +451,9 @@ class TestCrystallization:
         # Residence time
         assert pytest.approx(1.0228, rel=1e-3) == value(b.t_res)
         # Mass-basis costing
-        assert pytest.approx(300000, rel=1e-3) == value(m.fs.costing.total_capital_cost)
+        assert pytest.approx(300000, rel=1e-3) == value(
+            m.fs.costing.aggregate_capital_cost
+        )
 
     @pytest.mark.component
     def test_solution2_capcosting_by_mass(self, Crystallizer_frame):
@@ -479,7 +481,9 @@ class TestCrystallization:
         # Minimum active volume
         assert pytest.approx(0.959, rel=1e-3) == value(b.volume_suspension)
         # Mass-basis costing
-        assert pytest.approx(300000, rel=1e-3) == value(m.fs.costing.total_capital_cost)
+        assert pytest.approx(300000, rel=1e-3) == value(
+            m.fs.costing.aggregate_capital_cost
+        )
 
     @pytest.mark.component
     def test_solution2_capcosting_by_volume(self, Crystallizer_frame_2):
@@ -535,7 +539,9 @@ class TestCrystallization:
         # Minimum active volume
         assert pytest.approx(0.959, rel=1e-3) == value(b.volume_suspension)
         # Volume-basis costing
-        assert pytest.approx(199000, rel=1e-3) == value(m.fs.costing.total_capital_cost)
+        assert pytest.approx(199000, rel=1e-3) == value(
+            m.fs.costing.aggregate_capital_cost
+        )
 
     @pytest.mark.component
     def test_solution2_operatingcost(self, Crystallizer_frame_2):

--- a/watertap/unit_models/tests/test_electrodialysis_0D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_0D.py
@@ -286,13 +286,13 @@ class TestElectrodialysisVoltageConst:
         assert_optimal_termination(results)
 
         assert pytest.approx(388.6800, rel=1e-3) == value(
-            m.fs.costing.total_capital_cost
+            m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(45.86804, rel=1e-3) == value(
             m.fs.costing.total_operating_cost
         )
         assert pytest.approx(777.3600, rel=1e-3) == value(
-            m.fs.costing.total_investment_cost
+            m.fs.costing.total_capital_cost
         )
 
 
@@ -495,13 +495,13 @@ class TestElectrodialysisCurrentConst:
         ) == pytest.approx(1.330e-3, rel=5e-3)
 
         assert pytest.approx(388.6800, rel=1e-3) == value(
-            m.fs.costing.total_capital_cost
+            m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(47.16423, rel=1e-3) == value(
             m.fs.costing.total_operating_cost
         )
         assert pytest.approx(777.3600, rel=1e-3) == value(
-            m.fs.costing.total_investment_cost
+            m.fs.costing.total_capital_cost
         )
 
     @pytest.mark.component

--- a/watertap/unit_models/tests/test_electrodialysis_1D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_1D.py
@@ -287,13 +287,13 @@ class TestElectrodialysisVoltageConst:
         assert_optimal_termination(results)
 
         assert pytest.approx(388.6800, rel=1e-3) == value(
-            m.fs.costing.total_capital_cost
+            m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(45.86804, rel=1e-3) == value(
             m.fs.costing.total_operating_cost
         )
         assert pytest.approx(777.3600, rel=1e-3) == value(
-            m.fs.costing.total_investment_cost
+            m.fs.costing.total_capital_cost
         )
 
 

--- a/watertap/unit_models/tests/test_ion_exchange_0D.py
+++ b/watertap/unit_models/tests/test_ion_exchange_0D.py
@@ -926,12 +926,12 @@ class TestIonExchangeCosting:
         assert_optimal_termination(results)
 
         assert pytest.approx(453807.598, rel=1e-5) == value(
-            m.fs.costing.total_capital_cost
+            m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(1023617.357, rel=1e-5) == value(
             m.fs.costing.total_operating_cost
         )
         assert pytest.approx(907615.190, rel=1e-5) == value(
-            m.fs.costing.total_investment_cost
+            m.fs.costing.total_capital_cost
         )
         assert pytest.approx(0.78791, rel=1e-5) == value(m.fs.costing.LCOW)


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
In the `ZeroOrderCosting` package, `total_capital_cost` *includes* indirect capital expenditures. However, in the  `WaterTAPCosting` package `total_capital_cost` *excludes* indirect capital expenditures.

This PR would adopt the `ZeroOrderCosting` package convention for `total_capital_cost`, redefining it in the `WaterTAPCosting` package.

## Changes proposed in this PR:
- In the `WaterTAPCosting` package, rename `total_investment_cost` to `total_capital_cost`.
- Replace `total_investment_cost` with `total_capital_cost` and `total_capital_cost` with `aggregate_capital_cost` wherever referenced on the `WaterTAPCosting` package.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
