### PR TITLE
Resolve macOS CI failures due to conda-forge IPopt version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -292,7 +292,7 @@ jobs:
         echo '::endgroup::'
     - name: Install Ipopt from conda-forge
       run:
-        conda install --quiet --yes -c conda-forge ipopt
+        conda install --quiet --yes -c conda-forge ipopt=3.14.11
     - name: Build Pyomo extensions
       run: |
         conda install --quiet --yes cmake


### PR DESCRIPTION
## Fixes/Resolves:
#1029 

## Summary/Motivation:
Resolve macOS CI failures by pinning to ipopt to 3.14.11 (as opposed to latest, which is 3.14.12, just released this week and causing issues).

## Changes proposed in this PR:
- pin to previous ipopt to resolve until we figure out how to get things working with 3.14.12


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
