### PR TITLE
Remove myst parser for Markdown support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.doctest",
-    "myst_parser",
     "nbsphinx",  # Jupyter notebooks as docs
 ]
 
@@ -85,26 +84,6 @@ html_logo = "_static/NAWI_logo.png"
 # pixels large.
 #
 html_favicon = "_static/favicon.ico"
-
-## for MyST (Markdown)
-
-myst_enable_extensions = [
-    "dollarmath",
-    "amsmath",
-    "deflist",
-    "html_admonition",
-    "html_image",
-    "colon_fence",
-    "smartquotes",
-    "replacements",
-    "linkify",
-    "substitution",
-    "tasklist",
-]
-myst_heading_anchors = 2
-myst_footnote_transition = True
-myst_dmath_double_inline = True
-panels_add_bootstrap_css = False
 
 
 def run_apidoc(*args):

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,6 @@ setup(
             "nbmake",
         ],
         "dev": [
-            "myst-parser",  # markdown support for Sphinx
             "nbsphinx",  # jupyter notebook support for sphinx
             "jinja2<3.1.0",  # see watertap-org/watertap#449
             "Sphinx",  # docs


### PR DESCRIPTION
## Fixes/Resolves:

Closes issue #922.

## Summary/Motivation:

None of the documentation uses Markdown files; therefore, Markdown support is not needed for Sphinx.

## Changes proposed in this PR:
- Remove myst parser extension 
- Remove myst parser dependency

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
