### PR TITLE
[pylint] function-redefined

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ disable = [
     "no-member", # Pyomo / IDAES metaprogramming, a few other places
     "no-name-in-module", # IDAES metaprogramming
     "undefined-variable", # IDAES metaprogramming, a few other places
-    "function-redefined", # several places
 ]
 # see https://pylint.readthedocs.io/en/latest/user_guide/messages/messages_overview.html
 # for a list of all messages

--- a/watertap/core/membrane_channel_base.py
+++ b/watertap/core/membrane_channel_base.py
@@ -424,7 +424,7 @@ class MembraneChannelMixin:
             solute_set,
             doc="Concentration polarization modulus",
         )
-        def eq_cp_modulus(b, t, x, j):
+        def eq_cp_modulus(b, t, x, j):  # pylint: disable=function-redefined
             if b._skip_element(x):
                 return Constraint.Skip
             return (

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
@@ -233,7 +233,7 @@ def build(erd_type=None):
     )
 
     @m.fs.tb_desal_psttrt.Constraint(["H2O", "TDS"])
-    def eq_flow_mass_comp(blk, j):
+    def eq_flow_mass_comp(blk, j):  # pylint: disable=function-redefined
         if j == "TDS":
             jj = "tds"
         else:

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_magprex/magprex.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_magprex/magprex.py
@@ -156,15 +156,9 @@ def solve(blk, solver=None, tee=False, check_termination=True):
 
 
 def display_results(m):
-    print("\n+++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
-    print("++++++++++++++++++++ DISPLAY RESULTS ++++++++++++++++++++")
-    print("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
-
     unit_list = ["feed", "magprex", "centrifuge", "classifier"]
     for u in unit_list:
         m.fs.component(u).report()
-
-    print("\n+++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
 
 
 def add_costing(m):
@@ -255,28 +249,6 @@ def add_costing(m):
         ),
         doc="Levelized cost of struvite",
     )
-
-
-def initialize_system(m):
-    seq = SequentialDecomposition()
-    seq.options.tear_set = []
-    seq.options.iterLim = 1
-    seq.run(m, lambda u: u.initialize())
-
-
-def solve(blk, solver=None, tee=False, check_termination=True):
-    if solver is None:
-        solver = get_solver()
-    results = solver.solve(blk, tee=tee)
-    if check_termination:
-        assert_optimal_termination(results)
-    return results
-
-
-def display_results(m):
-    unit_list = ["feed", "magprex", "centrifuge", "classifier"]
-    for u in unit_list:
-        m.fs.component(u).report()
 
 
 def display_costing(m):

--- a/watertap/unit_models/pressure_exchanger.py
+++ b/watertap/unit_models/pressure_exchanger.py
@@ -287,7 +287,7 @@ class PressureExchangerData(InitializationMixin, UnitModelBlockData):
             self.flowsheet().config.time,
             doc="Work transferred to low pressure side fluid",
         )
-        def work(b, t):
+        def work(b, t):  # pylint: disable=function-redefined
             return b.properties_in[t].flow_vol * b.deltaP[t]
 
         # Add Ports


### PR DESCRIPTION
## Part of #914 

## Summary/Motivation:
Enable `function-redefined` error for pylint

## Changes proposed in this PR:
- Clean up an example flowsheet with multiple function definitions
- Add exceptions in a few places which utilize the Pyomo `@Constraint` decorator (to avoid changing the underlying model).

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
