### PR TITLE
Fix database path for user provided YAML file

### DIFF
--- a/watertap/core/tests/test_wt_database.py
+++ b/watertap/core/tests/test_wt_database.py
@@ -27,8 +27,12 @@ def test_default_path():
 
 @pytest.mark.unit
 def test_invalid_path():
-    with pytest.raises(OSError):
+    with pytest.raises(OSError) as excinfo:
         Database(dbpath="./some/foo.yaml")
+    assert (
+        "Could not find requested path some. Please check that this path exists."
+        in str(excinfo.value)
+    )
 
 
 @pytest.mark.unit

--- a/watertap/core/tests/test_wt_database.py
+++ b/watertap/core/tests/test_wt_database.py
@@ -14,7 +14,7 @@
 Tests for WaterTAP database wrapper
 """
 import pytest
-import os
+from pathlib import Path
 
 from watertap.core.wt_database import Database
 
@@ -22,39 +22,20 @@ from watertap.core.wt_database import Database
 @pytest.mark.unit
 def test_default_path():
     db = Database()
-
-    assert os.path.normpath(db._dbpath) == os.path.normpath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "..",
-            "..",
-            "data",
-            "techno_economic",
-        )
-    )
+    assert db._dbpath == Path(__file__).parent.parent.parent / "data/techno_economic"
 
 
 @pytest.mark.unit
 def test_invalid_path():
-    with pytest.raises(
-        OSError,
-        match="Could not find requested path . Please " "check that this path exists.",
-    ):
-        Database(dbpath="foo.yaml")
+    with pytest.raises(OSError):
+        Database(dbpath="./some/foo.yaml")
 
 
 @pytest.mark.unit
 def test_custom_path():
     # Pick a path we know will exist, even if it isn't a data folder
-    db = Database(
-        dbpath=os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "..", "..", "core"
-        )
-    )
-
-    assert db._dbpath == os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "..", ".."
-    )
+    db = Database(dbpath=Path(__file__).parent.parent / "core")
+    assert db._dbpath == Path(__file__).parent.parent
 
 
 class TestDatabase:

--- a/watertap/core/tests/test_wt_database.py
+++ b/watertap/core/tests/test_wt_database.py
@@ -38,10 +38,9 @@ def test_default_path():
 def test_invalid_path():
     with pytest.raises(
         OSError,
-        match="Could not find requested path foo. Please "
-        "check that this path exists.",
+        match="Could not find requested path . Please " "check that this path exists.",
     ):
-        Database(dbpath="foo")
+        Database(dbpath="foo.yaml")
 
 
 @pytest.mark.unit
@@ -54,7 +53,7 @@ def test_custom_path():
     )
 
     assert db._dbpath == os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "..", "..", "core"
+        os.path.dirname(os.path.abspath(__file__)), "..", ".."
     )
 
 

--- a/watertap/core/tests/test_zero_order_sido_reactive.py
+++ b/watertap/core/tests/test_zero_order_sido_reactive.py
@@ -48,7 +48,7 @@ from watertap.core.zero_order_sido_reactive import (
 
 solver = get_solver()
 
-local_path = os.path.dirname(os.path.abspath(__file__))
+local_path = os.path.dirname(os.path.abspath(__file__)) + "/test_sidor_data.yaml"
 
 
 @declare_process_block_class("DerivedSIDOR")

--- a/watertap/core/wt_database.py
+++ b/watertap/core/wt_database.py
@@ -27,10 +27,13 @@ class Database:
     associated with zero-order models in WaterTap.
 
     Args:
-        dbpath - (optional) path to database folder containing yaml files
+        dbpath - (optional) Path to a user provided YAML database file. For
+        example, the path could be ~/Desktop/myproject/mydata.yaml on a Mac.
+        If a path is not provided, then a default YAML database file is used
+        for the associated zero-order model.
 
     Returns:
-        an instance of a Database object linked to the provided database
+        An instance of a Database object linked to the provided database.
     """
 
     def __init__(self, dbpath=None):
@@ -44,7 +47,8 @@ class Database:
                 "techno_economic",
             )
         else:
-            self._dbpath = dbpath
+            self._dbpath = os.path.dirname(dbpath)
+            self._filename = os.path.basename(dbpath).split(".")[0]
 
             # Confirm valid path
             if not os.path.isdir(self._dbpath):
@@ -196,7 +200,10 @@ class Database:
             # If data is already in cached files, return
             return self._cached_files[technology]
         else:
-            # Else load data from required file
+            # If user provided a YAML file, use the filename as the technology
+            if hasattr(self, "_filename"):
+                technology = self._filename
+            # Load from database YAML file or from user provided YAML file
             try:
                 with open(os.path.join(self._dbpath, technology + ".yaml"), "r") as f:
                     lines = f.read()

