### PR TITLE
Adding density parameter to MCAS when `DensityCalculation.constant`

### DIFF
--- a/watertap/property_models/multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/multicomp_aq_sol_prop_pack.py
@@ -194,7 +194,7 @@ class MCASParameterData(PhysicalParameterBlock):
        .. csv-table::
            :header: "Configuration Options", "Description"
 
-           "``DensityCalculation.constant``", "Solution density assumed constant at 1000 kg/m3"
+           "``DensityCalculation.constant``", "Solution density assumed constant at 1000 kg/m3 by default in dens_mass_const parameter"
            "``DensityCalculation.seawater``", "Solution density based on correlation for seawater (TDS)"
            "``DensityCalculation.laliberte``", "Solution density based on mixing correlation from Laliberte"
        """,
@@ -373,7 +373,17 @@ class MCASParameterData(PhysicalParameterBlock):
             doc="Debye Huckel constant b",
         )
 
-        # Mass density parameters, eq. 8 in Sharqawy et al. (2010)
+        # Mass density
+        # For constant density
+        self.dens_mass_const = Param(
+            mutable=True,
+            default=1000,
+            initialize=1000,
+            units=pyunits.kg / pyunits.m**3,
+            doc="Mass density used in DensityCalculation.constant",
+        )
+
+        # Parameters for seawater density, eq. 8 in Sharqawy et al. (2010)
         dens_units = pyunits.kg / pyunits.m**3
         t_inv_units = pyunits.K**-1
 
@@ -932,7 +942,10 @@ class MCASStateBlockData(StateBlockData):
         # TODO: reconsider this approach for solution density based on arbitrary solute_list
         def rule_dens_mass_phase(b, p):
             if b.params.config.density_calculation == DensityCalculation.constant:
-                return b.dens_mass_phase[p] == 1000 * pyunits.kg * pyunits.m**-3
+                add_object_reference(
+                    self, "dens_mass_const", self.params.dens_mass_const
+                )
+                return b.dens_mass_phase[p] == self.dens_mass_const
             elif b.params.config.density_calculation == DensityCalculation.seawater:
                 # density, eq. 8 in Sharqawy #TODO- add Sharqawy reference
                 t = b.temperature - 273.15 * pyunits.K


### PR DESCRIPTION
## Fixes/Resolves:
DensityCalculation.constant allowed for solution density to be constant, but only at 1000 kg/m3. Adding a parameter to allow the constant density to be manipulated from 1000.

## Summary/Motivation:


## Changes proposed in this PR:
- add dens_mass_const as param

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
