### PR TITLE
[pylint] not-callable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ disable = [
     "no-name-in-module", # IDAES metaprogramming
     "undefined-variable", # IDAES metaprogramming, a few other places
     "function-redefined", # several places
-    "not-callable", # watertap/core/zero_order_base.py
 ]
 # see https://pylint.readthedocs.io/en/latest/user_guide/messages/messages_overview.html
 # for a list of all messages

--- a/watertap/core/tests/test_zero_order_base.py
+++ b/watertap/core/tests/test_zero_order_base.py
@@ -15,6 +15,7 @@ Tests for general zero-order base class
 """
 import pytest
 
+from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.exceptions import ConfigurationError
 from pyomo.environ import ConcreteModel, Var, units as pyunits
@@ -41,9 +42,9 @@ def test_private_attributes():
     assert m.fs.unit._tech_type is None
     assert m.fs.unit._has_recovery_removal is False
     assert m.fs.unit._fixed_perf_vars == []
-    assert m.fs.unit._initialize is None
-    assert m.fs.unit._scaling is None
-    assert m.fs.unit._get_Q is None
+    assert m.fs.unit._initialize == MethodType(ZeroOrderBaseData._initialize, m.fs.unit)
+    assert m.fs.unit._scaling == MethodType(ZeroOrderBaseData._scaling, m.fs.unit)
+    assert m.fs.unit._get_Q == MethodType(ZeroOrderBaseData._get_Q, m.fs.unit)
     assert m.fs.unit._stream_table_dict == {}
     assert m.fs.unit._perf_var_dict == {}
 

--- a/watertap/core/tests/test_zero_order_diso.py
+++ b/watertap/core/tests/test_zero_order_diso.py
@@ -15,6 +15,7 @@ Tests for zero-order DISO unit model
 """
 import pytest
 
+from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
@@ -83,9 +84,11 @@ class TestDISO:
         assert model.fs.unit._tech_type is None
         assert model.fs.unit._has_recovery_removal is True
         assert model.fs.unit._fixed_perf_vars == []
