### PR TITLE
Thickener & Dewatering Unit Model Documentation

### DIFF
--- a/docs/technical_reference/unit_models/dewatering.rst
+++ b/docs/technical_reference/unit_models/dewatering.rst
@@ -45,7 +45,7 @@ Parameters
 .. csv-table::
    :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
 
-   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
+   "Percentage of suspended solids in the underflow", ":math:`p_{dewat}`", "p_dewat", "None", "0.28", ":math:`\text{dimensionless}`"
    "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
 
 
@@ -56,8 +56,8 @@ Equations and Relationships
    :header: "Description", "Equation"
 
    "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
-   "Dewatering factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
-   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
+   "Dewatering factor", ":math:`f_{dewat} = p_{dewat} (\frac{10}{C_{TSS}})`"
+   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{dewat}}`"
    "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
    "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
 

--- a/docs/technical_reference/unit_models/dewatering.rst
+++ b/docs/technical_reference/unit_models/dewatering.rst
@@ -18,7 +18,7 @@ related to storage, processing, disposal, etc. This implementation of the dewate
 
 Degrees of Freedom
 ------------------
-The degrees of freedom in a dewatering unit model are the the inlet feed state variables:
+The degrees of freedom in a dewatering unit model are the inlet feed state variables:
 
     * temperature
     * pressure

--- a/docs/technical_reference/unit_models/dewatering.rst
+++ b/docs/technical_reference/unit_models/dewatering.rst
@@ -40,6 +40,8 @@ Sets
    "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
    "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
 
+NOTE: These components are defined in the `ASM1 Property Package <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_ documentation.
+
 Parameters
 ----------
 .. csv-table::
@@ -62,7 +64,7 @@ Equations and Relationships
    "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
 
 Class Documentation
--------
+-------------------
 .. currentmodule:: watertap.unit_models.dewatering
 
 .. autoclass:: DewateringUnit

--- a/docs/technical_reference/unit_models/dewatering.rst
+++ b/docs/technical_reference/unit_models/dewatering.rst
@@ -61,7 +61,7 @@ Equations and Relationships
    "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
    "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
 
-Classes
+Class Documentation
 -------
 .. currentmodule:: watertap.unit_models.dewatering
 

--- a/docs/technical_reference/unit_models/dewatering.rst
+++ b/docs/technical_reference/unit_models/dewatering.rst
@@ -1,0 +1,75 @@
+Dewatering Unit
+===============
+
+.. index::
+   pair: watertap.unit_models.dewatering;dewatering
+
+The main assumptions of the implemented model are as follows:
+
+1) Single liquid phase only
+2) Steady state only
+3) Has no volume
+
+Introduction
+------------
+Dewatering is a process commonly used in wastewater treatment plants to separate water from solids using centrifugal motion
+and/or vacuums. In doing so, the dewatering unit reduces the sludge volume, which improves system operation and mitigates costs
+related to storage, processing, disposal, etc. This implementation of the dewatering unit is based on the `IDAES separator unit <https://idaes-pse.readthedocs.io/en/stable/reference_guides/model_libraries/generic/unit_models/separator.html>`_.
+
+Degrees of Freedom
+------------------
+The degrees of freedom in a dewatering unit model are the the inlet feed state variables:
+
+    * temperature
+    * pressure
+    * component mass compositions
+
+Model Structure
+---------------
+The dewatering unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum
+balances to split the inlet stream into two outlet streams. Dewatering models have a single inlet Port
+(named inlet) and two outlet Ports (named overflow and underflow).
+
+Sets
+----
+.. csv-table::
+   :header: "Description", "Symbol", "Indices"
+
+   "Time", ":math:`t`", "[0]"
+   "Phases", ":math:`p`", "['Liq']"
+   "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
+   "Non-particulate Components", ":math:`j`", "['H2O','S_I','S_S','S_O','S_NO','S_NH','S_ND','S_ALK' ]"
+
+Parameters
+----------
+.. csv-table::
+   :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
+
+   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
+   "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
+
+
+Equations and Relationships
+---------------------------
+
+.. csv-table::
+   :header: "Description", "Equation"
+
+   "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
+   "Dewatering factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
+   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
+   "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
+   "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
+
+Classes
+-------
+.. currentmodule:: watertap.unit_models.dewatering
+
+.. autoclass:: DewateringUnit
+    :members:
+    :noindex:
+
+References
+----------
+J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson, I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer & P. A. Vanrolleghem
+Benchmark Simulation Model no. 2 (BSM2)

