### PR TITLE
Workaround for ReadTheDocs Sphinx build failures due to urllib3 v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
             "jinja2<3.1.0",  # see watertap-org/watertap#449
             "Sphinx",  # docs
             "sphinx_rtd_theme",  # docs
+            "urllib3 < 2",  # see watertap-org/watertap#1021,
             # other requirements
             "linkify-it-py",
             "json-schema-for-humans",  # pretty JSON schema in HTML


### PR DESCRIPTION
## Summary/motivation

ReadTheDocs builds are currently failing:

![image](https://user-images.githubusercontent.com/48035537/236343897-d531cee0-b08c-4854-912d-8152560c9757.png)

```log
Running Sphinx v5.3.0

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/sphinx/registry.py", line 459, in load_extension
    mod = import_module(extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/sphinx/builders/linkcheck.py", line 18, in <module>
    from requests import Response
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/urllib3/__init__.py", line 39, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/sphinx/cmd/build.py", line 280, in build_main
    args.pdb)
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/sphinx/application.py", line 219, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/sphinx/application.py", line 398, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/watertap/envs/1021/lib/python3.7/site-packages/sphinx/registry.py", line 463, in load_extension
    err) from err
sphinx.errors.ExtensionError: Could not import extension sphinx.builders.linkcheck (exception: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168)

Extension error:
Could not import extension sphinx.builders.linkcheck (exception: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168)
```

## Changes proposed in this PR:

- Add a version constraint for `urllib3 < 2` in the dev requirements

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
