### PR TITLE
Add documentation for running zero-order models

### DIFF
--- a/docs/how_to_guides/how_to_run_zero_order_model.rst
+++ b/docs/how_to_guides/how_to_run_zero_order_model.rst
@@ -69,13 +69,13 @@ The output from running this example is shown below.
        Mass Concentration tss              kilogram / meter ** 3   76.923   2.6019    659.86
    ====================================================================================
 
-To use a local YAML database file, define the folder path to the file using the `dbpath` parameter for the `Database` class. The line below defines the current working directory as the path for the YAML file.
+To use a local YAML database file, define the folder path to the file using the :code:`dbpath` parameter for the :code:`Database()` class. The line below defines the current working directory as the path for the YAML file.
 
 .. code-block::
 
    model.db = Database(dbpath=".")
 
-When using a local YAML file, the file name must be the same as the model name without the ZO letters. It must also use snake case style; for example, a YAML file for the `DualMediaFiltrationZO` model must be named `dual_media_filtration.yaml`. See below for the contents of this YAML file.
+When using a local YAML file, the file name must be the same as the model name without the ZO letters. It must also use snake case style; for example, a YAML file for the :code:`DualMediaFiltrationZO()` model must be named :code:`dual_media_filtration.yaml`. See below for the contents of this YAML file.
 
 .. code-block:: yaml
 

--- a/docs/how_to_guides/how_to_run_zero_order_model.rst
+++ b/docs/how_to_guides/how_to_run_zero_order_model.rst
@@ -1,7 +1,7 @@
 How to run a zero-order model
 -----------------------------
 
-The example below runs the dual media filtration zero-order model. This example uses the default parameters defined in the watertap YAML database. The output from running the example is also shown below.
+The example script shown below is for the dual media filtration zero-order model. This example uses the default parameters defined in the watertap YAML database.
 
 .. testcode::
 
@@ -17,28 +17,36 @@ The example below runs the dual media filtration zero-order model. This example 
 
    def main():
 
+       # Create a Pyomo model and initialize the YAML database
        model = ConcreteModel()
        model.db = Database()
 
+       # Create an IDAES flowsheet and define the solutes
        model.fs = FlowsheetBlock(dynamic=False)
        model.fs.params = WaterParameterBlock(solute_list=["nonvolatile_toc", "toc", "tss"])
 
+       # Setup the zero-order model and define inlet flows
        model.fs.unit = DualMediaFiltrationZO(property_package=model.fs.params, database=model.db)
        model.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(10)
        model.fs.unit.inlet.flow_mass_comp[0, "nonvolatile_toc"].fix(1)
        model.fs.unit.inlet.flow_mass_comp[0, "toc"].fix(1)
        model.fs.unit.inlet.flow_mass_comp[0, "tss"].fix(1)
 
+       # Load default parameters from the YAML database
        model.fs.unit.load_parameters_from_database()
 
+       # Access the solver and solve the model
        solver = get_solver()
        solver.solve(model)
 
+       # Display a report of the results
        model.fs.unit.report()
 
 
    if __name__ == "__main__":
        main()
+
+The output from running the example is shown below.
 
 .. code-block:: text
 
@@ -67,7 +75,7 @@ The example below runs the dual media filtration zero-order model. This example 
        Mass Concentration tss              kilogram / meter ** 3   76.923   2.6019    659.86
    ====================================================================================
 
-To use a local YAML database file, define the folder path to the file using the :code:`dbpath` parameter for the :code:`Database()` class. The line below defines the current working directory as the path for the YAML file.
+The zero-order models rely on default model parameter values specified in YAML files. Users should supply their own values, if possible, instead of relying on the default parameter values. To use a local YAML database file, define the folder path to the file using the :code:`dbpath` parameter for the :code:`Database()` class. The line below defines the current working directory as the path for the YAML file.
 
 .. code-block::
 

