### PR TITLE
Use README for long description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # WaterTAP
+
 This is the WaterTAP development repository.
 
 WaterTAP is developed as part of the [National Alliance for Water Innovation](https://nawihub.org/) project.

--- a/setup.py
+++ b/setup.py
@@ -15,24 +15,10 @@ Project setup with setuptools
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_namespace_packages
-import pathlib
+from pathlib import Path
 
-cwd = pathlib.Path(__file__).parent.resolve()  # this will come in handy, probably
-
-long_description = """WaterTAP is an open-source, integrated suite of predictive multi-scale models
-for design and optimization of water treatment processes and systems. Specifically, WaterTAP is a new
-library of water treatment-specific property, process unit, and network models that depend on the IDAES Platform,
-an open source, next generation process systems engineering platform developed at the National Energy Technology
-Laboratory with other partners. The WaterTAP project is funded by the NAWI  as a part of U.S. Department of
-Energy’s Energy-Water Desalination Hub. The goal of WaterTAP is to assist the hub and the broader water R&D
-community in assessing existing and emerging water treatment technologies by 1) providing predictive capabilities
-involving the design, optimization, and performance of water treatment systems that will lead to improved energy
-efficiency and lower cost, 2) advancing the state of the art for the design of water treatment components, systems
-and networks to be comparable with, or even surpass, that in the chemical industry, and 3) disseminating these tools
-for active use by water treatment researchers and engineers.""".replace(
-    "\n", " "
-).strip()
-
+cwd = Path(__file__).parent
+long_description = (cwd / "README.md").read_text()
 
 SPECIAL_DEPENDENCIES_FOR_RELEASE = [
     "idaes-pse==2.0.*",  # from PyPI
@@ -54,7 +40,7 @@ setup(
     version="0.9.dev0",
     description="WaterTAP modeling library",
     long_description=long_description,
-    long_description_content_type="text/plain",
+    long_description_content_type="text/markdown",
     author="NAWI team",
     license="BSD",
     # Classifiers help users find your project by categorizing it.


### PR DESCRIPTION
## Fixes/Resolves:

This fixes issue #1018 regarding watertap's description that is displayed on PyPI at https://pypi.org/project/watertap/.

## Summary/Motivation:

The current description for watertap on PyPI is one long, unformatted, string. This pull request uses this repository's README content as the description that is displayed on PyPI.

## Changes proposed in this PR:
- Use README content for `long_description` in `setup.py`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
