### PR TITLE
Removing unnecessary warnings as a result of `diffus_phase_comp` in MCAS prop pack

### DIFF
--- a/watertap/property_models/multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/multicomp_aq_sol_prop_pack.py
@@ -1887,13 +1887,14 @@ class MCASStateBlockData(StateBlockData):
         for j, v in self.mw_comp.items():
             if iscale.get_scaling_factor(v) is None:
                 iscale.set_scaling_factor(self.mw_comp[j], value(v) ** -1)
-        for ind, v in self.diffus_phase_comp.items():
-            if iscale.get_scaling_factor(v) is None:
-                if ind in self.params.config.diffusivity_data.keys():
-                    sf = self.params.config.diffusivity_data[ind] ** -1
-                else:
-                    sf = 1e10
-                iscale.set_scaling_factor(self.diffus_phase_comp[ind], sf)
+        if self.is_property_constructed("diffus_phase_comp"):
+            for ind, v in self.diffus_phase_comp.items():
+                if iscale.get_scaling_factor(v) is None:
+                    if ind in self.params.config.diffusivity_data.keys():
+                        sf = self.params.config.diffusivity_data[ind] ** -1
+                    else:
+                        sf = 1e10
+                    iscale.set_scaling_factor(self.diffus_phase_comp[ind], sf)
         if self.is_property_constructed("dens_mass_solvent"):
             if iscale.get_scaling_factor(self.dens_mass_solvent) is None:
                 iscale.set_scaling_factor(self.dens_mass_solvent, 1e-3)


### PR DESCRIPTION
## Fixes/Resolves:
Addresses #950

## Summary/Motivation:
The warnings logged were not necessary as the variable in question is not even constructed. Since the warnings don't contribute to the pass/fail of tests, it's only really noticed when running` pytest -s -vv` but does not effect test actions.

## Changes proposed in this PR:
- Alter MCAS code to only log warnings when necessary

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
