### PR TITLE
Release state before InitializationError

### DIFF
--- a/watertap/property_models/NDMA_prop_pack.py
+++ b/watertap/property_models/NDMA_prop_pack.py
@@ -243,19 +243,18 @@ class _NDMAStateBlock(StateBlock):
                 "Property initialization: {}.".format(idaeslog.condition(results))
             )
 
-            if not check_optimal_termination(results):
-                raise InitializationError(
-                    f"{self.name} failed to initialize successfully. Please "
-                    f"check the output logs for more information."
-                )
-
-        # ---------------------------------------------------------------------
         # If input block, return flags, else release state
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
             else:
                 self.release_state(flags)
+
+        if (not skip_solve) and (not check_optimal_termination(results)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please "
+                f"check the output logs for more information."
+            )
 
     def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -298,19 +298,18 @@ class _NaClStateBlock(StateBlock):
                 "Property initialization: {}.".format(idaeslog.condition(results))
             )
 
-            if not check_optimal_termination(results):
-                raise InitializationError(
-                    f"{self.name} failed to initialize successfully. Please "
-                    f"check the output logs for more information."
-                )
-
-        # ---------------------------------------------------------------------
         # If input block, return flags, else release state
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
             else:
                 self.release_state(flags)
+
+        if (not skip_solve) and (not check_optimal_termination(results)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please "
+                f"check the output logs for more information."
+            )
 
     def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """

--- a/watertap/property_models/coagulation_prop_pack.py
+++ b/watertap/property_models/coagulation_prop_pack.py
@@ -307,21 +307,22 @@ class _CoagulationStateBlock(StateBlock):
             # Initialize properties
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = solve_indexed_blocks(opt, [self], tee=slc.tee)
-                if not check_optimal_termination(results):
-                    raise InitializationError(
-                        "The property package failed to solve during initialization"
-                    )
             init_log.info_high(
                 "Property initialization: {}.".format(idaeslog.condition(results))
             )
 
-        # ---------------------------------------------------------------------
         # If input block, return flags, else release state
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
             else:
                 self.release_state(flags)
+
+        if (not skip_solve) and (not check_optimal_termination(results)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please "
+                f"check the output logs for more information."
+            )
 
     def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """

--- a/watertap/property_models/cryst_prop_pack.py
+++ b/watertap/property_models/cryst_prop_pack.py
@@ -957,19 +957,18 @@ class _NaClStateBlock(StateBlock):
                 "Property initialization: {}.".format(idaeslog.condition(results))
             )
 
-            if not check_optimal_termination(results):
-                raise InitializationError(
-                    f"{self.name} failed to initialize successfully. Please "
-                    f"check the output logs for more information."
-                )
-
-        # ---------------------------------------------------------------------
         # If input block, return flags, else release state
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
             else:
                 self.release_state(flags)
+
+        if (not skip_solve) and (not check_optimal_termination(results)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please "
+                f"check the output logs for more information."
+            )
 
     def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """

--- a/watertap/property_models/multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/multicomp_aq_sol_prop_pack.py
@@ -721,28 +721,28 @@ class _MCASStateBlock(StateBlock):
         skip_solve = True  # skip solve if only state variables are present
         for k in self.keys():
             if number_unfixed_variables(self[k]) != 0:
-
                 skip_solve = False
 
         if not skip_solve:
             # Initialize properties
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = solve_indexed_blocks(opt, [self], tee=slc.tee)
-                if not check_optimal_termination(results):
-                    raise InitializationError(
-                        "The property package failed to solve during initialization."
-                    )
             init_log.info_high(
                 "Property initialization: {}.".format(idaeslog.condition(results))
             )
 
-        # ---------------------------------------------------------------------
         # If input block, return flags, else release state
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
             else:
                 self.release_state(flags)
+
+        if (not skip_solve) and (not check_optimal_termination(results)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please "
+                f"check the output logs for more information."
+            )
 
     def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """

--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -53,7 +53,10 @@ from idaes.core.util.initialization import (
     solve_indexed_blocks,
 )
 from idaes.core.solvers import get_solver