--- a/docs/technical_reference/unit_models/dewatering.rst
+++ b/docs/technical_reference/unit_models/dewatering.rst
@@ -38,7 +38,7 @@ Sets
    "Time", ":math:`t`", "[0]"
    "Phases", ":math:`p`", "['Liq']"
    "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
-   "Non-particulate Components", ":math:`j`", "['H2O','S_I','S_S','S_O','S_NO','S_NH','S_ND','S_ALK' ]"
+   "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
 
 Parameters
 ----------

--- a/docs/technical_reference/unit_models/index.rst
+++ b/docs/technical_reference/unit_models/index.rst
@@ -21,5 +21,7 @@ Unit Models
    anaerobic_digestor
    ion_exchange_0D
    mvc
+   thickener
+   dewatering
    translators/index
    zero_order_unit_models/index

--- a/docs/technical_reference/unit_models/thickener.rst
+++ b/docs/technical_reference/unit_models/thickener.rst
@@ -40,6 +40,8 @@ Sets
    "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
    "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
 
+NOTE: These components are defined in the `ASM1 Property Package <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_ documentation.
+
 Parameters
 ----------
 .. csv-table::
@@ -61,8 +63,8 @@ Equations and Relationships
    "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
    "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
 
-Classes
--------
+Class Documentation
+-------------------
 .. currentmodule:: watertap.unit_models.thickener
 
 .. autoclass:: Thickener

--- a/docs/technical_reference/unit_models/thickener.rst
+++ b/docs/technical_reference/unit_models/thickener.rst
@@ -1,0 +1,75 @@
+Thickener
+=========
+
+.. index::
+   pair: watertap.unit_models.thickener;thickener
+
+The main assumptions of the implemented model are as follows:
+
+1) Single liquid phase only
+2) Steady state only
+3) Has no volume
+
+Introduction
+------------
+Sludge thickening is a process commonly used in wastewater treatment plants to increase the sludge concentration of a stream
+as well as reduce its volume by removing free water. In doing so, the thickener reduces the load of downstream processes,
+such as digestion and dewatering. This implementation of the thickener unit is based on the `IDAES separator unit <https://idaes-pse.readthedocs.io/en/stable/reference_guides/model_libraries/generic/unit_models/separator.html>`_.
+
+Degrees of Freedom
+------------------
+The degrees of freedom in a thickener unit model are the the inlet feed state variables:
+
+    * temperature
+    * pressure
+    * component mass compositions
+
+Model Structure
+---------------
+The thickener unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum
+balances to split the inlet stream into two outlet streams. Thickener models have a single inlet Port
+(named inlet) and two outlet Ports (named overflow and underflow).
+
+Sets
+----
+.. csv-table::
+   :header: "Description", "Symbol", "Indices"
+
+   "Time", ":math:`t`", "[0]"
+   "Phases", ":math:`p`", "['Liq']"
+   "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
+   "Non-particulate Components", ":math:`j`", "['H2O','S_I','S_S','S_O','S_NO','S_NH','S_ND','S_ALK' ]"
+
+Parameters
+----------
+.. csv-table::
+   :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
+
+   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
+   "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
+
+
+Equations and Relationships
+---------------------------
+
+.. csv-table::
+   :header: "Description", "Equation"
+
+   "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
+   "Thickening factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
+   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
+   "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
+   "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
+
+Classes
+-------
+.. currentmodule:: watertap.unit_models.thickener
+
+.. autoclass:: Thickener
+    :members:
+    :noindex:
+
+References
+----------
+J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson, I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer & P. A. Vanrolleghem
+Benchmark Simulation Model no. 2 (BSM2)

--- a/docs/technical_reference/unit_models/thickener.rst
+++ b/docs/technical_reference/unit_models/thickener.rst
@@ -18,7 +18,7 @@ such as digestion and dewatering. This implementation of the thickener unit is b
 
 Degrees of Freedom
 ------------------
-The degrees of freedom in a thickener unit model are the the inlet feed state variables:
+The degrees of freedom in a thickener unit model are the inlet feed state variables:
 
     * temperature
     * pressure

--- a/docs/technical_reference/unit_models/thickener.rst
+++ b/docs/technical_reference/unit_models/thickener.rst
@@ -38,7 +38,7 @@ Sets
    "Time", ":math:`t`", "[0]"
    "Phases", ":math:`p`", "['Liq']"
    "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
-   "Non-particulate Components", ":math:`j`", "['H2O','S_I','S_S','S_O','S_NO','S_NH','S_ND','S_ALK' ]"
+   "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
 
 Parameters
 ----------


### PR DESCRIPTION
## Summary/Motivation:
Adds documentation for the thickener and dewatering unit models, both of which are based off the IDAES separator

## Changes proposed in this PR:
- Adds unit model documentation
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
