### PR TITLE
Remove explicit uses of MPI from ParameterSweep and ParameterSweepWri…

### DIFF
--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -157,13 +157,12 @@ class _ParameterSweepBase(ABC):
 
         self.comm = options.pop("comm", MPI.COMM_WORLD)
         self.rank = self.comm.Get_rank()
-        self.num_procs = self.comm.Get_size()
 
         self.config = self.CONFIG(options)
 
         # Initialize the writer
         self.writer = ParameterSweepWriter(
-            self.comm,
+            self.parallel_manager,
             csv_results_file_name=self.config.csv_results_file_name,
             h5_results_file_name=self.config.h5_results_file_name,
             debugging_data_dir=self.config.debugging_data_dir,
@@ -189,7 +188,7 @@ class _ParameterSweepBase(ABC):
 
         if self.config.publish_progress:
             publish_dict = {
-                "worker_number": self.comm.Get_rank(),
+                "worker_number": self.parallel_manager.get_rank(),
                 "iteration": iteration,
                 "solve_status": solve_status,
                 "solve_time": solve_time,
@@ -293,10 +292,12 @@ class _ParameterSweepBase(ABC):
         # Split the total list of combinations into NUM_PROCS chunks,
         # one per each of the MPI ranks
         # divided_combo_array = np.array_split(global_combo_array, num_procs, axis=0)
-        divided_combo_array = np.array_split(global_combo_array, self.num_procs)
+        divided_combo_array = np.array_split(
+            global_combo_array, self.parallel_manager.number_of_processes()
+        )
 
         # Return only this rank's portion of the total workload
-        local_combo_array = divided_combo_array[self.rank]
+        local_combo_array = divided_combo_array[self.parallel_manager.get_rank()]
 
         return local_combo_array
 
@@ -323,12 +324,11 @@ class _ParameterSweepBase(ABC):
             (num_cases, len(global_results_dict["outputs"])), dtype=float
         )
 
-        if self.rank == 0:
+        if self.parallel_manager.is_root_process():
             for i, (key, item) in enumerate(global_results_dict["outputs"].items()):
                 global_results[:, i] = item["value"][:num_cases]
 
-        if self.num_procs > 1:  # pragma: no cover
-            self.comm.Bcast(global_results, root=0)
+        self.parallel_manager.sync_data(global_results)
 
         return global_results
 
@@ -451,7 +451,7 @@ class _ParameterSweepBase(ABC):
             req_num_samples = num_total_samples
 
         # Create the global value array on rank 0
-        if self.rank == 0:
+        if self.parallel_manager.is_root_process():
             global_output_dict = copy.deepcopy(local_output_dict)
             # Create a global value array of inputs in the dictionary
             for key, item in global_output_dict.items():
@@ -483,7 +483,7 @@ class _ParameterSweepBase(ABC):
             elif key == "solve_successful":
                 local_solve_successful = np.fromiter(item, dtype=bool, count=len(item))
 
-                if self.rank == 0:
+                if self.parallel_manager.is_root_process():
                     global_solve_successful = np.empty(num_total_samples, dtype=bool)
                 else:
                     global_solve_successful = None
@@ -494,7 +494,7 @@ class _ParameterSweepBase(ABC):
                     root=0,
                 )
 
-                if self.rank == 0:
+                if self.parallel_manager.is_root_process():
                     # Trim to the exact number
                     global_output_dict[key] = list(
                         global_solve_successful[0:req_num_samples]
@@ -825,14 +825,13 @@ class RecursiveParameterSweep(_ParameterSweepBase):
             dtype=float,
         )
 
-        if self.rank == 0:
+        if self.parallel_manager.is_root_process():
             for i, (key, item) in enumerate(
                 global_filtered_dict["sweep_params"].items()
             ):
                 global_filtered_values[:, i] = item["value"][:req_num_samples]
 
-        if self.num_procs > 1:  # pragma: no cover
-            self.comm.Bcast(global_filtered_values, root=0)
+        self.parallel_manager.sync_data(global_filtered_values)
 
         return global_filtered_values
 
@@ -921,7 +920,7 @@ class RecursiveParameterSweep(_ParameterSweepBase):
             failure_count = local_num_cases - success_count
 
             # Get the global number of successful solves and update the number of remaining samples
-            if self.num_procs > 1:  # pragma: no cover
+            if self.parallel_manager.number_of_processes() > 1:  # pragma: no cover
                 global_success_count = np.zeros(1, dtype=float)
                 global_failure_count = np.zeros(1, dtype=float)
                 self.comm.Allreduce(

--- a/watertap/tools/parameter_sweep/parameter_sweep_writer.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep_writer.py
@@ -69,13 +69,12 @@ class ParameterSweepWriter:
 
     def __init__(
         self,
-        comm,
+        parallel_manager,
         **options,
     ):
 
-        self.comm = comm
-        self.rank = self.comm.Get_rank()
-        self.num_procs = self.comm.Get_size()
+        self.parallel_manager = parallel_manager
+        self.rank = self.parallel_manager.get_rank()
 
         self.config = self.CONFIG(options)
 
@@ -311,7 +310,7 @@ class ParameterSweepWriter:
                     parents=True, exist_ok=True
                 )
 