-        assert model.fs.unit._initialize is initialize_diso
-        assert model.fs.unit._scaling is calculate_scaling_factors_diso
-        assert model.fs.unit._get_Q is _get_Q_diso
+        assert model.fs.unit._initialize == MethodType(initialize_diso, model.fs.unit)
+        assert model.fs.unit._scaling == MethodType(
+            calculate_scaling_factors_diso, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(_get_Q_diso, model.fs.unit)
         assert model.fs.unit._stream_table_dict == {
             "Inlet 1": model.fs.unit.inlet1,
             "Inlet 2": model.fs.unit.inlet2,

--- a/watertap/core/tests/test_zero_order_electricity.py
+++ b/watertap/core/tests/test_zero_order_electricity.py
@@ -15,6 +15,7 @@ Tests for general zero-order property package
 """
 import pytest
 
+from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.solvers import get_solver
@@ -49,7 +50,7 @@ class DerivedZOData(ZeroOrderBaseData):
     def build(self):
         super().build()
 
-        self._get_Q = get_Q
+        self._get_Q = MethodType(get_Q, self)
 
 
 class TestConstantIntensity:

--- a/watertap/core/tests/test_zero_order_electricity.py
+++ b/watertap/core/tests/test_zero_order_electricity.py
@@ -87,9 +87,13 @@ class TestConstantIntensity:
         assert model.fs.unit._fixed_perf_vars == [
             model.fs.unit.energy_electric_flow_vol_inlet
         ]
-        assert model.fs.unit._initialize is None
-        assert model.fs.unit._scaling is None
-        assert model.fs.unit._get_Q is get_Q
+        assert model.fs.unit._initialize == MethodType(
+            ZeroOrderBaseData._initialize, model.fs.unit
+        )
+        assert model.fs.unit._scaling == MethodType(
+            ZeroOrderBaseData._scaling, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(get_Q, model.fs.unit)
         assert model.fs.unit._perf_var_dict == {
             "Electricity Demand": model.fs.unit.electricity,
             "Electricity Intensity": model.fs.unit.energy_electric_flow_vol_inlet,
@@ -157,9 +161,13 @@ class TestPumpElectricity:
     def test_private_attributes(self, model):
         assert model.fs.unit._tech_type is None
         assert model.fs.unit._has_recovery_removal is False
-        assert model.fs.unit._initialize is None
-        assert model.fs.unit._scaling is None
-        assert model.fs.unit._get_Q is get_Q
+        assert model.fs.unit._initialize == MethodType(
+            ZeroOrderBaseData._initialize, model.fs.unit
+        )
+        assert model.fs.unit._scaling == MethodType(
+            ZeroOrderBaseData._scaling, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(get_Q, model.fs.unit)
         assert model.fs.unit._perf_var_dict == {
             "Electricity Demand": model.fs.unit.electricity
         }

--- a/watertap/core/tests/test_zero_order_pt.py
+++ b/watertap/core/tests/test_zero_order_pt.py
@@ -15,6 +15,7 @@ Tests for general zero-order property package
 """
 import pytest
 
+from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.solvers import get_solver
@@ -64,9 +65,11 @@ class TestPT:
         assert model.fs.unit._tech_type is None
         assert model.fs.unit._has_recovery_removal is False
         assert model.fs.unit._fixed_perf_vars == []
-        assert model.fs.unit._initialize is initialize_pt
-        assert model.fs.unit._scaling is calculate_scaling_factors_pt
-        assert model.fs.unit._get_Q is _get_Q_pt
+        assert model.fs.unit._initialize == MethodType(initialize_pt, model.fs.unit)
+        assert model.fs.unit._scaling == MethodType(
+            calculate_scaling_factors_pt, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(_get_Q_pt, model.fs.unit)
         assert model.fs.unit._stream_table_dict == {
             "Inlet": model.fs.unit.inlet,
             "Outlet": model.fs.unit.outlet,

--- a/watertap/core/tests/test_zero_order_sido.py
+++ b/watertap/core/tests/test_zero_order_sido.py
@@ -15,6 +15,7 @@ Tests for general zero-order property package
 """
 import pytest
 
+from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
@@ -78,9 +79,11 @@ class TestSIDO:
         assert model.fs.unit._tech_type is None
         assert model.fs.unit._has_recovery_removal is True
         assert model.fs.unit._fixed_perf_vars == []
-        assert model.fs.unit._initialize is initialize_sido
-        assert model.fs.unit._scaling is calculate_scaling_factors_sido
-        assert model.fs.unit._get_Q is _get_Q_sido
+        assert model.fs.unit._initialize == MethodType(initialize_sido, model.fs.unit)
+        assert model.fs.unit._scaling == MethodType(
+            calculate_scaling_factors_sido, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(_get_Q_sido, model.fs.unit)
         assert model.fs.unit._stream_table_dict == {
             "Inlet": model.fs.unit.inlet,
             "Treated": model.fs.unit.treated,

--- a/watertap/core/tests/test_zero_order_sido_reactive.py
+++ b/watertap/core/tests/test_zero_order_sido_reactive.py
@@ -15,6 +15,7 @@ Tests for general zero-order property package
 """
 import pytest
 import os
+from types import MethodType
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -87,9 +88,11 @@ class TestSIDOR:
     def test_private_attributes(self, model):
         assert model.fs.unit._has_recovery_removal is True
         assert model.fs.unit._fixed_perf_vars == []
-        assert model.fs.unit._initialize is initialize_sidor
-        assert model.fs.unit._scaling is calculate_scaling_factors_sidor
-        assert model.fs.unit._get_Q is _get_Q_sidor
+        assert model.fs.unit._initialize == MethodType(initialize_sidor, model.fs.unit)
+        assert model.fs.unit._scaling == MethodType(
+            calculate_scaling_factors_sidor, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(_get_Q_sidor, model.fs.unit)
         assert model.fs.unit._stream_table_dict == {
             "Inlet": model.fs.unit.inlet,
             "Treated": model.fs.unit.treated,

--- a/watertap/core/tests/test_zero_order_siso.py
+++ b/watertap/core/tests/test_zero_order_siso.py
@@ -14,6 +14,7 @@
 Tests for zero-order SISO unit model
 """
 import pytest
+from types import MethodType
 
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -78,9 +79,11 @@ class TestSISO:
         assert model.fs.unit._tech_type is None
         assert model.fs.unit._has_recovery_removal is True
         assert model.fs.unit._fixed_perf_vars == []
-        assert model.fs.unit._initialize is initialize_siso
-        assert model.fs.unit._scaling is calculate_scaling_factors_siso
-        assert model.fs.unit._get_Q is _get_Q_siso
+        assert model.fs.unit._initialize == MethodType(initialize_siso, model.fs.unit)
+        assert model.fs.unit._scaling == MethodType(
+            calculate_scaling_factors_siso, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(_get_Q_siso, model.fs.unit)
         assert model.fs.unit._stream_table_dict == {
             "Inlet": model.fs.unit.inlet,
             "Treated": model.fs.unit.treated,

--- a/watertap/core/zero_order_diso.py
+++ b/watertap/core/zero_order_diso.py
@@ -15,6 +15,7 @@ This module contains the methods for constructing the material balances for
 zero-order double-input/single-output (DISO) unit models (i.e. units with two inlets and single
 outlet where composition changes, such as a generic bioreactor).
 """
+from types import MethodType
 
 import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
@@ -58,8 +59,8 @@ def build_diso(self):
     the inlet volumetric flow rate.
     """
     self._has_recovery_removal = True
-    self._initialize = initialize_diso
-    self._scaling = calculate_scaling_factors_diso
+    self._initialize = MethodType(initialize_diso, self)
+    self._scaling = MethodType(calculate_scaling_factors_diso, self)
 
     # Create state blocks for inlet and outlets
     tmp_dict = dict(**self.config.property_package_args)
@@ -136,7 +137,7 @@ def build_diso(self):
     self._perf_var_dict["Water Recovery"] = self.recovery_frac_mass_H2O
     self._perf_var_dict["Solute Removal"] = self.removal_frac_mass_comp
 
-    self._get_Q = _get_Q_diso
+    self._get_Q = MethodType(_get_Q_diso, self)
 
 
 def initialize_diso(

--- a/watertap/core/zero_order_pt.py
+++ b/watertap/core/zero_order_pt.py
@@ -15,6 +15,7 @@ This module contains the methods for constructing the material balances for
 zero-order pass-through unit models (i.e. units with a single inlet and single
 outlet where flow and composition do not change, such as pumps).
 """
+from types import MethodType
 from pyomo.environ import check_optimal_termination
 
 import idaes.logger as idaeslog
@@ -44,8 +45,8 @@ def build_pt(self):
     the inlet volumetric flow rate.
     """
     self._has_recovery_removal = False
-    self._initialize = initialize_pt
-    self._scaling = calculate_scaling_factors_pt
+    self._initialize = MethodType(initialize_pt, self)
+    self._scaling = MethodType(calculate_scaling_factors_pt, self)
 
     # Create state blocks for inlet and outlet
     tmp_dict = dict(**self.config.property_package_args)
@@ -62,7 +63,7 @@ def build_pt(self):
 
     self._stream_table_dict = {"Inlet": self.inlet, "Outlet": self.outlet}
 
-    self._get_Q = _get_Q_pt
+    self._get_Q = MethodType(_get_Q_pt, self)
 
 
 def initialize_pt(

--- a/watertap/core/zero_order_sido.py
+++ b/watertap/core/zero_order_sido.py
@@ -14,6 +14,7 @@
 This module contains methods for constructing the material balances for
 zero-order single inlet-double outlet (SIDO) unit models.
 """
+from types import MethodType
 
 import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
@@ -59,8 +60,8 @@ def build_sido(self):
     the inlet volumetric flow rate.
     """
     self._has_recovery_removal = True
-    self._initialize = initialize_sido
-    self._scaling = calculate_scaling_factors_sido
+    self._initialize = MethodType(initialize_sido, self)
+    self._scaling = MethodType(calculate_scaling_factors_sido, self)
 
     # Create state blocks for inlet and outlets
     tmp_dict = dict(**self.config.property_package_args)
@@ -156,7 +157,7 @@ def build_sido(self):
     self._perf_var_dict["Water Recovery"] = self.recovery_frac_mass_H2O
     self._perf_var_dict["Solute Removal"] = self.removal_frac_mass_comp
 
-    self._get_Q = _get_Q_sido
+    self._get_Q = MethodType(_get_Q_sido, self)
 
 
 def initialize_sido(

--- a/watertap/core/zero_order_sido_reactive.py
+++ b/watertap/core/zero_order_sido_reactive.py
@@ -15,6 +15,7 @@ This module contains methods for constructing the material balances for
 zero-order single inlet-double outlet (SIDO) unit models with chemical
 reactions.
 """
+from types import MethodType
 
 import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
@@ -62,8 +63,8 @@ def build_sido_reactive(self):
     the inlet volumetric flow rate.
     """
     self._has_recovery_removal = True
-    self._initialize = initialize_sidor
-    self._scaling = calculate_scaling_factors_sidor
+    self._initialize = MethodType(initialize_sidor, self)
+    self._scaling = MethodType(calculate_scaling_factors_sidor, self)
 
     # Create state blocks for inlet and outlets
     tmp_dict = dict(**self.config.property_package_args)
@@ -326,7 +327,7 @@ def build_sido_reactive(self):
     self._perf_var_dict["Solute Removal"] = self.removal_frac_mass_comp
     self._perf_var_dict["Reaction Extent"] = self.extent_of_reaction
 
-    self._get_Q = _get_Q_sidor
+    self._get_Q = MethodType(_get_Q_sidor, self)
 
 
 def initialize_sidor(

--- a/watertap/core/zero_order_siso.py
+++ b/watertap/core/zero_order_siso.py
@@ -15,6 +15,7 @@ This module contains the methods for constructing the material balances for
 zero-order single-input/single-output (SISO) unit models (i.e. units with a single inlet and single
 outlet where composition changes, such as a generic bioreactor).
 """
+from types import MethodType
 
 import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
@@ -58,8 +59,8 @@ def build_siso(self):
     the inlet volumetric flow rate.
     """
     self._has_recovery_removal = True
-    self._initialize = initialize_siso
-    self._scaling = calculate_scaling_factors_siso
+    self._initialize = MethodType(initialize_siso, self)
+    self._scaling = MethodType(calculate_scaling_factors_siso, self)
 
     # Create state blocks for inlet and outlets
     tmp_dict = dict(**self.config.property_package_args)
@@ -123,7 +124,7 @@ def build_siso(self):
 
     self._perf_var_dict["Solute Removal"] = self.removal_frac_mass_comp
 
-    self._get_Q = _get_Q_siso
+    self._get_Q = MethodType(_get_Q_siso, self)
 
 
 def initialize_siso(

--- a/watertap/unit_models/zero_order/gas_sparged_membrane_zo.py
+++ b/watertap/unit_models/zero_order/gas_sparged_membrane_zo.py
@@ -13,6 +13,7 @@
 """
 This module contains a zero-order representation of a gas-sparged membrane unit.
 """
+from types import MethodType
 from idaes.core import declare_process_block_class
 
 from watertap.core import pump_electricity, ZeroOrderBaseData
@@ -65,8 +66,8 @@ class GasSpargedMembraneZOData(ZeroOrderBaseData):
         self._tech_type = "gas_sparged_membrane"
 
         self._has_recovery_removal = True
-        self._initialize = initialize_sido
-        self._scaling = calculate_scaling_factors_gas_extraction
+        self._initialize = MethodType(initialize_sido, self)
+        self._scaling = MethodType(calculate_scaling_factors_gas_extraction, self)
 
         # Create state blocks for inlet and outlets
         tmp_dict = dict(**self.config.property_package_args)
@@ -205,7 +206,7 @@ class GasSpargedMembraneZOData(ZeroOrderBaseData):
         self._perf_var_dict["Water Recovery"] = self.recovery_frac_mass_H2O
         self._perf_var_dict["Solute Removal"] = self.removal_frac_mass_comp
 
-        self._get_Q = _get_Q_gas_extraction
+        self._get_Q = MethodType(_get_Q_gas_extraction, self)
 
         self._Q = Reference(self.properties_in[:].flow_vol)
         pump_electricity(self, self._Q)

--- a/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
+++ b/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
@@ -15,7 +15,7 @@ Tests for zero-order gas-sparged membrane unit
 """
 import pytest
 
-
+from types import MethodType
 from idaes.core import FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
@@ -68,9 +68,11 @@ class TestGasSpargedMembraneZO:
         assert model.fs.unit.config.database is model.db
 
         assert model.fs.unit._has_recovery_removal is True
-        assert model.fs.unit._initialize is initialize_sido
-        assert model.fs.unit._scaling is calculate_scaling_factors_gas_extraction
-        assert model.fs.unit._get_Q is _get_Q_gas_extraction
+        assert model.fs.unit._initialize == MethodType(initialize_sido, model.fs.unit)
+        assert model.fs.unit._scaling == MethodType(
+            calculate_scaling_factors_gas_extraction, model.fs.unit
+        )
+        assert model.fs.unit._get_Q == MethodType(_get_Q_gas_extraction, model.fs.unit)
         assert model.fs.unit._stream_table_dict == {
             "Inlet": model.fs.unit.inlet,
             "Treated": model.fs.unit.treated,


### PR DESCRIPTION
## Part of #914 

## Summary/Motivation:
Fix pylint's `not-callable` error throughout WaterTAP

## Changes proposed in this PR:
- Upgrade the function references `_initialize`, `_scaling` and `_get_Q` to proper methods on the ZeroOrderBase class
- Update tests and "derived" classes appropriately.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