--- a/docs/how_to_guides/how_to_run_zero_order_model.rst
+++ b/docs/how_to_guides/how_to_run_zero_order_model.rst
@@ -1,0 +1,120 @@
+How to run a zero-order model
+-----------------------------
+
+The example below runs the dual media filtration zero-order model. This example uses the default parameters defined in the watertap YAML database.
+
+.. testcode::
+
+   from pyomo.environ import ConcreteModel
+
+   from idaes.core import FlowsheetBlock
+   from idaes.core.solvers import get_solver
+
+   from watertap.core.wt_database import Database
+   from watertap.core.zero_order_properties import WaterParameterBlock
+   from watertap.unit_models.zero_order import DualMediaFiltrationZO
+
+
+   def main():
+
+       model = ConcreteModel()
+       model.db = Database()
+
+       model.fs = FlowsheetBlock(dynamic=False)
+       model.fs.params = WaterParameterBlock(solute_list=["nonvolatile_toc", "toc", "tss"])
+
+       model.fs.unit = DualMediaFiltrationZO(property_package=model.fs.params, database=model.db)
+       model.fs.unit.inlet.flow_mass_comp[0, "H2O"].fix(10)
+       model.fs.unit.inlet.flow_mass_comp[0, "nonvolatile_toc"].fix(1)
+       model.fs.unit.inlet.flow_mass_comp[0, "toc"].fix(1)
+       model.fs.unit.inlet.flow_mass_comp[0, "tss"].fix(1)
+
+       model.fs.unit.load_parameters_from_database()
+
+       solver = get_solver()
+       solver.solve(model)
+
+       model.fs.unit.report()
+
+
+   if __name__ == "__main__":
+       main()
+
+The output from running this example is shown below.
+
+.. testoutput::
+
+   ====================================================================================
+   Unit : fs.unit                                                             Time: 0.0
+   ------------------------------------------------------------------------------------
+       Unit Performance
+
+       Variables:
+
+       Key                              : Value      : Units         : Fixed : Bounds
+                     Electricity Demand :     2373.6 :          watt : False : (0, None)
+                  Electricity Intensity : 1.8259e+05 :        pascal :  True : (None, None)
+       Solute Removal [nonvolatile_toc] :    0.20000 : dimensionless :  True : (0, None)
+                   Solute Removal [toc] :    0.20000 : dimensionless :  True : (0, None)
+                   Solute Removal [tss] :    0.97000 : dimensionless :  True : (0, None)
+                         Water Recovery :    0.99000 : dimensionless :  True : (0.0, 1.0000001)
+
+   ------------------------------------------------------------------------------------
+       Stream Table
+                                                  Units            Inlet   Treated  Byproduct
+       Volumetric Flowrate                   meter ** 3 / second 0.013000 0.011530 0.0014700
+       Mass Concentration H2O              kilogram / meter ** 3   769.23   858.63    68.027
+       Mass Concentration nonvolatile_toc  kilogram / meter ** 3   76.923   69.384    136.05
+       Mass Concentration toc              kilogram / meter ** 3   76.923   69.384    136.05
+       Mass Concentration tss              kilogram / meter ** 3   76.923   2.6019    659.86
+   ====================================================================================
+
+To use a local YAML database file, define the folder path to the file using the `dbpath` parameter for the `Database` class. The line below defines the current working directory as the path for the YAML file.
+
+.. code-block::
+
+   model.db = Database(dbpath=".")
+
+When using a local YAML file, the file name must be the same as the model name without the ZO letters. It must also use snake case style; for example, a YAML file for the `DualMediaFiltrationZO` model must be named `dual_media_filtration.yaml`. See below for the contents of this YAML file.
+
+.. code-block:: yaml
+
+   # Contents of YAML file named dual_media_filtration.yaml
+   # This defines parameter values for the DualMediaFiltrationZO() zero-order model
+
+   default:
+     energy_electric_flow_vol_inlet:
+       value: 0.050718512
+       units: kWh/m^3
+     capital_cost:
+       basis: flow_vol
+       cost_factor: None
+       reference_state:
+         value: 4732.0
+         units: m^3/hr
+       capital_a_parameter:
+         value: 12.17829669e6
+         units: USD_2014
+       capital_b_parameter:
+         value: 0.5862
+         units: dimensionless
+     recovery_frac_mass_H2O:
+       value: 0.99
+       units: dimensionless
+       reference:
+     default_removal_frac_mass_comp:
+       value: 0
+       units: dimensionless
+     removal_frac_mass_comp:
+       nonvolatile_toc:
+         value: 0.2
+         units: dimensionless
+         constituent_longform: Nonvolatile TOC
+       toc:
+         value: 0.2
+         units: dimensionless
+         constituent_longform: Total Organic Carbon (TOC)
+       tss:
+         value: 0.97
+         units: dimensionless
+         constituent_longform: Total Suspended Solids (TSS)

