### PR TITLE
Added a put request for WaterTAP GUI.

### DIFF
--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -188,7 +188,7 @@ class TestParallelManager:
         )
 
         with pytest.raises(requests.exceptions.ConnectionError):
-            r = ps._publish_updates(1, True)
+            r = ps._publish_updates(1, True, 5.0)
 
     def test_random_build_combinations(self):
         ps = ParameterSweep()

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -13,6 +13,7 @@
 import pytest
 import os
 import numpy as np
+import requests
 import pyomo.environ as pyo
 
 from pyomo.environ import value
@@ -179,6 +180,15 @@ class TestParallelManager:
         assert global_combo_array[-1, 0] == pytest.approx(range_A[1])
         assert global_combo_array[-1, 1] == pytest.approx(range_B[1])
         assert global_combo_array[-1, 2] == pytest.approx(range_C[1])
+
+    @pytest.mark.component
+    def test_status_publishing(self):
+        ps = ParameterSweep(
+            publish_progress=True, publish_address="http://localhost:8888"
+        )
+
+        with pytest.raises(requests.exceptions.ConnectionError):
+            r = ps._publish_updates(1, True)
 
     def test_random_build_combinations(self):
         ps = ParameterSweep()


### PR DESCRIPTION
## Fixes/Resolves:

Adds an HTTP put request to send progress of the parameter sweep to the GUI.

## Summary/Motivation:

Users running long parameter sweeps of complicated flowsheets will benefit from a progress indicator that tells them how many iterations have happened and how many are remaining.

## Changes proposed in this PR:
- Add a put request function to publish progress
- Add request details to config options in the `_ParameterSweepBase` class.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