--- a/watertap/core/wt_database.py
+++ b/watertap/core/wt_database.py
@@ -190,24 +190,25 @@ class Database:
         return self._component_list
 
     def _get_technology(self, technology):
+        # If data is already in cached files, then return that data
         if technology in self._cached_files:
-            # If data is already in cached files, return
             return self._cached_files[technology]
-        else:
-            # If user provided a YAML file, use the filename as the technology
-            if hasattr(self, "_filename"):
-                technology = self._filename
-            # Load from database YAML file or from user provided YAML file
-            try:
-                lines = (self._dbpath / technology).with_suffix(".yaml").read_text()
-            except OSError:
-                raise KeyError(f"Could not find entry for {technology} in database.")
 
-            fdata = yaml.load(lines, yaml.Loader)
+        # If user provided a YAML file, use the filename as the technology
+        if hasattr(self, "_filename"):
+            technology = self._filename
 
-            # Store data in cache and return
-            self._cached_files[technology] = fdata
-            return fdata
+        # Load from database YAML file or from user provided YAML file
+        try:
+            lines = (self._dbpath / technology).with_suffix(".yaml").read_text()
+        except OSError:
+            raise KeyError(f"Could not find entry for {technology} in database.")
+
+        fdata = yaml.load(lines, yaml.Loader)
+
+        # Store data in cache and return
+        self._cached_files[technology] = fdata
+        return fdata
 
     def _load_component_list(self):
         """

--- a/watertap/core/wt_database.py
+++ b/watertap/core/wt_database.py
@@ -14,9 +14,9 @@
 This module contains the base class for interacting with WaterTAP data files
 with zero-order model parameter data.
 """
-import os
 import yaml
 from copy import deepcopy
+from pathlib import Path
 
 
 class Database:
@@ -40,18 +40,14 @@ class Database:
         self._cached_files = {}
 
         if dbpath is None:
-            self._dbpath = os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                "..",
-                "data",
-                "techno_economic",
-            )
+            self._dbpath = Path(__file__).parent.parent / "data/techno_economic"
         else:
-            self._dbpath = os.path.dirname(dbpath)
-            self._filename = os.path.basename(dbpath).split(".")[0]
+            path = Path(dbpath)
+            self._dbpath = path.parent
+            self._filename = path.stem
 
             # Confirm valid path
-            if not os.path.isdir(self._dbpath):
+            if not self._dbpath.is_dir():
                 raise OSError(
                     f"Could not find requested path {self._dbpath}. Please "
                     f"check that this path exists."
@@ -80,9 +76,7 @@ class Database:
         else:
             # Else load data from required file
             try:
-                with open(os.path.join(self._dbpath, "water_sources.yaml"), "r") as f:
-                    lines = f.read()
-                    f.close()
+                lines = (self._dbpath / "water_sources.yaml").read_text()
             except OSError:
                 raise KeyError("Could not find water_sources.yaml in database.")
 
@@ -205,9 +199,7 @@ class Database:
                 technology = self._filename
             # Load from database YAML file or from user provided YAML file
             try:
-                with open(os.path.join(self._dbpath, technology + ".yaml"), "r") as f:
-                    lines = f.read()
-                    f.close()
+                lines = (self._dbpath / technology).with_suffix(".yaml").read_text()
             except OSError:
                 raise KeyError(f"Could not find entry for {technology} in database.")
 
@@ -226,9 +218,7 @@ class Database:
             None
         """
         try:
-            with open(os.path.join(self._dbpath, "component_list.yaml"), "r") as f:
-                lines = f.read()
-                f.close()
+            lines = (self._dbpath / "component_list.yaml").read_text()
         except OSError:
             raise KeyError("Could not find component_list.yaml in database.")
 


### PR DESCRIPTION
## Fixes/Resolves:

Fixes issue #907.

## Summary/Motivation:

The Database class has an optional argument where the user can provide the path to a YAML file for use with a zero-order model.

```python
from pyomo.environ import ConcreteModel
from watertap.core.wt_database import Database

model = ConcreteModel()
model.db = Database(dbpath="./myfile.yaml")
```

This path variable does not account for the name of the YAML file; therefore, the default database file in `watertap/data/techno_economic`/ is always used for the associated model. This pull request fixes the Database class to actually use the YAML file at the given path.

## Changes proposed in this PR:
- Use a `self._filename` attribute for the `Database` class to define the `technology` variable. This will be set when `dbpath` is given; otherwise, the default database file is used for the associated zero-order model.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
