### PR TITLE
Add flow_vol property to SOP property package

### DIFF
--- a/watertap/property_models/tests/test_selective_oil_permeation_prop_pack.py
+++ b/watertap/property_models/tests/test_selective_oil_permeation_prop_pack.py
@@ -26,8 +26,8 @@ class TestSOPProperty(PropertyTestHarness):
             ("flow_mass_phase_comp", ("Liq", "oil")): 1e2,
         }
         self.stateblock_statistics = {
-            "number_variables": 15,
-            "number_total_constraints": 11,
+            "number_variables": 16,
+            "number_total_constraints": 12,
             "number_unused_variables": 2,
             "default_degrees_of_freedom": 2,
         }
@@ -41,6 +41,7 @@ class TestSOPProperty(PropertyTestHarness):
             ("flow_vol_phase_comp", ("Liq", "H2O")): 1e-3,
             ("flow_vol_phase_comp", ("Liq", "oil")): 1.28205e-5,
             ("flow_vol_phase", "Liq"): 1.01282e-3,
+            ("flow_vol", None): 1.01282e-3,
             ("flow_mass_phase", "Liq"): 1.01,
             ("dens_mass_phase", "Liq"): 997.215,
             ("vol_frac_phase_comp", ("Liq", "H2O")): 0.98734,
@@ -74,6 +75,7 @@ class TestSOPPropertySolution(PropertyRegressionTest):
             ("flow_vol_phase_comp", ("Liq", "H2O")): 5e-4,
             ("flow_vol_phase_comp", ("Liq", "oil")): 6.41026e-4,
             ("flow_vol_phase", "Liq"): 1.141025641025641e-3,
+            ("flow_vol", None): 1.141025641025641e-3,
             ("flow_mass_phase", "Liq"): 1,
             ("dens_mass_phase", "Liq"): 876.404,
             ("vol_frac_phase_comp", ("Liq", "H2O")): 0.4382,


### PR DESCRIPTION
## Fixes/Resolves:

Certain models (such as pumps) expect property packages to have a "flow_vol" property. Here, I have added that property to selective_oil_permeation_prop_pack.py.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