--- a/docs/how_to_guides/how_to_run_zero_order_model.rst
+++ b/docs/how_to_guides/how_to_run_zero_order_model.rst
@@ -1,7 +1,7 @@
 How to run a zero-order model
 -----------------------------
 
-The example below runs the dual media filtration zero-order model. This example uses the default parameters defined in the watertap YAML database.
+The example below runs the dual media filtration zero-order model. This example uses the default parameters defined in the watertap YAML database. The output from running the example is also shown below.
 
 .. testcode::
 
@@ -39,8 +39,6 @@ The example below runs the dual media filtration zero-order model. This example 
 
    if __name__ == "__main__":
        main()
-
-The output from running this example is shown below.
 
 .. testoutput::
 

--- a/docs/how_to_guides/how_to_run_zero_order_model.rst
+++ b/docs/how_to_guides/how_to_run_zero_order_model.rst
@@ -40,7 +40,7 @@ The example below runs the dual media filtration zero-order model. This example 
    if __name__ == "__main__":
        main()
 
-.. testoutput::
+.. code-block:: text
 
    ====================================================================================
    Unit : fs.unit                                                             Time: 0.0

--- a/docs/how_to_guides/index.rst
+++ b/docs/how_to_guides/index.rst
@@ -5,6 +5,7 @@ How To Guides
    :maxdepth: 1
 
    how_to_run_models_in_a_py_script
+   how_to_run_zero_order_model
    how_to_use_a_property_model
    how_to_setup_simple_RO
    how_to_setup_RO_config_options

--- a/docs/technical_reference/unit_models/zero_order_unit_models/index.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/index.rst
@@ -1,5 +1,8 @@
 Zero-Order Unit Models
 ======================
+
+The YAML database files for the zero-order models are located in :code:`watertap/data/techno_economic/`. The YAML file name should match the associated model name without the ZO letters and use snake case style. For example, the YAML file for the :code:`DualMediaFiltrationZO()` zero-order model is named :code:`dual_media_filtration.yaml`.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/technical_reference/unit_models/zero_order_unit_models/index.rst
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/index.rst
@@ -1,7 +1,7 @@
 Zero-Order Unit Models
 ======================
 
-The YAML database files for the zero-order models are located in :code:`watertap/data/techno_economic/`. The YAML file name should match the associated model name without the ZO letters and use snake case style. For example, the YAML file for the :code:`DualMediaFiltrationZO()` zero-order model is named :code:`dual_media_filtration.yaml`.
+The zero-order models rely on default model parameter values specified in YAML files. Users should supply their own values, if possible, instead of relying on the default parameter values. The YAML database files for the zero-order models are located in :code:`watertap/data/techno_economic/`. The name of the YAML file should match the associated model name without the ZO letters and use snake case style. For example, the YAML file for the :code:`DualMediaFiltrationZO()` zero-order model is named :code:`dual_media_filtration.yaml`.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Fixes/Resolves:

This adds some documentation in the How To Guides section for running a zero-order model. This also adds notes regarding the YAML file name associated with a zero-order model and how to use a local YAML database file.

## Summary/Motivation:

There is currently no documentation about running a zero-order model or providing a user defined YAML file. This request adds some documentation to hopefully clarify how to use a zero-order model.

## Changes proposed in this PR:
- Add documentation in the How To Guides section for running a zero-order model
- Add documentation regarding the use of a local YAML file and proper naming of that file for use with a zero-order model

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
