### PR TITLE
Add Acid-Base Eq.Constraints to ADM1 Documentation

### DIFF
--- a/docs/technical_reference/property_models/ADM1.rst
+++ b/docs/technical_reference/property_models/ADM1.rst
@@ -196,7 +196,7 @@ Acid-Base Equilibrium Constraints
    "Mass concentration of acetate, ac-", ":math:`C_{ac} = \frac{K_{a,ac} * C_{ac,ref}}{K_{a,ac} + S_{H}}`"
    "Molar concentration of bicarbonate, HCO3", ":math:`M_{hco3} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
    "Molar concentration of ammonia, NH3", ":math:`M_{nh3} = \frac{K_{a,IN} * \frac{C_{S_{IN},ref}}{14}}{K_{a,IN} + S_{H}}`"
-   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{C_{S_{IC},ref}}{12}} - M_{hco3}`"
+   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
    "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14} - M_{nh3}`"
    "Molar concentration of hydrogen, H+", ":math:`0 = M_{c} + M_{nh4} + S_{H} - M_{hco3} - C_{ac} - C_{pro} - C_{bu} - C_{va} - S_{OH} - M_{a}`"
    "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
@@ -230,13 +230,13 @@ The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hy
 
        I_{IN,lim} = \frac{1}{1 + \frac{K_{S_{IN}}}{C_{S_{IN}}/14}}
 
-       I_{h2, fa}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,fa}}}
+       I_{h2, fa}= \frac{1}{1 + \frac{C_{S_{h2}}}{K_{I,h2,fa}}}
 
-       I_{h2, c4}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,c4}}}
+       I_{h2, c4}= \frac{1}{1 + \frac{C_{S_{h2}}}{K_{I,h2,c4}}}
 
-       I_{h2, pro}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,pro}}}
+       I_{h2, pro}= \frac{1}{1 + \frac{C_{S_{h2}}}{K_{I,h2,pro}}}
 
