### PR TITLE
Add items to `.gitignore` for VSCode and Sublime Text editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ dmypy.json
 .pyre/
 
 # Pycharm
-.idea
+.idea/
 
 # Emacs
 *~
@@ -140,6 +140,20 @@ dmypy.json
 *.elc
 auto-save-list
 .\#*
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+*.sublime-workspace
 
 # MAC File System
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -142,12 +142,7 @@ auto-save-list
 .\#*
 
 # Visual Studio Code
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+.vscode/
 
 # Sublime Text
 *.tmlanguage.cache


### PR DESCRIPTION
## Fixes/Resolves:

The `.gitignore` does not consider files/folders associated with the Visual Studio Code and Sublime Text editors. Therefore, such files are committed with Git unless the user ignores these files/folders globally. This pull request adds those files/folders to the project's `.gitignore` file.

## Summary/Motivation:

Add items to `.gitignore` for the Visual Studio Code and Sublime Text editors. This will prevent files/folders associated with these editors from being committed by Git.

## Changes proposed in this PR:
- Add items to `.gitignore` for Visual Studio Code
- Add items to `.gitignore` for Sublime Text

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