-        self.comm.Barrier()
+        self.parallel_manager.sync_point()
 
         # Handle values in the debugging data_directory
         if self.config["debugging_data_dir"] is not None:

--- a/watertap/tools/parameter_sweep/tests/test_differential_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_differential_parameter_sweep.py
@@ -665,7 +665,7 @@ def test_differential_parameter_sweep(model, tmp_path):
         read_dict = _read_output_h5(h5_results_file_name)
         _assert_h5_csv_agreement(csv_results_file_name, read_dict)
         _assert_dictionary_correctness(global_results_dict, read_dict)
-        if ps.num_procs > 1:
+        if ps.parallel_manager.number_of_processes() > 1:
             # Compare the sorted dictionary. We need to work with a sorted dictionary
             # because the differential parameter sweep produces a global dictionary
             # that is jumbled by the number of procs.
@@ -1165,7 +1165,7 @@ def test_differential_parameter_sweep_selective(model, tmp_path):
         read_dict = _read_output_h5(h5_results_file_name)
         _assert_h5_csv_agreement(csv_results_file_name, read_dict)
         _assert_dictionary_correctness(global_results_dict, read_dict)
-        if ps.num_procs > 1:
+        if ps.parallel_manager.number_of_processes() > 1:
             # Compare the sorted dictionary. We need to work with a sorted dictionary
             # because the differential parameter sweep produces a global dictionary
             # that is jumbled by the number of procs.

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -274,7 +274,7 @@ class TestParallelManager:
             param_dict, SamplingType.FIXED, None
         )
 
-        num_procs = ps.num_procs
+        num_procs = ps.parallel_manager.number_of_processes()
         rank = ps.rank
         test = np.array_split(global_combo_array, num_procs, axis=0)[rank]
 
@@ -478,7 +478,7 @@ class TestParallelManager:
         m.fs.slack_penalty = 1000.0
         m.fs.slack.setub(0)
 
-        global_num_cases = 2 * ps.num_procs
+        global_num_cases = 2 * ps.parallel_manager.number_of_processes()
         sweep_params = {
             "input_a": NormalSample(m.fs.input["a"], 0.1, 0.9, global_num_cases),
             "input_b": NormalSample(m.fs.input["b"], 0.0, 0.5, global_num_cases),
@@ -520,7 +520,9 @@ class TestParallelManager:
         if ps.rank > 0:
             assert global_output_dict == local_output_dict
         else:
-            test_array = np.repeat(np.arange(0, ps.num_procs, dtype=float), 2)
+            test_array = np.repeat(
+                np.arange(0, ps.parallel_manager.number_of_processes(), dtype=float), 2
+            )
             test_list = [True] * global_num_cases
             for key, value in global_output_dict.items():
                 if key != "solve_successful":
@@ -582,7 +584,7 @@ class TestParallelManager:
             )
 
             # Check that all local output files have been created
-            for k in range(ps.num_procs):
+            for k in range(ps.parallel_manager.number_of_processes()):
                 assert os.path.isfile(
                     os.path.join(tmp_path, f"local_results_{k:03}.h5")
                 )

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep_writer.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep_writer.py
@@ -60,7 +60,7 @@ class TestParallelWriterManager:
     def test_interp_nan_values(self):
         ps = ParameterSweep()
         ps_writer = ParameterSweepWriter(
-            ps.comm,
+            ps.parallel_manager,
             csv_results_file_name=None,
             h5_results_file_name=None,
             debugging_data_dir=None,
@@ -104,7 +104,7 @@ class TestParallelWriterManager:
         h5_fname = "h5_test_{0}.h5".format(ps.rank)
 
         ps_writer = ParameterSweepWriter(
-            ps.comm,
+            ps.parallel_manager,
             csv_results_file_name=None,
             h5_results_file_name=h5_fname,
             debugging_data_dir=None,
@@ -244,7 +244,7 @@ class TestParallelWriterManager:
         reference_dict = dict()
         for h5_parent_group in h5_parent_groups:
             ps_writer_dict[h5_parent_group] = ParameterSweepWriter(
-                ps.comm,
+                ps.parallel_manager,
                 csv_results_file_name=None,
                 h5_results_file_name=h5_fname,
                 h5_parent_group_name=h5_parent_group,

--- a/watertap/tools/parameter_sweep/tests/test_recursive_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_recursive_parameter_sweep.py
@@ -224,7 +224,7 @@ def test_recursive_parameter_sweep(model, tmp_path):
         assert os.path.isfile(csv_results_file)
 
         # Check that all local output files have been created
-        for k in range(ps.num_procs):
+        for k in range(ps.parallel_manager.number_of_processes()):
             assert os.path.isfile(os.path.join(tmp_path, f"local_results_{k:03}.h5"))
             assert os.path.isfile(os.path.join(tmp_path, f"local_results_{k:03}.csv"))
 


### PR DESCRIPTION
…ter classes

## Fixes/Resolves:

This removes all other explicit uses of MPI from the ParameterSweep class, in preparation for implementing the concurrent futures parallel manager for that class.

There are still uses of MPI in the file, because they're needed by the other parameter sweep classes (differential, recursive). I'll plan to tackle those after getting the different parallel managers working for the basic class. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
