### PR TITLE
Switch to nl_v1 (for now)

### DIFF
--- a/watertap/core/plugins/solvers.py
+++ b/watertap/core/plugins/solvers.py
@@ -12,6 +12,7 @@
 ###############################################################################
 
 import pyomo.environ as pyo
+from pyomo.opt import WriterFactory
 from pyomo.core.base.block import _BlockData
 from pyomo.core.kernel.block import IBlock
 from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
@@ -25,6 +26,7 @@ from idaes.core.util.scaling import (
 from idaes.logger import getLogger
 
 _log = getLogger("watertap.core")
+_default_nl_writer = WriterFactory.get_class("nl")
 
 
 @pyo.SolverFactory.register(
@@ -54,6 +56,9 @@ class IpoptWaterTAP(IPOPT):
             self.options["tol"] = 1e-08
         if "constr_viol_tol" not in self.options:
             self.options["constr_viol_tol"] = 1e-08
+
+        # temporarily switch to nl_v1 writer
+        WriterFactory.register("nl")(WriterFactory.get_class("nl_v1"))
 
         if not self._is_user_scaling():
             self._cleanup_needed = False
@@ -148,6 +153,7 @@ class IpoptWaterTAP(IPOPT):
             raise
 
     def _cleanup(self):
+        WriterFactory.register("nl")(_default_nl_writer)
         if self._cleanup_needed:
             self._reset_scaling_factors()
             self._reset_bounds()

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -15,6 +15,7 @@ import pytest
 import pyomo.environ as pyo
 import idaes.core.util.scaling as iscale
 
+from pyomo.opt import WriterFactory
 from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
 from pyomo.common.errors import ApplicationError
 from idaes.core.util.scaling import (
@@ -23,6 +24,8 @@ from idaes.core.util.scaling import (
 )
 from idaes.core.solvers import get_solver
 from watertap.core.plugins.solvers import IpoptWaterTAP
+
+_default_nl_writer = WriterFactory.get_class("nl")
 
 
 class TestIpoptWaterTAP:
@@ -60,6 +63,11 @@ class TestIpoptWaterTAP:
     @pytest.fixture(scope="class")
     def s(self):
         return pyo.SolverFactory("ipopt-watertap")
+
+    @pytest.mark.unit
+    def test_nl_writer_held_harmless(self, m, s):
+        s.solve(m, tee=True)
+        assert _default_nl_writer == WriterFactory.get_class("nl")
 
     @pytest.mark.unit
     def test_pyomo_registration(self, s):

--- a/watertap/core/util/tests/test_infeasible.py
+++ b/watertap/core/util/tests/test_infeasible.py
@@ -108,7 +108,7 @@ abcon near LB of 0
         assert (
             captured.out
             == """VAR a: 20 </= UB 10
-VAR b: -20 >/= LB -10
+VAR b: LB -10 </= -20
 """
         )
 


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
Test are failing on `main` with Pyomo 6.5.0

## Changes proposed in this PR:
- Switch ipopt-watertap to use nl_v1 writer until #929 is resolved
- Fix failing infeasibility util test for Pyomo 6.5.0

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
