### PR TITLE
Updates for numpy 1.24.0

### DIFF
--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -189,7 +189,7 @@ class _ParameterSweepBase(ABC):
             nx = int(nx)
 
             # Allocate memory to hold the Bcast array
-            global_combo_array = np.zeros((nx, num_var_params), dtype=np.float64)
+            global_combo_array = np.zeros((nx, num_var_params), dtype=float)
 
         ### Broadcast the array to all processes
         if self.num_procs > 1:
@@ -229,7 +229,7 @@ class _ParameterSweepBase(ABC):
     def _aggregate_results_arr(self, global_results_dict, num_cases):
 
         global_results = np.zeros(
-            (num_cases, len(global_results_dict["outputs"])), dtype=np.float64
+            (num_cases, len(global_results_dict["outputs"])), dtype=float
         )
 
         if self.rank == 0:
@@ -302,7 +302,7 @@ class _ParameterSweepBase(ABC):
     def _create_component_output_skeleton(self, component, num_samples):
 
         comp_dict = {}
-        comp_dict["value"] = np.zeros(num_samples, dtype=np.float64)
+        comp_dict["value"] = np.zeros(num_samples, dtype=float)
         if hasattr(component, "lb"):
             comp_dict["lower bound"] = component.lb
         if hasattr(component, "ub"):
@@ -369,7 +369,7 @@ class _ParameterSweepBase(ABC):
             for key, item in global_output_dict.items():
                 if key != "solve_successful":
                     for subkey, subitem in item.items():
-                        subitem["value"] = np.zeros(num_total_samples, dtype=np.float64)
+                        subitem["value"] = np.zeros(num_total_samples, dtype=float)
 
         else:
             global_output_dict = local_output_dict
@@ -393,12 +393,10 @@ class _ParameterSweepBase(ABC):
                     ]["value"][0:req_num_samples]
 
             elif key == "solve_successful":
-                local_solve_successful = np.fromiter(
-                    item, dtype=np.bool, count=len(item)
-                )
+                local_solve_successful = np.fromiter(item, dtype=bool, count=len(item))
 
                 if self.rank == 0:
-                    global_solve_successful = np.empty(num_total_samples, dtype=np.bool)
+                    global_solve_successful = np.empty(num_total_samples, dtype=bool)
                 else:
                     global_solve_successful = None
 
@@ -661,7 +659,7 @@ class RecursiveParameterSweep(_ParameterSweepBase):
 
         global_filtered_values = np.zeros(
             (req_num_samples, len(global_filtered_dict["sweep_params"])),
-            dtype=np.float64,
+            dtype=float,
         )
 
         if self.rank == 0:
@@ -746,13 +744,13 @@ class RecursiveParameterSweep(_ParameterSweepBase):
 
             # Get the global number of successful solves and update the number of remaining samples
             if self.num_procs > 1:  # pragma: no cover
-                global_success_count = np.zeros(1, dtype=np.float64)
-                global_failure_count = np.zeros(1, dtype=np.float64)
+                global_success_count = np.zeros(1, dtype=float)
+                global_failure_count = np.zeros(1, dtype=float)
                 self.comm.Allreduce(
-                    np.array(success_count, dtype=np.float64), global_success_count
+                    np.array(success_count, dtype=float), global_success_count
                 )
                 self.comm.Allreduce(
-                    np.array(failure_count, dtype=np.float64), global_failure_count
+                    np.array(failure_count, dtype=float), global_failure_count
                 )
             else:
                 global_success_count = success_count
@@ -783,7 +781,7 @@ class RecursiveParameterSweep(_ParameterSweepBase):
         if self.writer.config["debugging_data_dir"] is not None:
             local_filtered_values = np.zeros(
                 (local_n_successful, len(local_filtered_dict["sweep_params"])),
-                dtype=np.float64,
+                dtype=float,
             )
             for i, (key, item) in enumerate(
                 local_filtered_dict["sweep_params"].items()

--- a/watertap/tools/parameter_sweep/parameter_sweep_differential.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep_differential.py
@@ -169,7 +169,7 @@ class DifferentialParameterSweep(_ParameterSweepBase):
         num_local_samples = len(local_results_dict["solve_successful"])
         local_inputs = np.zeros(
             (num_local_samples, len(local_results_dict["sweep_params"])),
-            dtype=np.float64,
+            dtype=float,
         )
 
         for i, (key, item) in enumerate(local_results_dict["sweep_params"].items()):
@@ -181,7 +181,7 @@ class DifferentialParameterSweep(_ParameterSweepBase):
 
         global_values = np.zeros(
             (num_global_samples, len(global_results_dict["sweep_params"])),
-            dtype=np.float64,
+            dtype=float,
         )
 
         if self.rank == 0:

--- a/watertap/tools/parameter_sweep/parameter_sweep_writer.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep_writer.py
@@ -198,7 +198,7 @@ class ParameterSweepWriter:
             data_header = ",".join(itertools.chain(sweep_params))
             local_results = np.zeros(
                 (np.shape(local_values)[0], len(local_results_dict["outputs"])),
-                dtype=np.float64,
+                dtype=float,
             )
             for i, (key, item) in enumerate(local_results_dict["outputs"].items()):
                 data_header = ",".join([data_header, key])


### PR DESCRIPTION
## Fixes/Resolves:
On #853 some tests starting failing due to a new numpy release. The parameter sweep tool is affected by a numpy deprecation.

## Summary/Motivation:
As @lbianchi-lbl pointed out here: (https://github.com/watertap-org/watertap/pull/853#issuecomment-1358089299), numpy removed some aliases for built-in Python types. The PR would replace our call to these types with their equivalent Python type.

## Changes proposed in this PR:
- Replace `numpy.bool` with `bool` everywhere
- Replace `numpy.float64` with `float` everywhere.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