-       I_{nh3}= \frac{1}{1 + \frac{M_{nh3}{K_{I,nh3}}}
+       I_{nh3}= \frac{1}{1 + \frac{M_{nh3}}{K_{I,nh3}}}
 
 
 Classes

--- a/docs/technical_reference/property_models/ADM1.rst
+++ b/docs/technical_reference/property_models/ADM1.rst
@@ -187,9 +187,9 @@ Acid-Base Equilibrium Constraints
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Dissociation constant constraint", ":math:`KW = 10^{-14} exp{\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
-   "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 10^{-6.35} exp{\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
-   "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 10^{-9.25} exp{\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "Dissociation constant constraint", ":math:`KW = 10^{-14} exp{(\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
+   "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 10^{-6.35} exp{(\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
+   "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 10^{-9.25} exp{(\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "Mass concentration of valerate, va-", ":math:`C_{va} = \frac{K_{a,va} * C_{va,ref}}{K_{a,va} + S_{H}}`"
    "Mass concentration of butyrate, bu-", ":math:`C_{bu} = \frac{K_{a,bu} * C_{bu,ref}}{K_{a,bu} + S_{H}}`"
    "Mass concentration of propionate, pro-", ":math:`C_{pro} = \frac{K_{a,pro} * C_{pro,ref}}{K_{a,pro} + S_{H}}`"
@@ -198,7 +198,7 @@ Acid-Base Equilibrium Constraints
    "Molar concentration of ammonia, NH3", ":math:`M_{nh3} = \frac{K_{a,IN} * \frac{C_{S_{IN},ref}}{14}}{K_{a,IN} + S_{H}}`"
    "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
    "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14} - M_{nh3}`"
-   "Molar concentration of hydrogen, H+", ":math:`0 = M_{c} + M_{nh4} + S_{H} - M_{hco3} - C_{ac} - C_{pro} - C_{bu} - C_{va} - S_{OH} - M_{a}`"
+   "Molar concentration of hydrogen, H+", ":math:`S_{H} = M_{hco3} + C_{ac} + C_{pro} + C_{bu} + C_{va} + S_{OH} + M_{a} - M_{c} - M_{nh4}`"
    "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
    "pH of solution", ":math:`pH = -log_{10}(S_{H})`"
 

--- a/docs/technical_reference/property_models/ADM1.rst
+++ b/docs/technical_reference/property_models/ADM1.rst
@@ -139,7 +139,7 @@ Kinetic Parameters
    "First-order decay rate for X_pro, k_dec_X_pro", ":math:`k_{dec,X_{pro}}`", "k_dec_X_pro", 0.02, ":math:`\text{d}^{-1}`"
    "First-order decay rate for X_ac, k_dec_X_ac", ":math:`k_{dec,X_{ac}}`", "k_dec_X_ac", 0.02, ":math:`\text{d}^{-1}`"
    "First-order decay rate for X_h2, k_dec_X_h2", ":math:`k_{dec,X_{h2}}`", "k_dec_X_h2", 0.02, ":math:`\text{d}^{-1}`"
-   "Dissociation constant, KW", ":math:`KW`", "KW", 2.08e-14, ":math:`(\text{kmol/}\text{m}^3)^2`"
+   "Water dissociation constant, KW", ":math:`KW`", "KW", 2.08e-14, ":math:`(\text{kmol/}\text{m}^3)^2`"
    "Valerate acid-base equilibrium constant, K_a_va", ":math:`K_{a,va}`", "K_a_va", 1.38e-5, ":math:`\text{kmol/}\text{m}^3`"
    "Butyrate acid-base equilibrium constant, K_a_bu", ":math:`K_{a,bu}`", "K_a_bu", 1.5e-5, ":math:`\text{kmol/}\text{m}^3`"
    "Propionate acid-base equilibrium constant, K_a_pro", ":math:`K_{a,pro}`", "K_a_bu", 1.32e-5, ":math:`\text{kmol/}\text{m}^3`"

--- a/docs/technical_reference/property_models/ADM1.rst
+++ b/docs/technical_reference/property_models/ADM1.rst
@@ -182,8 +182,8 @@ Process Rate Equations
    "Decay of X_ac", ":math:`\rho_{18} = k_{dec, X_{ac}} C_{X_{ac}}`"
    "Decay of X_h2", ":math:`\rho_{19} = k_{dec, X_{h2}} C_{X_{h2}}`"
 
-Acid-Base Equilibrium Constraints
----------------------------------
+Additional Constraints
+----------------------
 .. csv-table::
    :header: "Description", "Equation"
 
@@ -196,9 +196,9 @@ Acid-Base Equilibrium Constraints
    "Mass concentration of acetate, ac-", ":math:`C_{ac} = \frac{K_{a,ac} * C_{ac,ref}}{K_{a,ac} + S_{H}}`"
    "Molar concentration of bicarbonate, HCO3", ":math:`M_{hco3} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
    "Molar concentration of ammonia, NH3", ":math:`M_{nh3} = \frac{K_{a,IN} * \frac{C_{S_{IN},ref}}{14}}{K_{a,IN} + S_{H}}`"
-   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
+   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{C_{S_{IC},ref}}{12} - M_{hco3}`"
    "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14} - M_{nh3}`"
-   "Molar concentration of hydrogen, H+", ":math:`S_{H} = M_{hco3} + C_{ac} + C_{pro} + C_{bu} + C_{va} + S_{OH} + M_{a} - M_{c} - M_{nh4}`"
+   "Molar concentration of hydrogen, H+", ":math:`S_{H} = M_{hco3} + \frac{C_{ac}}{64} + \frac{C_{pro}}{112} + \frac{C_{bu}}{160} + \frac{C_{va}}{208} + S_{OH} + M_{a} - M_{c} - M_{nh4}`"
    "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
    "pH of solution", ":math:`pH = -log_{10}(S_{H})`"
 
@@ -208,19 +208,19 @@ The rules for pH inhibition of amino-acid-utilizing microorganisms (:math:`I_{pH
 
        I_{pH,aa}=
        \begin{cases}
-         \exp{-3 (\frac{pH - pH_{UL,aa}}{pH_{UL,aa} - pH_{LL,aa}})^2} & \text{for } pH \le pH_{UL,aa}\\
+         \exp{(-3 (\frac{pH - pH_{UL,aa}}{pH_{UL,aa} - pH_{LL,aa}})^2)} & \text{for } pH \le pH_{UL,aa}\\
          1 & \text{for } pH > pH_{UL,aa}
        \end{cases}
 
        I_{pH,ac}=
        \begin{cases}
-         \exp{-3 (\frac{pH - pH_{UL,ac}}{pH_{UL,ac} - pH_{LL,ac}})^2} & \text{for } pH \le pH_{UL,ac}\\
+         \exp{(-3 (\frac{pH - pH_{UL,ac}}{pH_{UL,ac} - pH_{LL,ac}})^2)} & \text{for } pH \le pH_{UL,ac}\\
          1 & \text{for } pH > pH_{UL,ac}
        \end{cases}
 
        I_{pH,h2}=
        \begin{cases}
-         \exp{-3 (\frac{pH - pH_{UL,h2}}{pH_{UL,h2} - pH_{LL,h2}})^2} & \text{for } pH \le pH_{UL,h2}\\
+         \exp{(-3 (\frac{pH - pH_{UL,h2}}{pH_{UL,h2} - pH_{LL,h2}})^2)} & \text{for } pH \le pH_{UL,h2}\\
          1 & \text{for } pH > pH_{UL,h2}
        \end{cases}
 

--- a/docs/technical_reference/property_models/ADM1.rst
+++ b/docs/technical_reference/property_models/ADM1.rst
@@ -187,17 +187,17 @@ Acid-Base Equilibrium Constraints
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Dissociation constant constraint", ":math:`KW = 1e-14^{\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
-   "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 4.46684e-07^{\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
-   "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 5.62341e-10^{\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "Dissociation constant constraint", ":math:`KW = 10^{-14} exp{\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 10^{-6.35} exp{\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 10^{-9.25} exp{\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
    "Mass concentration of valerate, va-", ":math:`C_{va} = \frac{K_{a,va} * C_{va,ref}}{K_{a,va} + S_{H}}`"
    "Mass concentration of butyrate, bu-", ":math:`C_{bu} = \frac{K_{a,bu} * C_{bu,ref}}{K_{a,bu} + S_{H}}`"
    "Mass concentration of propionate, pro-", ":math:`C_{pro} = \frac{K_{a,pro} * C_{pro,ref}}{K_{a,pro} + S_{H}}`"
    "Mass concentration of acetate, ac-", ":math:`C_{ac} = \frac{K_{a,ac} * C_{ac,ref}}{K_{a,ac} + S_{H}}`"
    "Molar concentration of bicarbonate, HCO3", ":math:`M_{hco3} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
    "Molar concentration of ammonia, NH3", ":math:`M_{nh3} = \frac{K_{a,IN} * \frac{C_{S_{IN},ref}}{14}}{K_{a,IN} + S_{H}}`"
-   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
-   "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14}} - M_{nh3}`"
+   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{C_{S_{IC},ref}}{12}} - M_{hco3}`"
+   "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14} - M_{nh3}`"
    "Molar concentration of hydrogen, H+", ":math:`0 = M_{c} + M_{nh4} + S_{H} - M_{hco3} - C_{ac} - C_{pro} - C_{bu} - C_{va} - S_{OH} - M_{a}`"
    "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
    "pH of solution", ":math:`pH = -log_{10}(S_{H})`"
@@ -224,11 +224,11 @@ The rules for pH inhibition of amino-acid-utilizing microorganisms (:math:`I_{pH
          1 & \text{for } pH > pH_{UL,h2}
        \end{cases}
 
-The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hydrogen inhibition attributed to long chain fatty acids (:math:`I_{h2,fa}`), hydrogen inhibition attributed to valerate and butyrate uptake (:math:`I_{h2,c4}`), hydrogen inhibition attributed to propionate uptake (:math:`I_{h2,pro}`), ammonia inibition attributed to acetate uptake (:math:`I_{nh3}`),  are:
+The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hydrogen inhibition attributed to long chain fatty acids (:math:`I_{h2,fa}`), hydrogen inhibition attributed to valerate and butyrate uptake (:math:`I_{h2,c4}`), hydrogen inhibition attributed to propionate uptake (:math:`I_{h2,pro}`), ammonia inibition attributed to acetate uptake (:math:`I_{nh3}`), are:
 
     .. math::
 
-       I_{IN,lim} = \frac{1}{1 + \frac{K_{S_{IN}}}{\frac{C_{S_{IN}}}{14}}
+       I_{IN,lim} = \frac{1}{1 + \frac{K_{S_{IN}}}{C_{S_{IN}}/14}}
 
        I_{h2, fa}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,fa}}}
 

--- a/docs/technical_reference/property_models/ADM1.rst
+++ b/docs/technical_reference/property_models/ADM1.rst
@@ -245,8 +245,8 @@ The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hy
        I_{nh3}= \frac{1}{1 + \frac{M_{nh3}}{K_{I,nh3}}}
 
 
-Classes
--------
+Class Documentation
+-------------------
 .. currentmodule:: watertap.property_models.anaerobic_digestion.adm1_properties
 
 .. autoclass:: ADM1ParameterBlock

--- a/docs/technical_reference/property_models/ADM1.rst
+++ b/docs/technical_reference/property_models/ADM1.rst
@@ -146,8 +146,6 @@ Kinetic Parameters
    "Acetate acid-base equilibrium constant, K_a_ac", ":math:`K_{a,ac}`", "K_a_ac", 1.74e-5, ":math:`\text{kmol/}\text{m}^3`"
    "Carbon dioxide acid-base equilibrium constant, K_a_co2", ":math:`K_{a,co2}`", "K_a_co2", 4.94e-7, ":math:`\text{kmol/}\text{m}^3`"
    "Inorganic nitrogen acid-base equilibrium constant, K_a_IN", ":math:`K_{a,IN}`", "K_a_IN", 1.11e-9, ":math:`\text{kmol/}\text{m}^3`"
-   "Molar concentration of hydrogen, S_H", ":math:`S_{H}`", "S_H", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
-   "Molar concentration of hydroxide, S_OH", ":math:`S_{OH}`", "S_OH", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
 
 Properties
 ----------
@@ -182,12 +180,20 @@ Process Rate Equations
    "Decay of X_ac", ":math:`\rho_{18} = k_{dec, X_{ac}} C_{X_{ac}}`"
    "Decay of X_h2", ":math:`\rho_{19} = k_{dec, X_{h2}} C_{X_{h2}}`"
 
+Additional Variables
+--------------------
+.. csv-table::
+ :header: "Description", "Symbol", "Parameter", "Value at 20 C", "Units"
+
+   "Molar concentration of hydrogen, S_H", ":math:`S_{H}`", "S_H", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
+   "Molar concentration of hydroxide, S_OH", ":math:`S_{OH}`", "S_OH", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
+
 Additional Constraints
 ----------------------
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Dissociation constant constraint", ":math:`KW = 10^{-14} exp{(\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
+   "Water dissociation constant constraint", ":math:`KW = 10^{-14} exp{(\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 10^{-6.35} exp{(\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 10^{-9.25} exp{(\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "Mass concentration of valerate, va-", ":math:`C_{va} = \frac{K_{a,va} * C_{va,ref}}{K_{a,va} + S_{H}}`"

--- a/docs/technical_reference/property_models/ASM1.rst
+++ b/docs/technical_reference/property_models/ASM1.rst
@@ -42,8 +42,8 @@ State variables
    "Total volumetric flowrate", ":math:`Q`", "flow_vol", "None", ":math:`\text{m}^3\text{/s}`"
    "Temperature", ":math:`T`", "temperature", "None", ":math:`\text{K}`"
    "Pressure", ":math:`P`", "pressure", "None", ":math:`\text{Pa}`"
-   "Component mass concentrations", ":math:`C_j`", "conc_mass_comp", "[p]", ":math:`\text{kg/}\text{m}^3`"
-   "Alkalinity in molar concentration", ":math:`A`", "alkalinity", "[p]", ":math:`\text{kmol HCO}_{3}^{-}\text{/m}^{3}`"
+   "Component mass concentrations", ":math:`C_j`", "conc_mass_comp", "[j]", ":math:`\text{kg/}\text{m}^3`"
+   "Alkalinity in molar concentration", ":math:`A`", "alkalinity", "None", ":math:`\text{kmol HCO}_{3}^{-}\text{/m}^{3}`"
 
 Stoichiometric Parameters
 -------------------------

--- a/docs/technical_reference/property_models/ASM1.rst
+++ b/docs/technical_reference/property_models/ASM1.rst
@@ -103,6 +103,44 @@ Scaling
 -------
 Scaling for the ASM1 property package has yet to be implemented.
 
+Class Documentation
+-------------------
+.. currentmodule:: watertap.property_models.activated_sludge.asm1_properties
+
+.. autoclass:: ASM1ParameterBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM1ParameterData
+    :members:
+    :noindex:
+
+.. autoclass:: _ASM1StateBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM1StateBlockData
+    :members:
+    :noindex:
+
+.. currentmodule:: watertap.property_models.activated_sludge.asm1_reactions
+
+.. autoclass:: ASM1ReactionParameterBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM1ReactionParameterData
+    :members:
+    :noindex:
+
+.. autoclass:: _ASM1ReactionBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM1ReactionBlockData
+    :members:
+    :noindex:
+
 
 References
 ----------

--- a/docs/technical_reference/property_models/ASM2D.rst
+++ b/docs/technical_reference/property_models/ASM2D.rst
@@ -164,6 +164,43 @@ Scaling
 -------
 A thorough scaling routine for the ASM2D property package has yet to be implemented.
 
+Class Documentation
+-------------------
+.. currentmodule:: watertap.property_models.activated_sludge.asm2d_properties
+
+.. autoclass:: ASM2dParameterBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM2dParameterData
+    :members:
+    :noindex:
+
+.. autoclass:: _ASM2dStateBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM2dStateBlockData
+    :members:
+    :noindex:
+
+.. currentmodule:: watertap.property_models.activated_sludge.asm2d_reactions
+
+.. autoclass:: ASM2dReactionParameterBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM2dReactionParameterData
+    :members:
+    :noindex:
+
+.. autoclass:: _ASM2dReactionBlock
+    :members:
+    :noindex:
+
+.. autoclass:: ASM2dReactionBlockData
+    :members:
+    :noindex:
 
 References
 ----------

--- a/docs/technical_reference/property_models/ASM2D.rst
+++ b/docs/technical_reference/property_models/ASM2D.rst
@@ -57,8 +57,8 @@ State variables
    "Total volumetric flowrate", ":math:`Q`", "flow_vol", "None", ":math:`\text{m}^3\text{/s}`"
    "Temperature", ":math:`T`", "temperature", "None", ":math:`\text{K}`"
    "Pressure", ":math:`P`", "pressure", "None", ":math:`\text{Pa}`"
-   "Component mass concentrations", ":math:`C_j`", "conc_mass_comp", "[p]", ":math:`\text{kg/}\text{m}^3`"
-   "Molar alkalinity", ":math:`A`", "alkalinity", "[p]", ":math:`\text{kmol HCO}_{3}^{-}\text{/m}^{3}`"
+   "Component mass concentrations", ":math:`C_j`", "conc_mass_comp", "[j]", ":math:`\text{kg/}\text{m}^3`"
+   "Molar alkalinity", ":math:`A`", "alkalinity", "None", ":math:`\text{kmol HCO}_{3}^{-}\text{/m}^{3}`"
 
 Stoichiometric Coefficients
 ---------------------------

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -253,9 +253,9 @@ Acid-Base Equilibrium Constraints
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Dissociation constant constraint", ":math:`KW = 1e-14^{\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
-   "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 4.46684e-07^{\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
-   "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 5.62341e-10^{\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "Dissociation constant constraint", ":math:`KW = 10^{-14} exp{(\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
+   "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 10^{-6.35} exp{(\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
+   "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 10^{-9.25} exp{(\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "Mass concentration of valerate, va-", ":math:`C_{va} = \frac{K_{a,va} * C_{va,ref}}{K_{a,va} + S_{H}}`"
    "Mass concentration of butyrate, bu-", ":math:`C_{bu} = \frac{K_{a,bu} * C_{bu,ref}}{K_{a,bu} + S_{H}}`"
    "Mass concentration of propionate, pro-", ":math:`C_{pro} = \frac{K_{a,pro} * C_{pro,ref}}{K_{a,pro} + S_{H}}`"
@@ -266,7 +266,7 @@ Acid-Base Equilibrium Constraints
    "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14} - M_{nh3}`"
    ":lime:`Molar concentration of magnesium, Mg`", ":math:`M_{Mg} = \frac{C_{X_{PP},ref}}{300.41}`"
    ":lime:`Molar concentration of potassium, K`", ":math:`M_{K} = \frac{C_{X_{PP},ref}}{300.41}`"
-   ":blue:`Molar concentration of hydrogen, H+`", ":math:`0 = M_{c} + M_{nh4} + M_{Mg} + M_{K} + S_{H} - M_{hco3} - C_{ac} - C_{pro} - C_{bu} - C_{va} - S_{OH} - M_{a}`"
+   ":blue:`Molar concentration of hydrogen, H+`", ":math:`S_{H} = M_{hco3} + C_{ac} + C_{pro} + C_{bu} + C_{va} + S_{OH} + M_{a} - M_{c} - M_{nh4} - M_{Mg} - M_{K}`"
    "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
    "pH of solution", ":math:`pH = -log_{10}(S_{H})`"
 

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -201,8 +201,6 @@ Kinetic Parameters
    ":lime:`Magnesium coefficient for polyphosphates, Mg_PP`", ":math:`Mg_{PP}`", "Mg_PP", 1/3, ":math:`\text{dimensionless}`"
    "Carbon dioxide acid-base equilibrium constant, K_a_co2", ":math:`K_{a,co2}`", "K_a_co2", 4.94e-7, ":math:`\text{kmol/}\text{m}^3`"
    "Inorganic nitrogen acid-base equilibrium constant, K_a_IN", ":math:`K_{a,IN}`", "K_a_IN", 1.11e-9, ":math:`\text{kmol/}\text{m}^3`"
-   "Molar concentration of hydrogen, S_H", ":math:`S_{H}`", "S_H", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
-   "Molar concentration of hydroxide, S_OH", ":math:`S_{OH}`", "S_OH", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
 
 Properties
 ----------
@@ -246,6 +244,14 @@ Process Rate Equations
    ":lime:`Lysis of X_PP`", ":math:`\rho_{24} = b_{PP} C_{X_{PP}}`"
    ":lime:`Lysis of X_PHA`", ":math:`\rho_{25} = b_{PHA} C_{X_{PHA}}`"
 
+Additional Variables
+--------------------
+.. csv-table::
+ :header: "Description", "Symbol", "Parameter", "Value at 20 C", "Units"
+
+   "Molar concentration of hydrogen, S_H", ":math:`S_{H}`", "S_H", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
+   "Molar concentration of hydroxide, S_OH", ":math:`S_{OH}`", "S_OH", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
+
 Additional Constraints
 ----------------------
 :lime:`Lime` text indicates the equation has been added, and :blue:`blue` text indicates the equation has been modified from its base ADM1 implementation.
@@ -253,7 +259,7 @@ Additional Constraints
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Dissociation constant constraint", ":math:`KW = 10^{-14} exp{(\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
+   "Water dissociation constant constraint", ":math:`KW = 10^{-14} exp{(\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 10^{-6.35} exp{(\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 10^{-9.25} exp{(\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T}))}`"
    "Mass concentration of valerate, va-", ":math:`C_{va} = \frac{K_{a,va} * C_{va,ref}}{K_{a,va} + S_{H}}`"

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -86,10 +86,12 @@ State variables
    "Total volumetric flowrate", ":math:`Q`", "flow_vol", "None", ":math:`\text{m}^3\text{/s}`"
    "Temperature", ":math:`T`", "temperature", "None", ":math:`\text{K}`"
    "Pressure", ":math:`P`", "pressure", "None", ":math:`\text{Pa}`"
-   "Component mass concentrations", ":math:`C_j`", "conc_mass_comp", "[p]", ":math:`\text{kg/}\text{m}^3`"
+   "Component mass concentrations", ":math:`C_j`", "conc_mass_comp", "[j]", ":math:`\text{kg/}\text{m}^3`"
    "Anions in molar concentrations", ":math:`M_a`", "anions", "None", ":math:`\text{kmol/}\text{m}^3`"
    "Cations in molar concentrations", ":math:`M_c`", "cations", "None", ":math:`\text{kmol/}\text{m}^3`"
-   "Component pressure", ":math:`P_{j,sat}`", "pressure_sat", "[p]", ":math:`\text{Pa}`"
+   "Component pressure", ":math:`P_{j,sat}`", "pressure_sat", "[j]", ":math:`\text{Pa}`"
+   "Reference temperature", ":math:`T_{ref}`", "temperature_ref", "None", ":math:`\text{K}`"
+   "Reference component mass concentrations", ":math:`C_{j,ref}`", "conc_mass_comp_ref", "[j]", ":math:`\text{kg/}\text{m}^3`"
 
 Stoichiometric Parameters
 -------------------------
@@ -199,6 +201,8 @@ Kinetic Parameters
    ":lime:`Magnesium coefficient for polyphosphates, Mg_PP`", ":math:`Mg_{PP}`", "Mg_PP", 1/3, ":math:`\text{dimensionless}`"
    "Carbon dioxide acid-base equilibrium constant, K_a_co2", ":math:`K_{a,co2}`", "K_a_co2", 4.94e-7, ":math:`\text{kmol/}\text{m}^3`"
    "Inorganic nitrogen acid-base equilibrium constant, K_a_IN", ":math:`K_{a,IN}`", "K_a_IN", 1.11e-9, ":math:`\text{kmol/}\text{m}^3`"
+   "Molar concentration of hydrogen, S_H", ":math:`S_{H}`", "S_H", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
+   "Molar concentration of hydroxide, S_OH", ":math:`S_{OH}`", "S_OH", 3.4e-8, ":math:`\text{kmol/}\text{m}^3`"
 
 Properties
 ----------
@@ -242,8 +246,31 @@ Process Rate Equations
    ":lime:`Lysis of X_PP`", ":math:`\rho_{24} = b_{PP} C_{X_{PP}}`"
    ":lime:`Lysis of X_PHA`", ":math:`\rho_{25} = b_{PHA} C_{X_{PHA}}`"
 
+Acid-Base Equilibrium Constraints
+---------------------------------
+:lime:`Lime` text indicates the equation has been added, and :blue:`blue` text indicates the equation has been modified from its base ADM1 implementation.
 
-The rules for pH inhibition of amino-acid-utilizing microorganisms (:math:`I_{pH,aa}`), acetate-utilizing microorganisms (:math:`I_{pH,ac}`), hydrogen-utilizing microorganisms (:math:`I_{pH,h2}`) are:
+.. csv-table::
+   :header: "Description", "Equation"
+
+   "Dissociation constant constraint", ":math:`KW = 1e-14^{\frac{55900}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "CO2 acid-base equilibrium constraint", ":math:`K_{a,co2} = 4.46684e-07^{\frac{7646}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "Nitrogen acid-base equilibrium constraint", ":math:`K_{a,IN} = 5.62341e-10^{\frac{51965}{R} * (\frac{1}{T_{ref}} - \frac{1}{T})}`"
+   "Mass concentration of valerate, va-", ":math:`C_{va} = \frac{K_{a,va} * C_{va,ref}}{K_{a,va} + S_{H}}`"
+   "Mass concentration of butyrate, bu-", ":math:`C_{bu} = \frac{K_{a,bu} * C_{bu,ref}}{K_{a,bu} + S_{H}}`"
+   "Mass concentration of propionate, pro-", ":math:`C_{pro} = \frac{K_{a,pro} * C_{pro,ref}}{K_{a,pro} + S_{H}}`"
+   "Mass concentration of acetate, ac-", ":math:`C_{ac} = \frac{K_{a,ac} * C_{ac,ref}}{K_{a,ac} + S_{H}}`"
+   "Molar concentration of bicarbonate, HCO3", ":math:`M_{hco3} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
+   "Molar concentration of ammonia, NH3", ":math:`M_{nh3} = \frac{K_{a,IN} * \frac{C_{S_{IN},ref}}{14}}{K_{a,IN} + S_{H}}`"
+   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
+   "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14}} - M_{nh3}`"
+   ":lime:`Molar concentration of magnesium, Mg`", ":math:`M_{Mg} = \frac{C_{X_{PP},ref}}{300.41}}`"
+   ":lime:`Molar concentration of potassium, K`", ":math:`M_{K} = \frac{C_{X_{PP},ref}}{300.41}}`"
+   ":blue:`Molar concentration of hydrogen, H+`", ":math:`0 = M_{c} + M_{nh4} + M_{Mg} + M_{K} + S_{H} - M_{hco3} - C_{ac} - C_{pro} - C_{bu} - C_{va} - S_{OH} - M_{a}`"
+   "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
+   "pH of solution", ":math:`pH = -log_{10}(S_{H})`"
+
+The rules for inhibition of amino-acid-utilizing microorganisms (:math:`I_{pH,aa}`), acetate-utilizing microorganisms (:math:`I_{pH,ac}`), hydrogen-utilizing microorganisms (:math:`I_{pH,h2}`) are:
 
     .. math::
 
@@ -259,13 +286,28 @@ The rules for pH inhibition of amino-acid-utilizing microorganisms (:math:`I_{pH
          1 & \text{for } pH > pH_{UL,ac}
        \end{cases}
 
-       I_{pH,aa}=
+       I_{pH,h2}=
        \begin{cases}
          \exp{-3 (\frac{pH - pH_{UL,h2}}{pH_{UL,h2} - pH_{LL,h2}})^2} & \text{for } pH \le pH_{UL,h2}\\
          1 & \text{for } pH > pH_{UL,h2}
        \end{cases}
 
-The rules for hydrogen sulfide inhibition factors are shown below; however, since :math:`Z_{h2s}` is assumed to be 0, all of these inhibition factors are negligible
+
+The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hydrogen inhibition attributed to long chain fatty acids (:math:`I_{h2,fa}`), hydrogen inhibition attributed to valerate and butyrate uptake (:math:`I_{h2,c4}`), hydrogen inhibition attributed to propionate uptake (:math:`I_{h2,pro}`), ammonia inibition attributed to acetate uptake (:math:`I_{nh3}`),  are:
+
+    .. math::
+
+       I_{IN,lim} = \frac{1}{1 + \frac{K_{S_{IN}}}{\frac{C_{S_{IN}}}{14}}
+
+       I_{h2, fa}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,fa}}}
+
+       I_{h2, c4}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,c4}}}
+
+       I_{h2, pro}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,pro}}}
+
+       I_{nh3}= \frac{1}{1 + \frac{M_{nh3}{K_{I,nh3}}}
+
+:lime:`The rules for hydrogen sulfide inhibition factors are shown below; however, since` :math:`Z_{h2s}` :lime:`is assumed to be 0, all of these inhibition factors are negligible`
 
     .. math::
 

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -325,8 +325,8 @@ The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hy
 
        I_{h2s, pro}= \frac{1}{1 + \frac{Z_{h2s}}{K_{I,h2s,pro}}}
 
-Classes
--------
+Class Documentation
+-------------------
 .. currentmodule:: watertap.property_models.anaerobic_digestion.modified_adm1_properties
 
 .. autoclass:: ModifiedADM1ParameterBlock

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -299,13 +299,13 @@ The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hy
 
        I_{IN,lim} = \frac{1}{1 + \frac{K_{S_{IN}}}{C_{S_{IN}}/14}}
 
-       I_{h2, fa}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,fa}}}
+       I_{h2, fa}= \frac{1}{1 + \frac{C_{S_{h2}}}{K_{I,h2,fa}}}
 
-       I_{h2, c4}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,c4}}}
+       I_{h2, c4}= \frac{1}{1 + \frac{C_{S_{h2}}}{K_{I,h2,c4}}}
 
-       I_{h2, pro}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,pro}}}
+       I_{h2, pro}= \frac{1}{1 + \frac{C_{S_{h2}}}{K_{I,h2,pro}}}
 
-       I_{nh3}= \frac{1}{1 + \frac{M_{nh3}{K_{I,nh3}}}
+       I_{nh3}= \frac{1}{1 + \frac{M_{nh3}}{K_{I,nh3}}}
 
 :lime:`The rules for hydrogen sulfide inhibition factors are shown below; however, since` :math:`Z_{h2s}` :lime:`is assumed to be 0, all of these inhibition factors are negligible`
 

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -246,8 +246,8 @@ Process Rate Equations
    ":lime:`Lysis of X_PP`", ":math:`\rho_{24} = b_{PP} C_{X_{PP}}`"
    ":lime:`Lysis of X_PHA`", ":math:`\rho_{25} = b_{PHA} C_{X_{PHA}}`"
 
-Acid-Base Equilibrium Constraints
----------------------------------
+Additional Constraints
+----------------------
 :lime:`Lime` text indicates the equation has been added, and :blue:`blue` text indicates the equation has been modified from its base ADM1 implementation.
 
 .. csv-table::
@@ -262,11 +262,11 @@ Acid-Base Equilibrium Constraints
    "Mass concentration of acetate, ac-", ":math:`C_{ac} = \frac{K_{a,ac} * C_{ac,ref}}{K_{a,ac} + S_{H}}`"
    "Molar concentration of bicarbonate, HCO3", ":math:`M_{hco3} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
    "Molar concentration of ammonia, NH3", ":math:`M_{nh3} = \frac{K_{a,IN} * \frac{C_{S_{IN},ref}}{14}}{K_{a,IN} + S_{H}}`"
-   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
+   "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{C_{S_{IC},ref}}{12} - M_{hco3}`"
    "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14} - M_{nh3}`"
    ":lime:`Molar concentration of magnesium, Mg`", ":math:`M_{Mg} = \frac{C_{X_{PP},ref}}{300.41}`"
    ":lime:`Molar concentration of potassium, K`", ":math:`M_{K} = \frac{C_{X_{PP},ref}}{300.41}`"
-   ":blue:`Molar concentration of hydrogen, H+`", ":math:`S_{H} = M_{hco3} + C_{ac} + C_{pro} + C_{bu} + C_{va} + S_{OH} + M_{a} - M_{c} - M_{nh4} - M_{Mg} - M_{K}`"
+   ":blue:`Molar concentration of hydrogen, H+`", ":math:`S_{H} = M_{hco3} + \frac{C_{ac}}{64} + \frac{C_{pro}}{112} + \frac{C_{bu}}{160} + \frac{C_{va}}{208} + S_{OH} + M_{a} - M_{c} - M_{nh4} - M_{Mg} - M_{K}`"
    "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
    "pH of solution", ":math:`pH = -log_{10}(S_{H})`"
 
@@ -276,19 +276,19 @@ The rules for inhibition of amino-acid-utilizing microorganisms (:math:`I_{pH,aa
 
        I_{pH,aa}=
        \begin{cases}
-         \exp{-3 (\frac{pH - pH_{UL,aa}}{pH_{UL,aa} - pH_{LL,aa}})^2} & \text{for } pH \le pH_{UL,aa}\\
+         \exp{(-3 (\frac{pH - pH_{UL,aa}}{pH_{UL,aa} - pH_{LL,aa}})^2)} & \text{for } pH \le pH_{UL,aa}\\
          1 & \text{for } pH > pH_{UL,aa}
        \end{cases}
 
        I_{pH,ac}=
        \begin{cases}
-         \exp{-3 (\frac{pH - pH_{UL,ac}}{pH_{UL,ac} - pH_{LL,ac}})^2} & \text{for } pH \le pH_{UL,ac}\\
+         \exp{(-3 (\frac{pH - pH_{UL,ac}}{pH_{UL,ac} - pH_{LL,ac}})^2)} & \text{for } pH \le pH_{UL,ac}\\
          1 & \text{for } pH > pH_{UL,ac}
        \end{cases}
 
        I_{pH,h2}=
        \begin{cases}
-         \exp{-3 (\frac{pH - pH_{UL,h2}}{pH_{UL,h2} - pH_{LL,h2}})^2} & \text{for } pH \le pH_{UL,h2}\\
+         \exp{(-3 (\frac{pH - pH_{UL,h2}}{pH_{UL,h2} - pH_{LL,h2}})^2)} & \text{for } pH \le pH_{UL,h2}\\
          1 & \text{for } pH > pH_{UL,h2}
        \end{cases}
 
@@ -307,7 +307,7 @@ The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hy
 
        I_{nh3}= \frac{1}{1 + \frac{M_{nh3}}{K_{I,nh3}}}
 
-:lime:`The rules for hydrogen sulfide inhibition factors are shown below; however, since` :math:`Z_{h2s}` :lime:`is assumed to be 0, all of these inhibition factors are negligible`
+:lime:`The rules for hydrogen sulfide inhibition factors are shown below; however, since` :math:`Z_{h2s}` :lime:`is assumed to be 0, all of these inhibition factors are negligible.`
 
     .. math::
 

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -176,7 +176,7 @@ Kinetic Parameters
    "First-order decay rate for X_pro, k_dec_X_pro", ":math:`k_{dec,X_{pro}}`", "k_dec_X_pro", 0.02, ":math:`\text{d}^{-1}`"
    "First-order decay rate for X_ac, k_dec_X_ac", ":math:`k_{dec,X_{ac}}`", "k_dec_X_ac", 0.02, ":math:`\text{d}^{-1}`"
    "First-order decay rate for X_h2, k_dec_X_h2", ":math:`k_{dec,X_{h2}}`", "k_dec_X_h2", 0.02, ":math:`\text{d}^{-1}`"
-   "Dissociation constant, KW", ":math:`KW`", "KW", 2.08e-14, ":math:`(\text{kmol/}\text{m}^3)^2`"
+   "Water dissociation constant, KW", ":math:`KW`", "KW", 2.08e-14, ":math:`(\text{kmol/}\text{m}^3)^2`"
    "Valerate acid-base equilibrium constant, K_a_va", ":math:`K_{a,va}`", "K_a_va", 1.38e-5, ":math:`\text{kmol/}\text{m}^3`"
    "Butyrate acid-base equilibrium constant, K_a_bu", ":math:`K_{a,bu}`", "K_a_bu", 1.5e-5, ":math:`\text{kmol/}\text{m}^3`"
    "Propionate acid-base equilibrium constant, K_a_pro", ":math:`K_{a,pro}`", "K_a_bu", 1.32e-5, ":math:`\text{kmol/}\text{m}^3`"

--- a/docs/technical_reference/property_models/modified_ADM1.rst
+++ b/docs/technical_reference/property_models/modified_ADM1.rst
@@ -263,9 +263,9 @@ Acid-Base Equilibrium Constraints
    "Molar concentration of bicarbonate, HCO3", ":math:`M_{hco3} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
    "Molar concentration of ammonia, NH3", ":math:`M_{nh3} = \frac{K_{a,IN} * \frac{C_{S_{IN},ref}}{14}}{K_{a,IN} + S_{H}}`"
    "Molar concentration of carbon dioxide, CO2", ":math:`M_{co2} = \frac{K_{a,co2} * \frac{C_{S_{IC},ref}}{12}}{K_{a,co2} + S_{H}}`"
-   "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14}} - M_{nh3}`"
-   ":lime:`Molar concentration of magnesium, Mg`", ":math:`M_{Mg} = \frac{C_{X_{PP},ref}}{300.41}}`"
-   ":lime:`Molar concentration of potassium, K`", ":math:`M_{K} = \frac{C_{X_{PP},ref}}{300.41}}`"
+   "Molar concentration of ammonium, NH4+", ":math:`M_{nh4} = \frac{C_{S_{IN},ref}}{14} - M_{nh3}`"
+   ":lime:`Molar concentration of magnesium, Mg`", ":math:`M_{Mg} = \frac{C_{X_{PP},ref}}{300.41}`"
+   ":lime:`Molar concentration of potassium, K`", ":math:`M_{K} = \frac{C_{X_{PP},ref}}{300.41}`"
    ":blue:`Molar concentration of hydrogen, H+`", ":math:`0 = M_{c} + M_{nh4} + M_{Mg} + M_{K} + S_{H} - M_{hco3} - C_{ac} - C_{pro} - C_{bu} - C_{va} - S_{OH} - M_{a}`"
    "Molar concentration of hydroxide, OH-", ":math:`S_{OH} = \frac{KW}{S_{H}}`"
    "pH of solution", ":math:`pH = -log_{10}(S_{H})`"
@@ -297,7 +297,7 @@ The rules for inhibition related to secondary substrate (:math:`I_{IN,lim}`), hy
 
     .. math::
 
-       I_{IN,lim} = \frac{1}{1 + \frac{K_{S_{IN}}}{\frac{C_{S_{IN}}}{14}}
+       I_{IN,lim} = \frac{1}{1 + \frac{K_{S_{IN}}}{C_{S_{IN}}/14}}
 
        I_{h2, fa}= \frac{1}{1 + \frac{C_{S_{h2}}{K_{I,h2,fa}}}
 

--- a/watertap/property_models/activated_sludge/asm1_properties.py
+++ b/watertap/property_models/activated_sludge/asm1_properties.py
@@ -154,27 +154,22 @@ class _ASM1StateBlock(StateBlock):
         Initialization routine for property package.
 
         Keyword Arguments:
-        state_args : Dictionary with initial guesses for the state vars
-                     chosen. Note that if this method is triggered
-                     through the control volume, and if initial guesses
-                     were not provied at the unit model level, the
-                     control volume passes the inlet values as initial
-                     guess.The keys for the state_args dictionary are:
-
-                     flow_mol_comp : value at which to initialize component
-                                     flows (default=None)
-                     pressure : value at which to initialize pressure
-                                (default=None)
-                     temperature : value at which to initialize temperature
-                                  (default=None)
+            state_args : Dictionary with initial guesses for the state vars
+                         chosen. Note that if this method is triggered
+                         through the control volume, and if initial guesses
+                         were not provided at the unit model level, the
+                         control volume passes the inlet values as initial
+                         guess.The keys for the state_args dictionary are:
+            flow_mol_comp : value at which to initialize component flows (default=None)
+            pressure : value at which to initialize pressure (default=None)
+            temperature : value at which to initialize temperature (default=None)
             outlvl : sets output level of initialization routine
-            state_vars_fixed: Flag to denote if state vars have already been
-                              fixed.
-                              - True - states have already been fixed and
-                                       initialization does not need to worry
-                                       about fixing and unfixing variables.
-                             - False - states have not been fixed. The state
-                                       block will deal with fixing/unfixing.
+            state_vars_fixed: Flag to denote if state vars have already been fixed.
+                              True - states have already been fixed and
+                              initialization does not need to worry
+                              about fixing and unfixing variables.
+                              False - states have not been fixed. The state
+                              block will deal with fixing/unfixing.
             optarg : solver options dictionary object (default=None, use
                      default solver options)
             solver : str indicating which solver to use during
@@ -182,13 +177,11 @@ class _ASM1StateBlock(StateBlock):
             hold_state : flag indicating whether the initialization routine
                          should unfix any state variables fixed during
                          initialization (default=False).
-                         - True - states varaibles are not unfixed, and
-                                 a dict of returned containing flags for
-                                 which states were fixed during
-                                 initialization.
-                        - False - state variables are unfixed after
-                                 initialization by calling the
-                                 relase_state method
+                         True - states variables are not unfixed, and
+                         a dict of returned containing flags for
+                         which states were fixed during initialization.
+                         False - state variables are unfixed after
+                         initialization by calling the release_state method.
 
         Returns:
             If hold_states is True, returns a dict containing flags for

--- a/watertap/property_models/activated_sludge/asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/asm2d_properties.py
@@ -179,27 +179,22 @@ class _ASM2dStateBlock(StateBlock):
         Initialization routine for property package.
 
         Keyword Arguments:
-        state_args : Dictionary with initial guesses for the state vars
-                     chosen. Note that if this method is triggered
-                     through the control volume, and if initial guesses
-                     were not provied at the unit model level, the
-                     control volume passes the inlet values as initial
-                     guess.The keys for the state_args dictionary are:
-
-                     flow_mol_comp : value at which to initialize component
-                                     flows (default=None)
-                     pressure : value at which to initialize pressure
-                                (default=None)
-                     temperature : value at which to initialize temperature
-                                  (default=None)
+            state_args : Dictionary with initial guesses for the state vars
+                         chosen. Note that if this method is triggered
+                         through the control volume, and if initial guesses
+                         were not provided at the unit model level, the
+                         control volume passes the inlet values as initial
+                         guess.The keys for the state_args dictionary are:
+            flow_mol_comp : value at which to initialize component flows (default=None)
+            pressure : value at which to initialize pressure (default=None)
+            temperature : value at which to initialize temperature (default=None)
             outlvl : sets output level of initialization routine
-            state_vars_fixed: Flag to denote if state vars have already been
-                              fixed.
-                              - True - states have already been fixed and
-                                       initialization does not need to worry
-                                       about fixing and unfixing variables.
-                             - False - states have not been fixed. The state
-                                       block will deal with fixing/unfixing.
+            state_vars_fixed: Flag to denote if state vars have already been fixed.
+                              True - states have already been fixed and
+                              initialization does not need to worry
+                              about fixing and unfixing variables.
+                              False - states have not been fixed. The state
+                              block will deal with fixing/unfixing.
             optarg : solver options dictionary object (default=None, use
                      default solver options)
             solver : str indicating which solver to use during
@@ -207,13 +202,11 @@ class _ASM2dStateBlock(StateBlock):
             hold_state : flag indicating whether the initialization routine
                          should unfix any state variables fixed during
                          initialization (default=False).
-                         - True - states varaibles are not unfixed, and
-                                 a dict of returned containing flags for
-                                 which states were fixed during
-                                 initialization.
-                        - False - state variables are unfixed after
-                                 initialization by calling the
-                                 relase_state method
+                         True - states variables are not unfixed, and
+                         a dict of returned containing flags for
+                         which states were fixed during initialization.
+                         False - state variables are unfixed after
+                         initialization by calling the release_state method.
 
         Returns:
             If hold_states is True, returns a dict containing flags for

--- a/watertap/property_models/anaerobic_digestion/adm1_reactions.py
+++ b/watertap/property_models/anaerobic_digestion/adm1_reactions.py
@@ -1241,25 +1241,25 @@ class ADM1ReactionBlockData(ReactionBlockDataBase):
         self.conc_mass_va = pyo.Var(
             initialize=0.01159624,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of va-",
+            doc="mass concentration of va-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mass_bu = pyo.Var(
             initialize=0.0132208,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of bu-",
+            doc="mass concentration of bu-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mass_pro = pyo.Var(
             initialize=0.015742,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of pro-",
+            doc="mass concentration of pro-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mass_ac = pyo.Var(
             initialize=0.1972,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of ac-",
+            doc="mass concentration of ac-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mol_hco3 = pyo.Var(
@@ -1454,7 +1454,7 @@ class ADM1ReactionBlockData(ReactionBlockDataBase):
 
         self.concentration_of_nh4 = pyo.Constraint(
             rule=concentration_of_nh4_rule,
-            doc="constraint concentration of pro-",
+            doc="constraint concentration of nh4",
         )
 
         def S_OH_rule(self):
@@ -1482,7 +1482,7 @@ class ADM1ReactionBlockData(ReactionBlockDataBase):
 
         self.S_H_cons = pyo.Constraint(
             rule=S_H_rule,
-            doc="constraint concentration of pro-",
+            doc="constraint concentration of H",
         )
 
         def rule_pH(self):

--- a/watertap/property_models/anaerobic_digestion/adm1_reactions.py
+++ b/watertap/property_models/anaerobic_digestion/adm1_reactions.py
@@ -1319,7 +1319,7 @@ class ADM1ReactionBlockData(ReactionBlockDataBase):
 
         self.Dissociation = pyo.Constraint(
             rule=Dissociation_rule,
-            doc="Dissociation constant constraint",
+            doc="Water dissociation constant constraint",
         )
 
         # Equation from [2]

--- a/watertap/property_models/anaerobic_digestion/modified_adm1_reactions.py
+++ b/watertap/property_models/anaerobic_digestion/modified_adm1_reactions.py
@@ -1812,25 +1812,25 @@ class ModifiedADM1ReactionBlockData(ReactionBlockDataBase):
         self.conc_mass_va = pyo.Var(
             initialize=0.01159624,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of va-",
+            doc="mass concentration of va-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mass_bu = pyo.Var(
             initialize=0.0132208,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of bu-",
+            doc="mass concentration of bu-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mass_pro = pyo.Var(
             initialize=0.015742,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of pro-",
+            doc="mass concentration of pro-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mass_ac = pyo.Var(
             initialize=0.1972,
             domain=pyo.NonNegativeReals,
-            doc="molar concentration of ac-",
+            doc="mass concentration of ac-",
             units=pyo.units.kg / pyo.units.m**3,
         )
         self.conc_mol_hco3 = pyo.Var(

--- a/watertap/property_models/anaerobic_digestion/modified_adm1_reactions.py
+++ b/watertap/property_models/anaerobic_digestion/modified_adm1_reactions.py
@@ -1901,7 +1901,7 @@ class ModifiedADM1ReactionBlockData(ReactionBlockDataBase):
 
         self.Dissociation = pyo.Constraint(
             rule=Dissociation_rule,
-            doc="Dissociation constant constraint",
+            doc="Water dissociation constant constraint",
         )
 
         def CO2_acid_base_equilibrium_rule(self, t):


### PR DESCRIPTION
## Fixes/Resolves:

Part of the master issue #934 

## Changes proposed in this PR:
- Add the acid-base equilibrium constraints to the ADM1 and Modified ADM1 documentation
- Minor typo fixes in ADM1 reaction files
- Minor corrections to ASM documentation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
