### PR TITLE
[pylint] remove no-self-argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ disable = [
     "no-member", # Pyomo / IDAES metaprogramming, a few other places
     "no-name-in-module", # IDAES metaprogramming
     "undefined-variable", # IDAES metaprogramming, a few other places
-    "no-self-argument", # blk in place of self (several places, some fixed by #911)
     "function-redefined", # several places
     "not-callable", # watertap/core/zero_order_base.py
 ]

--- a/watertap/core/zero_order_properties.py
+++ b/watertap/core/zero_order_properties.py
@@ -158,7 +158,7 @@ class _WaterStateBlock(StateBlock):
     """
 
     def initialize(
-        blk,
+        self,
         state_args=None,
         state_vars_fixed=False,
         hold_state=False,
@@ -212,17 +212,17 @@ class _WaterStateBlock(StateBlock):
         """
         # For now, there are no constraints in the property package, so only
         # fix state variables if required
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         init_log.info("Initialization Complete.")
 
         if hold_state is True:
-            flags = fix_state_vars(blk, state_args)
+            flags = fix_state_vars(self, state_args)
             return flags
         else:
             return
 
-    def release_state(blk, flags, outlvl=idaeslog.NOTSET):
+    def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """
         Method to release state variables fixed during initialization.
 
@@ -233,13 +233,13 @@ class _WaterStateBlock(StateBlock):
                     hold_state=True.
             outlvl : sets output level of of logging
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         if flags is None:
             return
 
         # Unfix state variables
-        revert_state_vars(blk, flags)
+        revert_state_vars(self, flags)
         init_log.info("State Released.")
 
 
@@ -264,11 +264,11 @@ class WaterStateBlockData(StateBlockData):
     # -------------------------------------------------------------------------
     # Other properties
     def _conc_mass_comp(self):
-        def rule_cmc(blk, j):
+        def rule_cmc(self, j):
             return (
-                blk.flow_mass_comp[j]
+                self.flow_mass_comp[j]
                 / sum(self.flow_mass_comp[k] for k in self.component_list)
-                * blk.dens_mass
+                * self.dens_mass
             )
 
         self.conc_mass_comp = Expression(self.component_list, rule=rule_cmc)
@@ -295,16 +295,16 @@ class WaterStateBlockData(StateBlockData):
             doc="Dynamic viscosity of solution",
         )
 
-    def get_material_flow_terms(blk, p, j):
-        return blk.flow_mass_comp[j]
+    def get_material_flow_terms(self, p, j):
+        return self.flow_mass_comp[j]
 
-    def get_enthalpy_flow_terms(blk, p):
+    def get_enthalpy_flow_terms(self, p):
         raise NotImplementedError
 
-    def get_material_density_terms(blk, p, j):
-        return blk.conc_mass_comp[j]
+    def get_material_density_terms(self, p, j):
+        return self.conc_mass_comp[j]
 
-    def get_energy_density_terms(blk, p):
+    def get_energy_density_terms(self, p):
         raise NotImplementedError
 
     def default_material_balance_type(self):
@@ -313,16 +313,16 @@ class WaterStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.none
 
-    def define_state_vars(blk):
-        return {"flow_mass_comp": blk.flow_mass_comp}
+    def define_state_vars(self):
+        return {"flow_mass_comp": self.flow_mass_comp}
 
-    def define_display_vars(blk):
+    def define_display_vars(self):
         return {
-            "Volumetric Flowrate": blk.flow_vol,
-            "Mass Concentration": blk.conc_mass_comp,
+            "Volumetric Flowrate": self.flow_vol,
+            "Mass Concentration": self.conc_mass_comp,
         }
 
-    def get_material_flow_basis(blk):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def calculate_scaling_factors(self):

--- a/watertap/examples/flowsheets/full_treatment_train/model_components/eNRTL/entrl_config_FTPx.py
+++ b/watertap/examples/flowsheets/full_treatment_train/model_components/eNRTL/entrl_config_FTPx.py
@@ -38,12 +38,12 @@ from idaes.models.properties.modular_properties.pure.electrolyte import (
 
 
 class ConstantVolMol:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=18e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 

--- a/watertap/examples/flowsheets/full_treatment_train/model_components/eNRTL/entrl_config_FpcTP.py
+++ b/watertap/examples/flowsheets/full_treatment_train/model_components/eNRTL/entrl_config_FpcTP.py
@@ -38,12 +38,12 @@ from idaes.models.properties.modular_properties.pure.electrolyte import (
 
 
 class ConstantVolMol:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=18e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 

--- a/watertap/examples/flowsheets/full_treatment_train/model_components/seawater_ion_prop_pack.py
+++ b/watertap/examples/flowsheets/full_treatment_train/model_components/seawater_ion_prop_pack.py
@@ -426,7 +426,7 @@ class PropStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def define_state_vars(self):

--- a/watertap/examples/flowsheets/full_treatment_train/model_components/seawater_salt_prop_pack.py
+++ b/watertap/examples/flowsheets/full_treatment_train/model_components/seawater_salt_prop_pack.py
@@ -400,7 +400,7 @@ class PropStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def define_state_vars(self):

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -782,7 +782,7 @@ class NaClStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def define_state_vars(self):

--- a/watertap/property_models/activated_sludge/asm1_properties.py
+++ b/watertap/property_models/activated_sludge/asm1_properties.py
@@ -139,7 +139,7 @@ class _ASM1StateBlock(StateBlock):
     """
 
     def initialize(
-        blk,
+        self,
         state_args=None,
         state_vars_fixed=False,
         hold_state=False,
@@ -191,16 +191,16 @@ class _ASM1StateBlock(StateBlock):
             If hold_states is True, returns a dict containing flags for
             which states were fixed during initialization.
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         if state_vars_fixed is False:
             # Fix state variables if not already fixed
-            flags = fix_state_vars(blk, state_args)
+            flags = fix_state_vars(self, state_args)
 
         else:
             # Check when the state vars are fixed already result in dof 0
-            for k in blk.keys():
-                if degrees_of_freedom(blk[k]) != 0:
+            for k in self.keys():
+                if degrees_of_freedom(self[k]) != 0:
                     raise Exception(
                         "State vars fixed but degrees of freedom "
                         "for state block is not zero during "
@@ -211,11 +211,11 @@ class _ASM1StateBlock(StateBlock):
             if hold_state is True:
                 return flags
             else:
-                blk.release_state(flags)
+                self.release_state(flags)
 
         init_log.info("Initialization Complete.")
 
-    def release_state(blk, flags, outlvl=idaeslog.NOTSET):
+    def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """
         Method to relase state variables fixed during initialization.
 
@@ -226,12 +226,12 @@ class _ASM1StateBlock(StateBlock):
                     hold_state=True.
             outlvl : sets output level of of logging
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         if flags is None:
             return
         # Unfix state variables
-        revert_state_vars(blk, flags)
+        revert_state_vars(self, flags)
         init_log.info("State Released.")
 
 
@@ -359,25 +359,25 @@ class ASM1StateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def define_state_vars(b):
+    def define_state_vars(self):
         return {
-            "flow_vol": b.flow_vol,
-            "alkalinity": b.alkalinity,
-            "conc_mass_comp": b.conc_mass_comp,
-            "temperature": b.temperature,
-            "pressure": b.pressure,
+            "flow_vol": self.flow_vol,
+            "alkalinity": self.alkalinity,
+            "conc_mass_comp": self.conc_mass_comp,
+            "temperature": self.temperature,
+            "pressure": self.pressure,
         }
 
-    def define_display_vars(b):
+    def define_display_vars(self):
         return {
-            "Volumetric Flowrate": b.flow_vol,
-            "Molar Alkalinity": b.alkalinity,
-            "Mass Concentration": b.conc_mass_comp,
-            "Temperature": b.temperature,
-            "Pressure": b.pressure,
+            "Volumetric Flowrate": self.flow_vol,
+            "Molar Alkalinity": self.alkalinity,
+            "Mass Concentration": self.conc_mass_comp,
+            "Temperature": self.temperature,
+            "Pressure": self.pressure,
         }
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def calculate_scaling_factors(self):

--- a/watertap/property_models/activated_sludge/asm1_reactions.py
+++ b/watertap/property_models/activated_sludge/asm1_reactions.py
@@ -350,7 +350,7 @@ class _ASM1ReactionBlock(ReactionBlockBase):
     whole, rather than individual elements of indexed Reaction Blocks.
     """
 
-    def initialize(blk, outlvl=idaeslog.NOTSET, **kwargs):
+    def initialize(self, outlvl=idaeslog.NOTSET, **kwargs):
         """
         Initialization routine for reaction package.
 
@@ -360,7 +360,7 @@ class _ASM1ReactionBlock(ReactionBlockBase):
         Returns:
             None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
         init_log.info("Initialization Complete.")
 
 
@@ -511,5 +511,5 @@ class ASM1ReactionBlockData(ReactionBlockDataBase):
             self.del_component(self.rate_expression)
             raise
 
-    def get_reaction_rate_basis(b):
+    def get_reaction_rate_basis(self):
         return MaterialFlowBasis.mass

--- a/watertap/property_models/activated_sludge/asm2d_reactions.py
+++ b/watertap/property_models/activated_sludge/asm2d_reactions.py
@@ -1006,7 +1006,7 @@ class _ASM2dReactionBlock(ReactionBlockBase):
     whole, rather than individual elements of indexed Reaction Blocks.
     """
 
-    def initialize(blk, outlvl=idaeslog.NOTSET, **kwargs):
+    def initialize(self, outlvl=idaeslog.NOTSET, **kwargs):
         """
         Initialization routine for reaction package.
 
@@ -1016,7 +1016,7 @@ class _ASM2dReactionBlock(ReactionBlockBase):
         Returns:
             None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
         init_log.info("Initialization Complete.")
 
 
@@ -1529,7 +1529,7 @@ class ASM2dReactionBlockData(ReactionBlockDataBase):
             self.del_component(self.rate_expression)
             raise
 
-    def get_reaction_rate_basis(b):
+    def get_reaction_rate_basis(self):
         return MaterialFlowBasis.mass
 
     def calculate_scaling_factors(self):

--- a/watertap/property_models/anaerobic_digestion/adm1_properties.py
+++ b/watertap/property_models/anaerobic_digestion/adm1_properties.py
@@ -157,7 +157,7 @@ class _ADM1StateBlock(StateBlock):
     """
 
     def initialize(
-        blk,
+        self,
         state_args=None,
         state_vars_fixed=False,
         hold_state=False,
@@ -202,16 +202,16 @@ class _ADM1StateBlock(StateBlock):
             If hold_states is True, returns a dict containing flags for
             which states were fixed during initialization.
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         if state_vars_fixed is False:
             # Fix state variables if not already fixed
-            flags = fix_state_vars(blk, state_args)
+            flags = fix_state_vars(self, state_args)
 
         else:
             # Check when the state vars are fixed already result in dof 0
-            for k in blk.keys():
-                if degrees_of_freedom(blk[k]) != 0:
+            for k in self.keys():
+                if degrees_of_freedom(self[k]) != 0:
                     raise Exception(
                         "State vars fixed but degrees of freedom "
                         "for state block is not zero during "
@@ -222,11 +222,11 @@ class _ADM1StateBlock(StateBlock):
             if hold_state is True:
                 return flags
             else:
-                blk.release_state(flags)
+                self.release_state(flags)
 
         init_log.info("Initialization Complete.")
 
-    def release_state(blk, flags, outlvl=idaeslog.NOTSET):
+    def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """
         Method to release state variables fixed during initialization.
 
@@ -237,12 +237,12 @@ class _ADM1StateBlock(StateBlock):
                     hold_state=True.
             outlvl : sets output level of logging
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         if flags is None:
             return
         # Unfix state variables
-        revert_state_vars(blk, flags)
+        revert_state_vars(self, flags)
         init_log.info("State Released.")
 
 
@@ -388,27 +388,27 @@ class ADM1StateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def define_state_vars(b):
+    def define_state_vars(self):
         return {
-            "flow_vol": b.flow_vol,
-            "anions": b.anions,
-            "cations": b.cations,
-            "conc_mass_comp": b.conc_mass_comp,
-            "temperature": b.temperature,
-            "pressure": b.pressure,
+            "flow_vol": self.flow_vol,
+            "anions": self.anions,
+            "cations": self.cations,
+            "conc_mass_comp": self.conc_mass_comp,
+            "temperature": self.temperature,
+            "pressure": self.pressure,
         }
 
-    def define_display_vars(b):
+    def define_display_vars(self):
         return {
-            "Volumetric Flowrate": b.flow_vol,
-            "Molar anions": b.anions,
-            "Molar cations": b.cations,
-            "Mass Concentration": b.conc_mass_comp,
-            "Temperature": b.temperature,
-            "Pressure": b.pressure,
+            "Volumetric Flowrate": self.flow_vol,
+            "Molar anions": self.anions,
+            "Molar cations": self.cations,
+            "Mass Concentration": self.conc_mass_comp,
+            "Temperature": self.temperature,
+            "Pressure": self.pressure,
         }
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def calculate_scaling_factors(self):

--- a/watertap/property_models/anaerobic_digestion/adm1_properties_vapor.py
+++ b/watertap/property_models/anaerobic_digestion/adm1_properties_vapor.py
@@ -130,7 +130,7 @@ class _ADM1_vaporStateBlock(StateBlock):
     """
 
     def initialize(
-        blk,
+        self,
         state_args=None,
         state_vars_fixed=False,
         hold_state=False,
@@ -176,16 +176,16 @@ class _ADM1_vaporStateBlock(StateBlock):
             If hold_states is True, returns a dict containing flags for
             which states were fixed during initialization.
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         if state_vars_fixed is False:
             # Fix state variables if not already fixed
-            flags = fix_state_vars(blk, state_args)
+            flags = fix_state_vars(self, state_args)
 
         else:
             # Check when the state vars are fixed already result in dof 0
-            for k in blk.keys():
-                if degrees_of_freedom(blk[k]) != 0:
+            for k in self.keys():
+                if degrees_of_freedom(self[k]) != 0:
                     raise Exception(
                         "State vars fixed but degrees of freedom "
                         "for state block is not zero during "
@@ -196,11 +196,11 @@ class _ADM1_vaporStateBlock(StateBlock):
             if hold_state is True:
                 return flags
             else:
-                blk.release_state(flags)
+                self.release_state(flags)
 
         init_log.info("Initialization Complete.")
 
-    def release_state(blk, flags, outlvl=idaeslog.NOTSET):
+    def release_state(self, flags, outlvl=idaeslog.NOTSET):
         """
         Method to release state variables fixed during initialization.
 
@@ -211,12 +211,12 @@ class _ADM1_vaporStateBlock(StateBlock):
                     hold_state=True.
             outlvl : sets output level of logging
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
 
         if flags is None:
             return
         # Unfix state variables
-        revert_state_vars(blk, flags)
+        revert_state_vars(self, flags)
         init_log.info("State Released.")
 
 
@@ -405,23 +405,23 @@ class ADM1_vaporStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def define_state_vars(b):
+    def define_state_vars(self):
         return {
-            "flow_vol": b.flow_vol,
-            "conc_mass_comp": b.conc_mass_comp,
-            "temperature": b.temperature,
-            "pressure": b.pressure,
+            "flow_vol": self.flow_vol,
+            "conc_mass_comp": self.conc_mass_comp,
+            "temperature": self.temperature,
+            "pressure": self.pressure,
         }
 
-    def define_display_vars(b):
+    def define_display_vars(self):
         return {
-            "Volumetric Flowrate": b.flow_vol,
-            "Mass Concentration": b.conc_mass_comp,
-            "Temperature": b.temperature,
-            "Pressure": b.pressure,
+            "Volumetric Flowrate": self.flow_vol,
+            "Mass Concentration": self.conc_mass_comp,
+            "Temperature": self.temperature,
+            "Pressure": self.pressure,
         }
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def calculate_scaling_factors(self):

--- a/watertap/property_models/anaerobic_digestion/adm1_reactions.py
+++ b/watertap/property_models/anaerobic_digestion/adm1_reactions.py
@@ -1154,7 +1154,7 @@ class _ADM1ReactionBlock(ReactionBlockBase):
     whole, rather than individual elements of indexed Reaction Blocks.
     """
 
-    def initialize(blk, outlvl=idaeslog.NOTSET, **kwargs):
+    def initialize(self, outlvl=idaeslog.NOTSET, **kwargs):
         """
         Initialization routine for reaction package.
 
@@ -1164,7 +1164,7 @@ class _ADM1ReactionBlock(ReactionBlockBase):
         Returns:
             None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="properties")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="properties")
         init_log.info("Initialization Complete.")
 
 
@@ -1798,7 +1798,7 @@ class ADM1ReactionBlockData(ReactionBlockDataBase):
         iscale.set_scaling_factor(self.K_a_co2, 1e7)
         iscale.set_scaling_factor(self.K_a_IN, 1e9)
 
-    def get_reaction_rate_basis(b):
+    def get_reaction_rate_basis(self):
         return MaterialFlowBasis.mass
 
     def calculate_scaling_factors(self):

--- a/watertap/property_models/coagulation_prop_pack.py
+++ b/watertap/property_models/coagulation_prop_pack.py
@@ -666,7 +666,7 @@ class CoagulationStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def define_state_vars(self):

--- a/watertap/property_models/cryst_prop_pack.py
+++ b/watertap/property_models/cryst_prop_pack.py
@@ -1859,7 +1859,7 @@ class NaClStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def define_state_vars(self):

--- a/watertap/property_models/seawater_ion_generic.py
+++ b/watertap/property_models/seawater_ion_generic.py
@@ -49,72 +49,72 @@ _log = idaeslog.getLogger(__name__)
 
 
 class VolMolH2O:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=18e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 
 class VolMolNaCl:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=58.44e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 
 class VolMolNa2SO4:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=142.04e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 
 class VolMolCaCl2:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=110.98e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 
 class VolMolCaSO4:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=136.14e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 
 class VolMolMgCl2:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=95.21e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 
 class VolMolMgSO4:
-    def build_parameters(b):
-        b.vol_mol_pure = Param(
+    def build_parameters(self):
+        self.vol_mol_pure = Param(
             initialize=120.37e-6, units=pyunits.m**3 / pyunits.mol, mutable=True
         )
 
-    def return_expression(b, cobj, T):
+    def return_expression(self, cobj, T):
         return cobj.vol_mol_pure
 
 

--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -1590,7 +1590,7 @@ class SeawaterStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def define_state_vars(self):

--- a/watertap/property_models/water_prop_pack.py
+++ b/watertap/property_models/water_prop_pack.py
@@ -952,7 +952,7 @@ class WaterStateBlockData(StateBlockData):
     def default_energy_balance_type(self):
         return EnergyBalanceType.enthalpyTotal
 
-    def get_material_flow_basis(b):
+    def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
 
     def define_state_vars(self):

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -75,6 +75,7 @@ class ModelExport(BaseModel):
         arbitrary_types_allowed = True
 
     @validator("obj", always=True, pre=True)
+    @classmethod
     def ensure_obj_is_supported(cls, v):
         if v is not None:
             cls._ensure_supported_type(v)
@@ -112,6 +113,7 @@ class ModelExport(BaseModel):
 
     # Get value from object
     @validator("value", always=True)
+    @classmethod
     def validate_value(cls, v, values):
         if values.get("obj", None) is None:
             return v
@@ -120,6 +122,7 @@ class ModelExport(BaseModel):
 
     # Derive display_units from ui_units
     @validator("display_units", always=True)
+    @classmethod
     def validate_units(cls, v, values):
         if not v:
             u = values.get("ui_units", pyo.units.dimensionless)
@@ -128,6 +131,7 @@ class ModelExport(BaseModel):
 
     # set name dynamically from object
     @validator("name", always=True)
+    @classmethod
     def validate_name(cls, v, values):
         if not v:
             obj = cls._get_supported_obj(values, allow_none=False)
@@ -138,6 +142,7 @@ class ModelExport(BaseModel):
         return v
 
     @validator("is_readonly", always=True, pre=True)
+    @classmethod
     def set_readonly_default(cls, v, values):
         if v is None:
             v = True
@@ -147,6 +152,7 @@ class ModelExport(BaseModel):
         return v
 
     @validator("obj_key", always=True, pre=True)
+    @classmethod
     def set_obj_key_default(cls, v, values):
         if v is None:
             obj = cls._get_supported_obj(values, allow_none=False)
@@ -166,6 +172,7 @@ class FlowsheetExport(BaseModel):
 
     # set name dynamically from object
     @validator("name", always=True)
+    @classmethod
     def validate_name(cls, v, values):
         if not v:
             try:
@@ -177,6 +184,7 @@ class FlowsheetExport(BaseModel):
         return v
 
     @validator("description", always=True)
+    @classmethod
     def validate_description(cls, v, values):
         if not v:
             try:

--- a/watertap/unit_models/coag_floc_model.py
+++ b/watertap/unit_models/coag_floc_model.py
@@ -863,7 +863,7 @@ class CoagulationFlocculationData(InitializationMixin, UnitModelBlockData):
 
     # initialize method
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -884,14 +884,14 @@ class CoagulationFlocculationData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
         # Set solver options
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
         # Initialize holdup block
-        flags = blk.control_volume.initialize(
+        flags = self.control_volume.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -903,16 +903,16 @@ class CoagulationFlocculationData(InitializationMixin, UnitModelBlockData):
         # ---------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 2 {}.".format(idaeslog.condition(res)))
 
         # ---------------------------------------------------------------------
         # Release Inlet state
-        blk.control_volume.release_state(flags, outlvl + 1)
+        self.control_volume.release_state(flags, outlvl + 1)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def calculate_scaling_factors(self):
         super().calculate_scaling_factors()

--- a/watertap/unit_models/electrodialysis_0D.py
+++ b/watertap/unit_models/electrodialysis_0D.py
@@ -1549,7 +1549,7 @@ class Electrodialysis0DData(InitializationMixin, UnitModelBlockData):
 
     # initialize method
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -1570,35 +1570,35 @@ class Electrodialysis0DData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
         # Set solver options
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
 
         # Set the outlet has the same intial condition of the inlet.
-        for k in blk.keys():
-            for j in blk[k].config.property_package.component_list:
-                blk[k].diluate.properties_out[0].flow_mol_phase_comp["Liq", j] = value(
-                    blk[k].diluate.properties_in[0].flow_mol_phase_comp["Liq", j]
+        for k in self.keys():
+            for j in self[k].config.property_package.component_list:
+                self[k].diluate.properties_out[0].flow_mol_phase_comp["Liq", j] = value(
+                    self[k].diluate.properties_in[0].flow_mol_phase_comp["Liq", j]
                 )
-                blk[k].concentrate.properties_out[0].flow_mol_phase_comp[
+                self[k].concentrate.properties_out[0].flow_mol_phase_comp[
                     "Liq", j
                 ] = value(
-                    blk[k].concentrate.properties_in[0].flow_mol_phase_comp["Liq", j]
+                    self[k].concentrate.properties_in[0].flow_mol_phase_comp["Liq", j]
                 )
-        if hasattr(blk[k], "conc_mem_surf_mol_ioa"):
-            for mem in blk[k].membrane_set:
-                for side in blk[k].electrode_side:
-                    for j in blk[k].ion_set:
-                        blk[k].conc_mem_surf_mol_ioa[mem, side, 0, j].set_value(
-                            blk[k]
+        if hasattr(self[k], "conc_mem_surf_mol_ioa"):
+            for mem in self[k].membrane_set:
+                for side in self[k].electrode_side:
+                    for j in self[k].ion_set:
+                        self[k].conc_mem_surf_mol_ioa[mem, side, 0, j].set_value(
+                            self[k]
                             .concentrate.properties_in[0]
                             .conc_mol_phase_comp["Liq", j]
                         )
         # Initialize diluate block
-        flags_diluate = blk.diluate.initialize(
+        flags_diluate = self.diluate.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -1608,7 +1608,7 @@ class Electrodialysis0DData(InitializationMixin, UnitModelBlockData):
         init_log.info_high("Initialization Step 1 Complete.")
         # ---------------------------------------------------------------------
         # Initialize concentrate_side block
-        flags_concentrate = blk.concentrate.initialize(
+        flags_concentrate = self.concentrate.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -1619,17 +1619,17 @@ class Electrodialysis0DData(InitializationMixin, UnitModelBlockData):
         # ---------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 3 {}.".format(idaeslog.condition(res)))
         # ---------------------------------------------------------------------
         # Release state
-        blk.diluate.release_state(flags_diluate, outlvl)
+        self.diluate.release_state(flags_diluate, outlvl)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
-        blk.concentrate.release_state(flags_concentrate, outlvl)
+        self.concentrate.release_state(flags_concentrate, outlvl)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def calculate_scaling_factors(self):
         super().calculate_scaling_factors()

--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -1936,7 +1936,7 @@ class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
 
     # Intialization routines
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -1961,14 +1961,14 @@ class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
         # Set solver options
         opt = get_solver(solver, optarg)
         # Set the intial conditions over the 1D length from the state vars
-        for k in blk.keys():
-            for set in blk[k].diluate.properties:
-                if ("flow_mol_phase_comp" or "flow_mass_phase_comp") not in blk[
+        for k in self.keys():
+            for set in self[k].diluate.properties:
+                if ("flow_mol_phase_comp" or "flow_mass_phase_comp") not in self[
                     k
                 ].diluate.properties[set].define_state_vars():
                     raise ConfigurationError(
@@ -1976,48 +1976,52 @@ class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
                         "either a 'flow_mol_phase_comp' or 'flow_mass_phase_comp' "
                         "state variable basis to apply the 'propogate_initial_state' method"
                     )
-                if "temperature" in blk[k].diluate.properties[set].define_state_vars():
-                    blk[k].diluate.properties[set].temperature = value(
-                        blk[k].diluate.properties[(0.0, 0.0)].temperature
+                if "temperature" in self[k].diluate.properties[set].define_state_vars():
+                    self[k].diluate.properties[set].temperature = value(
+                        self[k].diluate.properties[(0.0, 0.0)].temperature
                     )
-                if "pressure" in blk[k].diluate.properties[set].define_state_vars():
-                    blk[k].diluate.properties[set].pressure = value(
-                        blk[k].diluate.properties[(0.0, 0.0)].pressure
+                if "pressure" in self[k].diluate.properties[set].define_state_vars():
+                    self[k].diluate.properties[set].pressure = value(
+                        self[k].diluate.properties[(0.0, 0.0)].pressure
                     )
                 if (
                     "flow_mol_phase_comp"
-                    in blk[k].diluate.properties[set].define_state_vars()
+                    in self[k].diluate.properties[set].define_state_vars()
                 ):
-                    for ind in blk[k].diluate.properties[set].flow_mol_phase_comp:
-                        blk[k].diluate.properties[set].flow_mol_phase_comp[ind] = value(
-                            blk[k]
+                    for ind in self[k].diluate.properties[set].flow_mol_phase_comp:
+                        self[k].diluate.properties[set].flow_mol_phase_comp[
+                            ind
+                        ] = value(
+                            self[k]
                             .diluate.properties[(0.0, 0.0)]
                             .flow_mol_phase_comp[ind]
                         )
                 if (
                     "flow_mass_phase_comp"
-                    in blk[k].diluate.properties[set].define_state_vars()
+                    in self[k].diluate.properties[set].define_state_vars()
                 ):
-                    for ind in blk[k].diluate.properties[set].flow_mass_phase_comp:
-                        blk[k].diluate.properties[set].flow_mass_phase_comp[
+                    for ind in self[k].diluate.properties[set].flow_mass_phase_comp:
+                        self[k].diluate.properties[set].flow_mass_phase_comp[
                             ind
                         ] = value(
-                            blk[k]
+                            self[k]
                             .diluate.properties[(0.0, 0.0)]
                             .flow_mass_phase_comp[ind]
                         )
-                if hasattr(blk[k], "conc_mem_surf_mol_x"):
-                    for mem in blk[k].membrane_set:
-                        for side in blk[k].electrode_side_set:
-                            for j in blk[k].ion_set:
-                                blk[k].conc_mem_surf_mol_x[mem, side, set, j].set_value(
-                                    blk[k]
+                if hasattr(self[k], "conc_mem_surf_mol_x"):
+                    for mem in self[k].membrane_set:
+                        for side in self[k].electrode_side_set:
+                            for j in self[k].ion_set:
+                                self[k].conc_mem_surf_mol_x[
+                                    mem, side, set, j
+                                ].set_value(
+                                    self[k]
                                     .diluate.properties[set]
                                     .conc_mol_phase_comp["Liq", j]
                                 )
 
-            for set in blk[k].concentrate.properties:
-                if ("flow_mol_phase_comp" or "flow_mass_phase_comp") not in blk[
+            for set in self[k].concentrate.properties:
+                if ("flow_mol_phase_comp" or "flow_mass_phase_comp") not in self[
                     k
                 ].concentrate.properties[set].define_state_vars():
                     raise ConfigurationError(
@@ -2027,67 +2031,72 @@ class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
                     )
                 if (
                     "temperature"
-                    in blk[k].concentrate.properties[set].define_state_vars()
+                    in self[k].concentrate.properties[set].define_state_vars()
                 ):
-                    blk[k].concentrate.properties[set].temperature = value(
-                        blk[k].concentrate.properties[(0.0, 0.0)].temperature
+                    self[k].concentrate.properties[set].temperature = value(
+                        self[k].concentrate.properties[(0.0, 0.0)].temperature
                     )
-                if "pressure" in blk[k].concentrate.properties[set].define_state_vars():
-                    blk[k].concentrate.properties[set].pressure = value(
-                        blk[k].concentrate.properties[(0.0, 0.0)].pressure
+                if (
+                    "pressure"
+                    in self[k].concentrate.properties[set].define_state_vars()
+                ):
+                    self[k].concentrate.properties[set].pressure = value(
+                        self[k].concentrate.properties[(0.0, 0.0)].pressure
                     )
                 if (
                     "flow_mol_phase_comp"
-                    in blk[k].concentrate.properties[set].define_state_vars()
+                    in self[k].concentrate.properties[set].define_state_vars()
                 ):
-                    for ind in blk[k].concentrate.properties[set].flow_mol_phase_comp:
-                        blk[k].concentrate.properties[set].flow_mol_phase_comp[
+                    for ind in self[k].concentrate.properties[set].flow_mol_phase_comp:
+                        self[k].concentrate.properties[set].flow_mol_phase_comp[
                             ind
                         ] = value(
-                            blk[k]
+                            self[k]
                             .concentrate.properties[(0.0, 0.0)]
                             .flow_mol_phase_comp[ind]
                         )
                 if (
                     "flow_mass_phase_comp"
-                    in blk[k].concentrate.properties[set].define_state_vars()
+                    in self[k].concentrate.properties[set].define_state_vars()
                 ):
-                    for ind in blk[k].concentrate.properties[set].flow_mass_phase_comp:
-                        blk[k].concentrate.properties[set].flow_mass_phase_comp[
+                    for ind in self[k].concentrate.properties[set].flow_mass_phase_comp:
+                        self[k].concentrate.properties[set].flow_mass_phase_comp[
                             ind
                         ] = value(
-                            blk[k]
+                            self[k]
                             .concentrate.properties[(0.0, 0.0)]
                             .flow_mass_phase_comp[ind]
                         )
-                if hasattr(blk[k], "conc_mem_surf_mol_x"):
-                    for mem in blk[k].membrane_set:
-                        for side in blk[k].electrode_side_set:
-                            for j in blk[k].ion_set:
-                                blk[k].conc_mem_surf_mol_x[mem, side, set, j].set_value(
-                                    blk[k]
+                if hasattr(self[k], "conc_mem_surf_mol_x"):
+                    for mem in self[k].membrane_set:
+                        for side in self[k].electrode_side_set:
+                            for j in self[k].ion_set:
+                                self[k].conc_mem_surf_mol_x[
+                                    mem, side, set, j
+                                ].set_value(
+                                    self[k]
                                     .concentrate.properties[set]
                                     .conc_mol_phase_comp["Liq", j]
                                 )
-                blk[k].total_areal_resistance_x[set].set_value(
+                self[k].total_areal_resistance_x[set].set_value(
                     (
-                        blk[k].membrane_areal_resistance["aem"]
-                        + blk[k].membrane_areal_resistance["cem"]
-                        + blk[k].channel_height
+                        self[k].membrane_areal_resistance["aem"]
+                        + self[k].membrane_areal_resistance["cem"]
+                        + self[k].channel_height
                         * (
-                            blk[k].concentrate.properties[set].elec_cond_phase["Liq"]
+                            self[k].concentrate.properties[set].elec_cond_phase["Liq"]
                             ** -1
-                            + blk[k].diluate.properties[set].elec_cond_phase["Liq"]
+                            + self[k].diluate.properties[set].elec_cond_phase["Liq"]
                             ** -1
                         )
                     )
-                    * blk[k].cell_pair_num
-                    + blk[k].electrodes_resistance
+                    * self[k].cell_pair_num
+                    + self[k].electrodes_resistance
                 )
 
         # ---------------------------------------------------------------------
         # Initialize diluate block
-        flags_diluate = blk.diluate.initialize(
+        flags_diluate = self.diluate.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -2097,10 +2106,10 @@ class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
         init_log.info_high("Initialization Step 1 Complete.")
         # ---------------------------------------------------------------------
         if not ignore_dof:
-            check_dof(blk, fail_flag=fail_on_warning, logger=init_log)
+            check_dof(self, fail_flag=fail_on_warning, logger=init_log)
 
         # Initialize concentrate block
-        flags_concentrate = blk.concentrate.initialize(
+        flags_concentrate = self.concentrate.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -2111,7 +2120,7 @@ class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
         # ---------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 3 {}.".format(idaeslog.condition(res)))
         check_solve(
             res,
@@ -2121,12 +2130,12 @@ class Electrodialysis1DData(InitializationMixin, UnitModelBlockData):
         )
         # ---------------------------------------------------------------------
         # Release state
-        blk.diluate.release_state(flags_diluate, outlvl)
-        blk.concentrate.release_state(flags_concentrate, outlvl)
+        self.diluate.release_state(flags_diluate, outlvl)
+        self.concentrate.release_state(flags_concentrate, outlvl)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def calculate_scaling_factors(self):
         super().calculate_scaling_factors()

--- a/watertap/unit_models/gac.py
+++ b/watertap/unit_models/gac.py
@@ -1044,7 +1044,7 @@ class GACData(InitializationMixin, UnitModelBlockData):
     # ---------------------------------------------------------------------
     # initialize method
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -1065,8 +1065,8 @@ class GACData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
         # Set solver options
         opt = get_solver(solver, optarg)
 
@@ -1074,8 +1074,8 @@ class GACData(InitializationMixin, UnitModelBlockData):
         # Set state_args from inlet state
         if state_args is None:
             state_args = {}
-            state_dict = blk.process_flow.properties_in[
-                blk.flowsheet().config.time.first()
+            state_dict = self.process_flow.properties_in[
+                self.flowsheet().config.time.first()
             ].define_port_members()
 
             for k in state_dict.keys():
@@ -1089,14 +1089,14 @@ class GACData(InitializationMixin, UnitModelBlockData):
         # specify conditions to solve at a feasible point during initialization
         # necessary to invert user provided scaling factor due to
         # low values creating infeasible initialization conditions
-        for j in blk.config.property_package.component_list:
+        for j in self.config.property_package.component_list:
             temp_scale = iscale.get_scaling_factor(
-                blk.process_flow.properties_in[0].flow_mol_phase_comp["Liq", j]
+                self.process_flow.properties_in[0].flow_mol_phase_comp["Liq", j]
             )
             state_args["flow_mol_phase_comp"][("Liq", j)] = temp_scale**-1
 
         # Initialize control volume
-        flags = blk.process_flow.initialize(
+        flags = self.process_flow.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -1106,10 +1106,10 @@ class GACData(InitializationMixin, UnitModelBlockData):
         init_log.info_high("Initialization Step 1 Complete.")
         # ---------------------------------------------------------------------
         # Initialize adsorbed_contam port
-        for j in blk.config.property_package.component_list:
-            if j in blk.config.target_species:
+        for j in self.config.property_package.component_list:
+            if j in self.config.target_species:
                 temp_scale = iscale.get_scaling_factor(
-                    blk.process_flow.properties_in[0].flow_mol_phase_comp["Liq", j]
+                    self.process_flow.properties_in[0].flow_mol_phase_comp["Liq", j]
                 )
                 state_args["flow_mol_phase_comp"][("Liq", j)] = temp_scale**-1
             else:
@@ -1117,7 +1117,7 @@ class GACData(InitializationMixin, UnitModelBlockData):
                     ("Liq", j)
                 ] = 0  # all non-adsorbed species initialized to 0
 
-        blk.adsorbed_contam.initialize(
+        self.adsorbed_contam.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -1128,15 +1128,15 @@ class GACData(InitializationMixin, UnitModelBlockData):
         # --------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 3 {}.".format(idaeslog.condition(res)))
         # ---------------------------------------------------------------------
         # Release Inlet state
-        blk.process_flow.release_state(flags, outlvl + 1)
+        self.process_flow.release_state(flags, outlvl + 1)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     # ---------------------------------------------------------------------
 

--- a/watertap/unit_models/ion_exchange_0D.py
+++ b/watertap/unit_models/ion_exchange_0D.py
@@ -1135,7 +1135,7 @@ class IonExchangeODData(InitializationMixin, UnitModelBlockData):
             return b.number_columns * b.col_vol_per
 
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -1156,13 +1156,13 @@ class IonExchangeODData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
 
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
-        flags = blk.properties_in.initialize(
+        flags = self.properties_in.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -1174,9 +1174,9 @@ class IonExchangeODData(InitializationMixin, UnitModelBlockData):
         # Initialize other state blocks
         # Set state_args from inlet state
         if state_args is None:
-            blk.state_args = state_args = {}
-            state_dict = blk.properties_in[
-                blk.flowsheet().config.time.first()
+            self.state_args = state_args = {}
+            state_dict = self.properties_in[
+                self.flowsheet().config.time.first()
             ].define_port_members()
 
             for k in state_dict.keys():
@@ -1187,13 +1187,13 @@ class IonExchangeODData(InitializationMixin, UnitModelBlockData):
                 else:
                     state_args[k] = state_dict[k].value
         state_args_out = deepcopy(state_args)
-        for p, j in blk.properties_out.phase_component_set:
-            if j == blk.config.target_ion:
+        for p, j in self.properties_out.phase_component_set:
+            if j == self.config.target_ion:
                 state_args_out["flow_mol_phase_comp"][(p, j)] = (
                     state_args["flow_mol_phase_comp"][(p, j)] * 1e-5
                 )
 
-        blk.properties_out.initialize(
+        self.properties_out.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -1203,50 +1203,50 @@ class IonExchangeODData(InitializationMixin, UnitModelBlockData):
 
         state_args_regen = deepcopy(state_args)
 
-        for p, j in blk.properties_regen.phase_component_set:
+        for p, j in self.properties_regen.phase_component_set:
             if j == "H2O":
                 state_args_regen["flow_mol_phase_comp"][(p, j)] = (
                     state_args["flow_mol_phase_comp"][(p, j)] * 0.01
                 )
-            elif j != blk.config.target_ion:
+            elif j != self.config.target_ion:
                 state_args_regen["flow_mol_phase_comp"][(p, j)] = (
                     state_args["flow_mol_phase_comp"][(p, j)] * 1e-8
                 )
-            elif j == blk.config.target_ion:
+            elif j == self.config.target_ion:
                 state_args_regen["flow_mol_phase_comp"][(p, j)] = (
                     state_args["flow_mol_phase_comp"][(p, j)] * 1e3
                 )
 
-        blk.properties_regen.initialize(
+        self.properties_regen.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
             state_args=state_args_regen,
         )
 
-        blk.state_args_out = state_args_out
-        blk.state_args_regen = state_args_regen
+        self.state_args_out = state_args_out
+        self.state_args_regen = state_args_regen
 
         init_log.info("Initialization Step 1c Complete.")
 
         # Solve unit with coupling constraints deactivated
-        blk.eq_flow_conservation.deactivate()
+        self.eq_flow_conservation.deactivate()
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info("Initialization Step 2 {}.".format(idaeslog.condition(res)))
-        blk.eq_flow_conservation.activate()
+        self.eq_flow_conservation.activate()
 
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info("Initialization Step 3 {}.".format(idaeslog.condition(res)))
         # ---------------------------------------------------------------------
         # Release Inlet state
-        blk.properties_in.release_state(flags, outlvl=outlvl)
+        self.properties_in.release_state(flags, outlvl=outlvl)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def calculate_scaling_factors(self):
         super().calculate_scaling_factors()

--- a/watertap/unit_models/mvc/components/compressor.py
+++ b/watertap/unit_models/mvc/components/compressor.py
@@ -255,7 +255,7 @@ class CompressorData(InitializationMixin, UnitModelBlockData):
             )
 
     def initialize_build(
-        blk, state_args=None, outlvl=idaeslog.NOTSET, solver=None, optarg=None
+        self, state_args=None, outlvl=idaeslog.NOTSET, solver=None, optarg=None
     ):
         """
         General wrapper for pressure changer initialization routines
@@ -272,14 +272,14 @@ class CompressorData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
         # Set solver options
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
         # Initialize state blocks
-        flags = blk.control_volume.initialize(
+        flags = self.control_volume.initialize(
             solver=solver, optarg=optarg, hold_state=True
         )
 
@@ -288,8 +288,8 @@ class CompressorData(InitializationMixin, UnitModelBlockData):
         # Set state_args from inlet state
         if state_args is None:
             state_args = {}
-            state_dict = blk.control_volume.properties_in[
-                blk.flowsheet().config.time.first()
+            state_dict = self.control_volume.properties_in[
+                self.flowsheet().config.time.first()
             ].define_port_members()
 
             for k in state_dict.keys():
@@ -300,7 +300,7 @@ class CompressorData(InitializationMixin, UnitModelBlockData):
                 else:
                     state_args[k] = state_dict[k].value
 
-        blk.properties_isentropic_out.initialize(
+        self.properties_isentropic_out.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -311,16 +311,16 @@ class CompressorData(InitializationMixin, UnitModelBlockData):
         # ---------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 3 {}.".format(idaeslog.condition(res)))
 
         # ---------------------------------------------------------------------
         # Release Inlet state
-        blk.control_volume.release_state(flags, outlvl=outlvl)
+        self.control_volume.release_state(flags, outlvl=outlvl)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def _get_performance_contents(self, time_point=0):
         var_dict = {}

--- a/watertap/unit_models/nanofiltration_0D.py
+++ b/watertap/unit_models/nanofiltration_0D.py
@@ -533,7 +533,7 @@ class NanoFiltrationData(InitializationMixin, UnitModelBlockData):
             )
 
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -554,14 +554,14 @@ class NanoFiltrationData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
         # Set solver options
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
         # Initialize holdup block
-        flags = blk.feed_side.initialize(
+        flags = self.feed_side.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -573,8 +573,8 @@ class NanoFiltrationData(InitializationMixin, UnitModelBlockData):
         # Set state_args from inlet state
         if state_args is None:
             state_args = {}
-            state_dict = blk.feed_side.properties_in[
-                blk.flowsheet().config.time.first()
+            state_dict = self.feed_side.properties_in[
+                self.flowsheet().config.time.first()
             ].define_port_members()
 
             for k in state_dict.keys():
@@ -585,7 +585,7 @@ class NanoFiltrationData(InitializationMixin, UnitModelBlockData):
                 else:
                     state_args[k] = state_dict[k].value
 
-        blk.properties_permeate.initialize(
+        self.properties_permeate.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -596,16 +596,16 @@ class NanoFiltrationData(InitializationMixin, UnitModelBlockData):
         # ---------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 3 {}.".format(idaeslog.condition(res)))
 
         # ---------------------------------------------------------------------
         # Release Inlet state
-        blk.feed_side.release_state(flags, outlvl + 1)
+        self.feed_side.release_state(flags, outlvl + 1)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def _get_performance_contents(self, time_point=0):
         # TODO: make a unit specific stream table

--- a/watertap/unit_models/nanofiltration_ZO.py
+++ b/watertap/unit_models/nanofiltration_ZO.py
@@ -474,7 +474,7 @@ class NanofiltrationData(InitializationMixin, UnitModelBlockData):
             )
 
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -495,14 +495,14 @@ class NanofiltrationData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
 
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
         # Initialize holdup block
-        flags = blk.feed_side.initialize(
+        flags = self.feed_side.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -514,8 +514,8 @@ class NanofiltrationData(InitializationMixin, UnitModelBlockData):
         # Set state_args from inlet state
         if state_args is None:
             state_args = {}
-            state_dict = blk.feed_side.properties_in[
-                blk.flowsheet().config.time.first()
+            state_dict = self.feed_side.properties_in[
+                self.flowsheet().config.time.first()
             ].define_port_members()
 
             for k in state_dict.keys():
@@ -526,7 +526,7 @@ class NanofiltrationData(InitializationMixin, UnitModelBlockData):
                 else:
                     state_args[k] = state_dict[k].value
 
-        blk.properties_permeate.initialize(
+        self.properties_permeate.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -537,16 +537,16 @@ class NanofiltrationData(InitializationMixin, UnitModelBlockData):
         # ---------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 3 {}.".format(idaeslog.condition(res)))
 
         # ---------------------------------------------------------------------
         # Release Inlet state
-        blk.feed_side.release_state(flags, outlvl + 1)
+        self.feed_side.release_state(flags, outlvl + 1)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def _get_performance_contents(self, time_point=0):
         for k in ("ion_set", "solute_set"):

--- a/watertap/unit_models/uv_aop.py
+++ b/watertap/unit_models/uv_aop.py
@@ -720,7 +720,7 @@ class Ultraviolet0DData(InitializationMixin, UnitModelBlockData):
             )
 
     def initialize_build(
-        blk,
+        self,
         state_args=None,
         outlvl=idaeslog.NOTSET,
         solver=None,
@@ -741,14 +741,14 @@ class Ultraviolet0DData(InitializationMixin, UnitModelBlockData):
 
         Returns: None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
         # Set solver options
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
         # Initialize holdup block
-        flags = blk.control_volume.initialize(
+        flags = self.control_volume.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -760,8 +760,8 @@ class Ultraviolet0DData(InitializationMixin, UnitModelBlockData):
         # Set state_args from inlet state
         if state_args is None:
             state_args = {}
-            state_dict = blk.control_volume.properties_in[
-                blk.flowsheet().config.time.first()
+            state_dict = self.control_volume.properties_in[
+                self.flowsheet().config.time.first()
             ].define_port_members()
 
             for k in state_dict.keys():
@@ -777,16 +777,16 @@ class Ultraviolet0DData(InitializationMixin, UnitModelBlockData):
         # ---------------------------------------------------------------------
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info_high("Initialization Step 3 {}.".format(idaeslog.condition(res)))
 
         # ---------------------------------------------------------------------
         # Release Inlet state
-        blk.control_volume.release_state(flags, outlvl + 1)
+        self.control_volume.release_state(flags, outlvl + 1)
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
-            raise InitializationError(f"Unit model {blk.name} failed to initialize")
+            raise InitializationError(f"Unit model {self.name} failed to initialize")
 
     def _get_performance_contents(self, time_point=0):
         # TODO: add other performance constants

--- a/watertap/unit_models/zero_order/feed_zo.py
+++ b/watertap/unit_models/zero_order/feed_zo.py
@@ -151,7 +151,7 @@ class FeedZOData(InitializationMixin, FeedData):
             )
 
     def initialize_build(
-        blk, state_args=None, outlvl=idaeslog.NOTSET, solver=None, optarg=None
+        self, state_args=None, outlvl=idaeslog.NOTSET, solver=None, optarg=None
     ):
         """
         This method calls the initialization method of the Feed state block.
@@ -171,8 +171,8 @@ class FeedZOData(InitializationMixin, FeedData):
             None
         """
         # ---------------------------------------------------------------------
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
 
         if optarg is None:
             optarg = {}
@@ -183,16 +183,16 @@ class FeedZOData(InitializationMixin, FeedData):
             state_args = {}
 
         # Initialize state block
-        blk.properties.initialize(
+        self.properties.initialize(
             outlvl=outlvl, optarg=optarg, solver=solver, state_args=state_args
         )
 
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = opt.solve(blk, tee=slc.tee)
+            res = opt.solve(self, tee=slc.tee)
         init_log.info("Initialization complete: {}.".format(idaeslog.condition(res)))
 
         if not check_optimal_termination(res):
             raise InitializationError(
-                f"{blk.name} failed to initialize successfully. Please check "
+                f"{self.name} failed to initialize successfully. Please check "
                 f"the output logs for more information."
             )


### PR DESCRIPTION
## Part of #914 

## Summary/Motivation:
Fixes code in WaterTAP violating the no-self-argument rule for Pylint.

## Changes proposed in this PR:
- Change all instances of `blk` or `b` to `self` where appropriate
- Add a few `@classmethod` decorators where appropriate
- Drive by change `initialize` to `initialize_build` for the crystallizer unit

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