-from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.model_statistics import (
+    degrees_of_freedom,
+    number_unfixed_variables,
+)
 from idaes.core.util.exceptions import (
     ConfigurationError,
     InitializationError,
@@ -845,26 +848,31 @@ class _SeawaterStateBlock(StateBlock):
                 )
 
         # ---------------------------------------------------------------------
-        # Initialize properties
-        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            results = solve_indexed_blocks(opt, [self], tee=slc.tee)
-        init_log.info(
-            "Property initialization: {}.".format(idaeslog.condition(results))
-        )
+        skip_solve = True  # skip solve if only state variables are present
+        for k in self.keys():
+            if number_unfixed_variables(self[k]) != 0:
+                skip_solve = False
 
-        if not check_optimal_termination(results):
-            raise InitializationError(
-                f"{self.name} failed to initialize successfully. Please check "
-                f"the output logs for more information."
+        if not skip_solve:
+            # Initialize properties
+            with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+                results = solve_indexed_blocks(opt, [self], tee=slc.tee)
+            init_log.info_high(
+                "Property initialization: {}.".format(idaeslog.condition(results))
             )
 
-        # ---------------------------------------------------------------------
         # If input block, return flags, else release state
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
             else:
                 self.release_state(flags)
+
+        if (not skip_solve) and (not check_optimal_termination(results)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please "
+                f"check the output logs for more information."
+            )
 
     def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """

--- a/watertap/property_models/water_prop_pack.py
+++ b/watertap/property_models/water_prop_pack.py
@@ -16,10 +16,8 @@ from pyomo.environ import (
     Suffix,
     value,
     log,
-    log10,
     exp,
     check_optimal_termination,
-    Set,
 )
 from pyomo.environ import units as pyunits
 
@@ -35,14 +33,16 @@ from idaes.core import (
 )
 from idaes.core.base.components import Component, Solute, Solvent
 from idaes.core.base.phases import LiquidPhase, VaporPhase
-from idaes.core.util.constants import Constants
 from idaes.core.util.initialization import (
     fix_state_vars,
     revert_state_vars,
     solve_indexed_blocks,
 )
 from idaes.core.solvers import get_solver
-from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.model_statistics import (
+    degrees_of_freedom,
+    number_unfixed_variables,
+)
 from idaes.core.util.exceptions import (
     ConfigurationError,
     InitializationError,
@@ -477,26 +477,31 @@ class _WaterStateBlock(StateBlock):
                 )
 
         # ---------------------------------------------------------------------
-        # Initialize properties
-        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            results = solve_indexed_blocks(opt, [self], tee=slc.tee)
-        init_log.info(
-            "Property initialization: {}.".format(idaeslog.condition(results))
-        )
+        skip_solve = True  # skip solve if only state variables are present
+        for k in self.keys():
+            if number_unfixed_variables(self[k]) != 0:
+                skip_solve = False
 
-        if not check_optimal_termination(results):
-            raise InitializationError(
-                f"{self.name} failed to initialize successfully. Please check "
-                f"the output logs for more information."
+        if not skip_solve:
+            # Initialize properties
+            with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+                results = solve_indexed_blocks(opt, [self], tee=slc.tee)
+            init_log.info_high(
+                "Property initialization: {}.".format(idaeslog.condition(results))
             )
 
-        # ---------------------------------------------------------------------
         # If input block, return flags, else release state
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
             else:
                 self.release_state(flags)
+
+        if (not skip_solve) and (not check_optimal_termination(results)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please "
+                f"check the output logs for more information."
+            )
 
     def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """


### PR DESCRIPTION
## Fixes/Resolves:
NA

## Summary/Motivation:
We noticed issues with the OARO flowsheet, where upon failed initialization of RO, the DOF were < 0. Digging deeper with @luohezhiming , @bknueven , and @MarcusHolly, we realized that the failed initialization was attributed to the NaCl state block initialization (the permeate stateblocks), and corresponding state variables were not being unfixed as they should have been.  

## Changes proposed in this PR:
- Release state before raising `InitializationError`
- apply fix to all property models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
