### PR TITLE
ASM2d compatibility with thickener and dewatering units

### DIFF
--- a/watertap/property_models/activated_sludge/asm1_properties.py
+++ b/watertap/property_models/activated_sludge/asm1_properties.py
@@ -78,6 +78,20 @@ class ASM1ParameterData(PhysicalParameterBlock):
 
         self.S_ALK = Component(doc="Alkalinity, S_ALK")
 
+        # Create sets for use across ASM models and associated unit models (e.g., thickener, dewaterer)
+        self.non_particulate_component_set = pyo.Set(initialize=[
+                "S_I",
+                "S_S",
+                "S_O",
+                "S_NO",
+                "S_NH",
+                "S_ND",
+                "H2O",
+                "S_ALK",
+            ])
+        self.particulate_component_set = pyo.Set(initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"])
+        self.tss_component_set = pyo.Set(initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA"])
+
         # Heat capacity of water
         self.cp_mass = pyo.Param(
             mutable=False,

--- a/watertap/property_models/activated_sludge/asm1_properties.py
+++ b/watertap/property_models/activated_sludge/asm1_properties.py
@@ -79,7 +79,8 @@ class ASM1ParameterData(PhysicalParameterBlock):
         self.S_ALK = Component(doc="Alkalinity, S_ALK")
 
         # Create sets for use across ASM models and associated unit models (e.g., thickener, dewaterer)
-        self.non_particulate_component_set = pyo.Set(initialize=[
+        self.non_particulate_component_set = pyo.Set(
+            initialize=[
                 "S_I",
                 "S_S",
                 "S_O",
@@ -88,9 +89,14 @@ class ASM1ParameterData(PhysicalParameterBlock):
                 "S_ND",
                 "H2O",
                 "S_ALK",
-            ])
-        self.particulate_component_set = pyo.Set(initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"])
-        self.tss_component_set = pyo.Set(initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA"])
+            ]
+        )
+        self.particulate_component_set = pyo.Set(
+            initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]
+        )
+        self.tss_component_set = pyo.Set(
+            initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA"]
+        )
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(

--- a/watertap/property_models/activated_sludge/asm1_properties.py
+++ b/watertap/property_models/activated_sludge/asm1_properties.py
@@ -36,7 +36,7 @@ import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 
 # Some more information about this module
-__author__ = "Andrew Lee"
+__author__ = "Andrew Lee, Adam Atia"
 
 
 # Set up logger

--- a/watertap/property_models/activated_sludge/asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/asm2d_properties.py
@@ -103,6 +103,12 @@ class ASM2dParameterData(PhysicalParameterBlock):
         self.X_S = Solute(doc="Slowly biodegradable substrates. [kg COD/m^3]")
         self.X_TSS = Solute(doc="Total suspended solids, TSS. [kg TSS/m^3]")
 
+        # Create sets for use across ASM models and associated unit models
+        self.non_particulate_component_set = pyo.Set(initialize=["S_A", "S_F", "S_I", "S_N2", "S_NH4", "S_NO3", "S_O2", "S_PO4", "S_ALK", "H2O"])
+        self.particulate_component_set = pyo.Set(initialize=["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_TSS"])
+        self.tss_component_set = pyo.Set(initialize=["X_TSS"])
+
+
         # Heat capacity of water
         self.cp_mass = pyo.Param(
             mutable=False,

--- a/watertap/property_models/activated_sludge/asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/asm2d_properties.py
@@ -41,7 +41,7 @@ from idaes.core.util.initialization import fix_state_vars, revert_state_vars
 import idaes.logger as idaeslog
 
 # Some more information about this module
-__author__ = "Andrew Lee"
+__author__ = "Andrew Lee, Adam Atia"
 
 
 # Set up logger

--- a/watertap/property_models/activated_sludge/asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/asm2d_properties.py
@@ -105,7 +105,7 @@ class ASM2dParameterData(PhysicalParameterBlock):
 
         # Create sets for use across ASM models and associated unit models
         self.non_particulate_component_set = pyo.Set(initialize=["S_A", "S_F", "S_I", "S_N2", "S_NH4", "S_NO3", "S_O2", "S_PO4", "S_ALK", "H2O"])
-        self.particulate_component_set = pyo.Set(initialize=["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_TSS"])
+        self.particulate_component_set = pyo.Set(initialize=["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_S", "X_TSS"])
         self.tss_component_set = pyo.Set(initialize=["X_TSS"])
 
 

--- a/watertap/property_models/activated_sludge/asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/asm2d_properties.py
@@ -104,10 +104,35 @@ class ASM2dParameterData(PhysicalParameterBlock):
         self.X_TSS = Solute(doc="Total suspended solids, TSS. [kg TSS/m^3]")
 
         # Create sets for use across ASM models and associated unit models
-        self.non_particulate_component_set = pyo.Set(initialize=["S_A", "S_F", "S_I", "S_N2", "S_NH4", "S_NO3", "S_O2", "S_PO4", "S_ALK", "H2O"])
-        self.particulate_component_set = pyo.Set(initialize=["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_S", "X_TSS"])
+        self.non_particulate_component_set = pyo.Set(
+            initialize=[
+                "S_A",
+                "S_F",
+                "S_I",
+                "S_N2",
+                "S_NH4",
+                "S_NO3",
+                "S_O2",
+                "S_PO4",
+                "S_ALK",
+                "H2O",
+            ]
+        )
+        self.particulate_component_set = pyo.Set(
+            initialize=[
+                "X_AUT",
+                "X_H",
+                "X_I",
+                "X_MeOH",
+                "X_MeP",
+                "X_PAO",
+                "X_PHA",
+                "X_PP",
+                "X_S",
+                "X_TSS",
+            ]
+        )
         self.tss_component_set = pyo.Set(initialize=["X_TSS"])
-
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(

--- a/watertap/property_models/activated_sludge/modified_asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/modified_asm2d_properties.py
@@ -198,6 +198,7 @@ class ModifiedASM2dParameterData(PhysicalParameterBlock):
             domain=pyo.PositiveReals,
             doc="mass COD per mass VSS of XPHA",
         )
+        # Inorganic solids parameters
         self.ISS_P = pyo.Var(
             initialize=3.23,
             units=pyo.units.dimensionless,

--- a/watertap/property_models/activated_sludge/modified_asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/modified_asm2d_properties.py
@@ -101,6 +101,36 @@ class ModifiedASM2dParameterData(PhysicalParameterBlock):
         self.X_PP = Solute(doc="Poly-phosphate. [kg P/m^3]")
         self.X_S = Solute(doc="Slowly biodegradable substrates. [kg COD/m^3]")
 
+        # Create sets for use across ASM models and associated unit models
+        self.non_particulate_component_set = pyo.Set(
+            initialize=[
+                "S_A",
+                "S_F",
+                "S_I",
+                "S_N2",
+                "S_NH4",
+                "S_NO3",
+                "S_O2",
+                "S_PO4",
+                "S_K",
+                "S_Mg",
+                "S_IC",
+                "H2O",
+            ]
+        )
+        self.particulate_component_set = pyo.Set(
+            initialize=[
+                "X_AUT",
+                "X_H",
+                "X_I",
+                "X_PAO",
+                "X_PHA",
+                "X_PP",
+                "X_S",
+            ]
+        )
+        self.tss_component_set = self.particulate_component_set
+
         # Heat capacity of water
         self.cp_mass = pyo.Param(
             mutable=False,

--- a/watertap/property_models/activated_sludge/modified_asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/modified_asm2d_properties.py
@@ -38,9 +38,10 @@ from idaes.core import (
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import fix_state_vars, revert_state_vars
 import idaes.logger as idaeslog
+import idaes.core.util.scaling as iscale
 
 # Some more information about this module
-__author__ = "Marcus Holly"
+__author__ = "Marcus Holly, Adam Atia"
 
 
 # Set up logger
@@ -129,7 +130,17 @@ class ModifiedASM2dParameterData(PhysicalParameterBlock):
                 "X_S",
             ]
         )
-        self.tss_component_set = self.particulate_component_set
+        self.tss_component_set = pyo.Set(
+            initialize=[
+                "X_AUT",
+                "X_H",
+                "X_I",
+                "X_PAO",
+                "X_PHA",
+                "X_PP",
+                "X_S",
+            ]
+        )
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(
@@ -161,6 +172,48 @@ class ModifiedASM2dParameterData(PhysicalParameterBlock):
             doc="Reference temperature",
             units=pyo.units.K,
         )
+        
+        # COD to VSS coefficients
+        self.CODtoVSS_XI = pyo.Var(
+            initialize=1.5686,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of XI",
+        )
+        self.CODtoVSS_XS = pyo.Var(
+            initialize=1.5686,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of XS",
+        )
+        self.CODtoVSS_XBM = pyo.Var(
+            initialize=1.3072,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of biomass",
+        )
+        self.CODtoVSS_XPHA = pyo.Var(
+            initialize=1.9608,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of XPHA",
+        )
+        self.ISS_P = pyo.Var(
+            initialize=3.23,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass ISS per mass P",
+        )
+        self.f_ISS_BM = pyo.Var(
+            initialize=0.15,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="ISS fractional content of biomass",
+        )
+
+        # Fix Vars that are treated as Params
+        for v in self.component_objects(pyo.Var):
+            v.fix()
 
     @classmethod
     def define_metadata(cls, obj):
@@ -170,6 +223,13 @@ class ModifiedASM2dParameterData(PhysicalParameterBlock):
                 "pressure": {"method": None},
                 "temperature": {"method": None},
                 "conc_mass_comp": {"method": None},
+            }
+        )
+        obj.define_custom_properties(
+            {
+                "VSS": {"method": "_VSS"},
+                "ISS": {"method": "_ISS"},
+                "TSS": {"method": "_TSS"},
             }
         )
         obj.add_default_units(
@@ -299,7 +359,7 @@ class ModifiedASM2dStateBlockData(StateBlockData):
         self.flow_vol = pyo.Var(
             initialize=1.0,
             domain=pyo.NonNegativeReals,
-            doc="Total volumentric flowrate",
+            doc="Total volumetric flowrate",
             units=pyo.units.m**3 / pyo.units.s,
         )
         self.pressure = pyo.Var(
@@ -323,6 +383,53 @@ class ModifiedASM2dStateBlockData(StateBlockData):
             doc="Component mass concentrations",
             units=pyo.units.kg / pyo.units.m**3,
         )
+
+    # On-demand properties
+    def _VSS(self):
+        self.VSS = pyo.Var(
+            initialize=1,
+            domain=pyo.NonNegativeReals,
+            doc="Volatile suspended solids",
+            units=pyo.units.kg / pyo.units.m**3,
+        )
+
+        # TODO: X_SRB not included yet in biomass term summation
+        def rule_VSS(b):
+            return (b.VSS == b.conc_mass_comp["X_I"] / b.params.CODtoVSS_XI
+                    + b.conc_mass_comp["X_S"] / b.params.CODtoVSS_XS
+                    + (b.conc_mass_comp["X_H"] + b.conc_mass_comp["X_PAO"] + b.conc_mass_comp["X_AUT"]) / b.params.CODtoVSS_XBM
+                    + b.conc_mass_comp["X_PHA"] / b.params.CODtoVSS_XPHA
+                    )
+        self.eq_VSS = pyo.Constraint(rule=rule_VSS)
+    
+    def _ISS(self):
+        self.ISS = pyo.Var(
+            initialize=1,
+            domain=pyo.NonNegativeReals,
+            doc="Inorganic suspended solids",
+            units=pyo.units.kg / pyo.units.m**3,
+        )
+
+        #TODO: Several HFO and other terms omitted since not included yet.
+        def rule_ISS(b):
+            return (b.ISS == b.params.f_ISS_BM 
+                    * (b.conc_mass_comp["X_H"] + b.conc_mass_comp["X_PAO"] + b.conc_mass_comp["X_AUT"]) / b.params.CODtoVSS_XBM 
+                    + b.params.ISS_P * b.conc_mass_comp["X_PP"]
+                    )
+        self.eq_ISS = pyo.Constraint(rule=rule_ISS)
+
+    def _TSS(self):
+        self.TSS = pyo.Var(
+            initialize=1,
+            domain=pyo.NonNegativeReals,
+            doc="Total suspended solids",
+            units=pyo.units.kg / pyo.units.m**3,
+        )
+    
+        def rule_TSS(b):
+            return b.TSS == b.VSS + b.ISS
+
+        self.eq_TSS = pyo.Constraint(rule=rule_TSS)
 
     def get_material_flow_terms(self, p, j):
         if j == "H2O":
@@ -375,3 +482,19 @@ class ModifiedASM2dStateBlockData(StateBlockData):
 
     def get_material_flow_basis(self):
         return MaterialFlowBasis.mass
+
+    def calculate_scaling_factors(self):
+        super().calculate_scaling_factors()
+
+        #TODO: revisit scaling of these new on-demand props
+        if self.is_property_constructed("VSS"):
+            if iscale.get_scaling_factor(self.VSS) is None:
+                iscale.set_scaling_factor(self.VSS, 1)
+        
+        if self.is_property_constructed("ISS"):
+            if iscale.get_scaling_factor(self.ISS) is None:
+                iscale.set_scaling_factor(self.ISS, 1)
+        
+        if self.is_property_constructed("TSS"):
+            if iscale.get_scaling_factor(self.TSS) is None:
+                iscale.set_scaling_factor(self.TSS, 1)        

--- a/watertap/property_models/activated_sludge/modified_asm2d_reactions.py
+++ b/watertap/property_models/activated_sludge/modified_asm2d_reactions.py
@@ -257,7 +257,43 @@ class ModifiedASM2dReactionParameterData(ReactionParameterBlock):
             domain=pyo.PositiveReals,
             doc="Magnesium coefficient for polyphosphates",
         )
-
+        # COD to VSS coefficients
+        self.CODtoVSS_XI = pyo.Var(
+            initialize=1.5686,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of XI",
+        )
+        self.CODtoVSS_XS = pyo.Var(
+            initialize=1.5686,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of XS",
+        )
+        self.CODtoVSS_XBM = pyo.Var(
+            initialize=1.3072,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of biomass",
+        )
+        self.CODtoVSS_XPHA = pyo.Var(
+            initialize=1.9608,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass COD per mass VSS of XPHA",
+        )
+        self.ISS_P = pyo.Var(
+            initialize=3.23,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="mass ISS per mass P",
+        )
+        self.f_ISS_BM = pyo.Var(
+            initialize=0.15,
+            units=pyo.units.dimensionless,
+            domain=pyo.PositiveReals,
+            doc="ISS content of biomass",
+        )
         # Kinetic Parameters
         self.K_H = pyo.Var(
             initialize=2.46,
@@ -960,6 +996,14 @@ class ModifiedASM2dReactionParameterData(ReactionParameterBlock):
                 "reaction_rate": {"method": "_rxn_rate"},
             }
         )
+
+        obj.define_custom_properties(
+            {
+                "VSS": {"method": "_VSS"},
+                "ISS": {"method": "_ISS"},
+                "TSS": {"method": "_TSS"},
+            }
+        )
         obj.add_default_units(
             {
                 "time": pyo.units.s,
@@ -1589,6 +1633,52 @@ class ModifiedASM2dReactionBlockData(ReactionBlockDataBase):
             self.del_component(self.rate_expression)
             raise
 
+    def _VSS(self):
+        self.VSS = pyo.Var(
+            initialize=1,
+            domain=pyo.NonNegativeReals,
+            doc="Volatile suspended solids",
+            units=pyo.units.kg / pyo.units.m**3,
+        )
+
+        # TODO: X_SRB not included yet in biomass term summation
+        def rule_VSS(b):
+            return (b.VSS == b.conc_mass_comp_ref["X_I"] / b.params.CODtoVSS_XI
+                    + b.conc_mass_comp_ref["X_S"] / b.params.CODtoVSS_XS
+                    + (b.conc_mass_comp_ref["X_H"] + b.conc_mass_comp_ref["X_PAO"] + b.conc_mass_comp_ref["X_A"]) / b.params.CODtoVSS_XBM
+                    + b.conc_mass_comp_ref["X_PHA"] / b.params.CODtoVSS_XPHA
+                    )
+        self.eq_VSS = pyo.Constraint(rule=rule_VSS)
+    
+    def _ISS(self):
+        self.ISS = pyo.Var(
+            initialize=1,
+            domain=pyo.NonNegativeReals,
+            doc="Inorganic suspended solids",
+            units=pyo.units.kg / pyo.units.m**3,
+        )
+
+        #TODO: Several HFO and other terms omitted since not included yet.
+        def rule_ISS(b):
+            return (b.ISS == b.params.f_ISS_BM 
+                    * (b.conc_mass_comp_ref["X_H"] + b.conc_mass_comp_ref["X_PAO"] + b.conc_mass_comp_ref["X_A"]) / b.params.CODtoVSS_XBM 
+                    + b.params.ISS_P * b.conc_mass_comp_ref["X_PP"]
+                    )
+        self.eq_ISS = pyo.Constraint(rule=rule_ISS)
+
+    def _TSS(self):
+        self.TSS = pyo.Var(
+            initialize=1,
+            domain=pyo.NonNegativeReals,
+            doc="Total suspended solids",
+            units=pyo.units.kg / pyo.units.m**3,
+        )
+    
+        def rule_TSS(b):
+            return b.TSS == b.VSS + b.ISS
+
+        self.eq_TSS = pyo.Constraint(rule=rule_TSS)
+
     def get_reaction_rate_basis(self):
         return MaterialFlowBasis.mass
 
@@ -1599,3 +1689,15 @@ class ModifiedASM2dReactionBlockData(ReactionBlockDataBase):
             # TODO: Need to work out how to calculate good scaling factors
             # instead of a fixed 1e3.
             iscale.constraint_scaling_transform(c, 1e3, overwrite=True)
+        
+        if self.is_property_constructed("VSS"):
+            if iscale.get_scaling_factor(self.VSS) is None:
+                iscale.set_scaling_factor(self.VSS, 1)
+        
+        if self.is_property_constructed("ISS"):
+            if iscale.get_scaling_factor(self.ISS) is None:
+                iscale.set_scaling_factor(self.ISS, 1)
+        
+        if self.is_property_constructed("TSS"):
+            if iscale.get_scaling_factor(self.TSS) is None:
+                iscale.set_scaling_factor(self.TSS, 1)        

--- a/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
@@ -83,6 +83,39 @@ class TestParamBlock(object):
         assert isinstance(model.params.temperature_ref, Param)
         assert value(model.params.temperature_ref) == 298.15
 
+        assert len(model.params.particulate_component_set) == 6
+        assert len(model.params.non_particulate_component_set) == 8
+        assert len(model.params.tss_component_set) == 5
+        for i in model.params.particulate_component_set:
+            assert i in [
+                "X_I",
+                "X_S",
+                "X_BH",
+                "X_BA",
+                "X_P",
+                "X_ND",
+            ]
+        
+        for i in model.params.tss_component_set:
+            assert i in [
+                "X_I",
+                "X_S",
+                "X_BH",
+                "X_BA",
+                "X_P",
+            ]
+
+        for i in model.params.non_particulate_component_set:
+            assert i in [
+                "H2O",
+                "S_I",
+                "S_S",
+                "S_O",
+                "S_NO",
+                "S_NH",
+                "S_ND",
+                "S_ALK",
+            ]
 
 class TestStateBlock(object):
     @pytest.fixture(scope="class")

--- a/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
@@ -95,7 +95,7 @@ class TestParamBlock(object):
                 "X_P",
                 "X_ND",
             ]
-        
+
         for i in model.params.tss_component_set:
             assert i in [
                 "X_I",
@@ -116,6 +116,7 @@ class TestParamBlock(object):
                 "S_ND",
                 "S_ALK",
             ]
+
 
 class TestStateBlock(object):
     @pytest.fixture(scope="class")

--- a/watertap/property_models/activated_sludge/tests/test_asm2d_reaction.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm2d_reaction.py
@@ -377,7 +377,7 @@ class TestAerobic:
         # No data on TSS from EXPOsan at this point
         m.fs.R1.inlet.conc_mass_comp[0, "X_TSS"].fix(EPS * units.mg / units.liter)
 
-        # Alkalinity was givien in mg/L based on C
+        # Alkalinity was given in mg/L based on C
         m.fs.R1.inlet.alkalinity[0].fix(61 / 12 * units.mmol / units.liter)
 
         m.fs.R1.volume.fix(1333 * units.m**3)

--- a/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
@@ -89,6 +89,17 @@ class TestParamBlock(object):
         assert isinstance(model.params.temperature_ref, Param)
         assert value(model.params.temperature_ref) == 298.15
 
+        assert len(model.params.particulate_component_set) == 9
+        assert len(model.params.non_particulate_component_set) == 10
+        assert len(model.params.tss_component_set) == 1
+        for i in model.params.particulate_component_set:
+            assert i in ["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_TSS"]
+        
+        for i in model.params.tss_component_set:
+            assert i in ["X_TSS"]
+
+        for i in model.params.non_particulate_component_set:
+            assert i in ["S_A", "S_F", "S_I", "S_N2", "S_NH4", "S_NO3", "S_O2", "S_PO4", "S_ALK", "H2O"]
 
 class TestStateBlock(object):
     @pytest.fixture(scope="class")

--- a/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
@@ -93,13 +93,36 @@ class TestParamBlock(object):
         assert len(model.params.non_particulate_component_set) == 10
         assert len(model.params.tss_component_set) == 1
         for i in model.params.particulate_component_set:
-            assert i in ["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_S","X_TSS"]
-        
+            assert i in [
+                "X_AUT",
+                "X_H",
+                "X_I",
+                "X_MeOH",
+                "X_MeP",
+                "X_PAO",
+                "X_PHA",
+                "X_PP",
+                "X_S",
+                "X_TSS",
+            ]
+
         for i in model.params.tss_component_set:
             assert i in ["X_TSS"]
 
         for i in model.params.non_particulate_component_set:
-            assert i in ["S_A", "S_F", "S_I", "S_N2", "S_NH4", "S_NO3", "S_O2", "S_PO4", "S_ALK", "H2O"]
+            assert i in [
+                "S_A",
+                "S_F",
+                "S_I",
+                "S_N2",
+                "S_NH4",
+                "S_NO3",
+                "S_O2",
+                "S_PO4",
+                "S_ALK",
+                "H2O",
+            ]
+
 
 class TestStateBlock(object):
     @pytest.fixture(scope="class")

--- a/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
@@ -89,11 +89,11 @@ class TestParamBlock(object):
         assert isinstance(model.params.temperature_ref, Param)
         assert value(model.params.temperature_ref) == 298.15
 
-        assert len(model.params.particulate_component_set) == 9
+        assert len(model.params.particulate_component_set) == 10
         assert len(model.params.non_particulate_component_set) == 10
         assert len(model.params.tss_component_set) == 1
         for i in model.params.particulate_component_set:
-            assert i in ["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_TSS"]
+            assert i in ["X_AUT", "X_H", "X_I", "X_MeOH", "X_MeP", "X_PAO", "X_PHA", "X_PP", "X_S","X_TSS"]
         
         for i in model.params.tss_component_set:
             assert i in ["X_TSS"]

--- a/watertap/property_models/activated_sludge/tests/test_modified_asm2d_reaction.py
+++ b/watertap/property_models/activated_sludge/tests/test_modified_asm2d_reaction.py
@@ -11,7 +11,7 @@
 #################################################################################
 """
 Tests for modified ASM2d reaction package.
-Author: Marcus Holly
+Author: Marcus Holly, Adam Atia
 
 References:
 
@@ -746,8 +746,6 @@ class TestAnoxicPHA:
 
         m.fs.R1 = CSTR(property_package=m.fs.props, reaction_package=m.fs.rxn_props)
 
-        iscale.calculate_scaling_factors(m.fs)
-
         # NOTE: Concentrations of exactly 0 result in singularities, use EPS instead
         EPS = 1e-8
 
@@ -778,6 +776,13 @@ class TestAnoxicPHA:
         m.fs.R1.inlet.conc_mass_comp[0, "X_AUT"].fix(115.4611 * units.mg / units.liter)
 
         m.fs.R1.volume.fix(1000 * units.m**3)
+        
+        # Touch on-demand property, TSS, at inlet and outlet
+        m.fs.R1.control_volume.properties_in[0].TSS
+        m.fs.R1.control_volume.properties_out[0].TSS
+
+
+        iscale.calculate_scaling_factors(m.fs)
 
         return m
 
@@ -787,7 +792,7 @@ class TestAnoxicPHA:
 
     @pytest.mark.unit
     def test_unit_consistency(self, model):
-        assert_units_consistent(model) == 0
+        assert_units_consistent(model)
 
     @pytest.mark.component
     def test_solve(self, model):
@@ -861,3 +866,6 @@ class TestAnoxicPHA:
         assert value(model.fs.R1.outlet.conc_mass_comp[0, "X_S"]) == pytest.approx(
             121.314e-3, rel=1e-4
         )
+        assert value(1-model.fs.R1.control_volume.properties_out[0].TSS/model.fs.R1.control_volume.properties_in[0].TSS) * 100 == pytest.approx(
+            0.20371, rel=1e-4
+        )        

--- a/watertap/property_models/activated_sludge/tests/test_modified_asm2d_reaction.py
+++ b/watertap/property_models/activated_sludge/tests/test_modified_asm2d_reaction.py
@@ -776,11 +776,10 @@ class TestAnoxicPHA:
         m.fs.R1.inlet.conc_mass_comp[0, "X_AUT"].fix(115.4611 * units.mg / units.liter)
 
         m.fs.R1.volume.fix(1000 * units.m**3)
-        
+
         # Touch on-demand property, TSS, at inlet and outlet
         m.fs.R1.control_volume.properties_in[0].TSS
         m.fs.R1.control_volume.properties_out[0].TSS
-
 
         iscale.calculate_scaling_factors(m.fs)
 
@@ -866,6 +865,8 @@ class TestAnoxicPHA:
         assert value(model.fs.R1.outlet.conc_mass_comp[0, "X_S"]) == pytest.approx(
             121.314e-3, rel=1e-4
         )
-        assert value(1-model.fs.R1.control_volume.properties_out[0].TSS/model.fs.R1.control_volume.properties_in[0].TSS) * 100 == pytest.approx(
-            0.20371, rel=1e-4
-        )        
+        assert value(
+            1
+            - model.fs.R1.control_volume.properties_out[0].TSS
+            / model.fs.R1.control_volume.properties_in[0].TSS
+        ) * 100 == pytest.approx(0.20371, rel=1e-4)

--- a/watertap/property_models/activated_sludge/tests/test_modified_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_modified_asm2d_thermo.py
@@ -11,7 +11,7 @@
 #################################################################################
 """
 Tests for modified ASM2d thermo property package.
-Author: Marcus Holly
+Author: Marcus Holly, Adam Atia
 """
 
 import pytest
@@ -29,6 +29,7 @@ from idaes.core.util.model_statistics import (
 )
 
 from idaes.core.solvers import get_solver
+from watertap.property_models.tests.property_test_harness import PropertyAttributeError
 
 
 # -----------------------------------------------------------------------------
@@ -88,6 +89,69 @@ class TestParamBlock(object):
         assert isinstance(model.params.temperature_ref, Param)
         assert value(model.params.temperature_ref) == 298.15
 
+        assert len(model.params.particulate_component_set) == 7
+        assert len(model.params.non_particulate_component_set) == 12
+        assert len(model.params.tss_component_set) == 7
+        for i in model.params.particulate_component_set:
+            assert i in [
+                "X_AUT",
+                "X_H",
+                "X_I",
+                "X_PAO",
+                "X_PHA",
+                "X_PP",
+                "X_S",
+            ]
+        for i in model.params.tss_component_set:
+            assert i in [
+                "X_AUT",
+                "X_H",
+                "X_I",
+                "X_PAO",
+                "X_PHA",
+                "X_PP",
+                "X_S",
+            ]
+
+        for i in model.params.non_particulate_component_set:
+            assert i in [
+                "S_A",
+                "S_F",
+                "S_I",
+                "S_N2",
+                "S_NH4",
+                "S_NO3",
+                "S_O2",
+                "S_PO4",
+                "S_K",
+                "S_Mg",
+                "S_IC",
+                "H2O",
+            ]
+        
+        assert isinstance(model.params.CODtoVSS_XI, Var)
+        assert model.params.CODtoVSS_XI.is_fixed()
+        assert value(model.params.CODtoVSS_XI) == 1.5686
+
+        assert isinstance(model.params.CODtoVSS_XS, Var)
+        assert model.params.CODtoVSS_XS.is_fixed()
+        assert value(model.params.CODtoVSS_XS) == 1.5686
+
+        assert isinstance(model.params.CODtoVSS_XBM, Var)
+        assert model.params.CODtoVSS_XBM.is_fixed()
+        assert value(model.params.CODtoVSS_XBM) == 1.3072
+
+        assert isinstance(model.params.CODtoVSS_XPHA, Var)
+        assert model.params.CODtoVSS_XPHA.is_fixed()
+        assert value(model.params.CODtoVSS_XPHA) == 1.9608
+
+        assert isinstance(model.params.ISS_P, Var)
+        assert model.params.ISS_P.is_fixed()
+        assert value(model.params.ISS_P) == 3.23
+
+        assert isinstance(model.params.f_ISS_BM, Var)
+        assert model.params.f_ISS_BM.is_fixed()
+        assert value(model.params.f_ISS_BM) == 0.15
 
 class TestStateBlock(object):
     @pytest.fixture(scope="class")
@@ -135,6 +199,27 @@ class TestStateBlock(object):
                 "X_S",
             ]
             assert value(model.props[1].conc_mass_comp[i]) == 0.1
+
+        metadata = model.params.get_metadata().properties
+
+        # check that properties are not built if not demanded
+        for v in metadata.list_supported_properties():
+            if metadata[v.name].method is not None:
+                if model.props[1].is_property_constructed(v.name):
+                    raise PropertyAttributeError(
+                        "Property {v_name} is an on-demand property, but was found "
+                        "on the stateblock without being demanded".format(v_name=v.name)
+                    )
+
+        # check that properties are built if demanded
+        for v in metadata.list_supported_properties():
+            if metadata[v.name].method is not None:
+                if not hasattr(model.props[1], v.name):
+                    raise PropertyAttributeError(
+                        "Property {v_name} is an on-demand property, but was not built "
+                        "when demanded".format(v_name=v.name)
+                    )
+
 
     @pytest.mark.unit
     def test_get_material_flow_terms(self, model):
@@ -259,3 +344,4 @@ class TestStateBlock(object):
     @pytest.mark.unit
     def check_units(self, model):
         assert_units_consistent(model)
+

--- a/watertap/property_models/activated_sludge/tests/test_modified_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_modified_asm2d_thermo.py
@@ -128,7 +128,7 @@ class TestParamBlock(object):
                 "S_IC",
                 "H2O",
             ]
-        
+
         assert isinstance(model.params.CODtoVSS_XI, Var)
         assert model.params.CODtoVSS_XI.is_fixed()
         assert value(model.params.CODtoVSS_XI) == 1.5686
@@ -152,6 +152,7 @@ class TestParamBlock(object):
         assert isinstance(model.params.f_ISS_BM, Var)
         assert model.params.f_ISS_BM.is_fixed()
         assert value(model.params.f_ISS_BM) == 0.15
+
 
 class TestStateBlock(object):
     @pytest.fixture(scope="class")
@@ -219,7 +220,6 @@ class TestStateBlock(object):
                         "Property {v_name} is an on-demand property, but was not built "
                         "when demanded".format(v_name=v.name)
                     )
-
 
     @pytest.mark.unit
     def test_get_material_flow_terms(self, model):
@@ -344,4 +344,3 @@ class TestStateBlock(object):
     @pytest.mark.unit
     def check_units(self, model):
         assert_units_consistent(model)
-

--- a/watertap/property_models/anaerobic_digestion/modified_adm1_properties.py
+++ b/watertap/property_models/anaerobic_digestion/modified_adm1_properties.py
@@ -36,7 +36,7 @@ import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 
 # Some more information about this module
-__author__ = "Chenyu Wang, Marcus Holly"
+__author__ = "Chenyu Wang, Marcus Holly, Adam Atia"
 # Using Andrew Lee's formulation of ASM1 as a template
 
 # Set up logger
@@ -181,6 +181,11 @@ class ModifiedADM1ParameterData(PhysicalParameterBlock):
             doc="ISS fractional content of biomass",
         )
 
+        # Fix Vars that are treated as Params
+        for v in self.component_objects(pyo.Var):
+            v.fix()
+
+    @classmethod
     def define_metadata(cls, obj):
         obj.add_properties(
             {
@@ -432,7 +437,7 @@ class ModifiedADM1StateBlockData(StateBlockData):
         iscale.set_scaling_factor(self.anions, 1e1)
         iscale.set_scaling_factor(self.cations, 1e1)
 
-        # On-demand properties
+    # On-demand properties
     def _VSS(self):
         self.VSS = pyo.Var(
             initialize=1,

--- a/watertap/unit_models/dewatering.py
+++ b/watertap/unit_models/dewatering.py
@@ -91,7 +91,7 @@ class DewateringData(SeparatorData):
             domain=list,
             doc="List of TSS components.",
         ),
-    )       
+    )
 
     def build(self):
         """
@@ -129,7 +129,9 @@ class DewateringData(SeparatorData):
 
         @self.Expression(self.flowsheet().time, doc="Suspended solid concentration")
         def TSS(blk, t):
-            return 0.75 * (sum(blk.inlet.conc_mass_comp[t, i] for i in self.config.tss_components))
+            return 0.75 * (
+                sum(blk.inlet.conc_mass_comp[t, i] for i in self.config.tss_components)
+            )
 
         @self.Expression(self.flowsheet().time, doc="Dewatering factor")
         def f_dewat(blk, t):

--- a/watertap/unit_models/dewatering.py
+++ b/watertap/unit_models/dewatering.py
@@ -34,7 +34,6 @@ from pyomo.environ import (
     units as pyunits,
     Set,
 )
-from pyomo.common.config import ConfigValue
 
 from idaes.core.util.exceptions import (
     ConfigurationError,
@@ -57,41 +56,6 @@ class DewateringData(SeparatorData):
     CONFIG.outlet_list = ["underflow", "overflow"]
     CONFIG.split_basis = SplittingType.componentFlow
 
-    CONFIG.declare(
-        "non_particulate_components_list",
-        ConfigValue(
-            default=[
-                "S_I",
-                "S_S",
-                "S_O",
-                "S_NO",
-                "S_NH",
-                "S_ND",
-                "H2O",
-                "S_ALK",
-            ],
-            domain=list,
-            doc="List of non particulate component list.",
-        ),
-    )
-
-    CONFIG.declare(
-        "particulate_components_list",
-        ConfigValue(
-            default=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"],
-            domain=list,
-            doc="List of particulate component list.",
-        ),
-    )
-
-    CONFIG.declare(
-        "tss_components",
-        ConfigValue(
-            default=["X_I", "X_S", "X_P", "X_BH", "X_BA"],
-            domain=list,
-            doc="List of TSS components.",
-        ),
-    )
 
     def build(self):
         """
@@ -130,7 +94,11 @@ class DewateringData(SeparatorData):
         @self.Expression(self.flowsheet().time, doc="Suspended solid concentration")
         def TSS(blk, t):
             return 0.75 * (
-                sum(blk.inlet.conc_mass_comp[t, i] for i in self.config.tss_components)
+                blk.inlet.conc_mass_comp[t, "X_I"]
+                + blk.inlet.conc_mass_comp[t, "X_P"]
+                + blk.inlet.conc_mass_comp[t, "X_BH"]
+                + blk.inlet.conc_mass_comp[t, "X_BA"]
+                + blk.inlet.conc_mass_comp[t, "X_S"]
             )
 
         @self.Expression(self.flowsheet().time, doc="Dewatering factor")
@@ -142,11 +110,20 @@ class DewateringData(SeparatorData):
             return blk.TSS_rem / (pyunits.kg / pyunits.m**3) / 100 / blk.f_dewat[t]
 
         self.non_particulate_components = Set(
-            initialize=self.config.non_particulate_components_list
+            initialize=[
+                "S_I",
+                "S_S",
+                "S_O",
+                "S_NO",
+                "S_NH",
+                "S_ND",
+                "H2O",
+                "S_ALK",
+            ]
         )
 
         self.particulate_components = Set(
-            initialize=self.config.particulate_components_list
+            initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]
         )
 
         @self.Constraint(

--- a/watertap/unit_models/dewatering.py
+++ b/watertap/unit_models/dewatering.py
@@ -50,6 +50,7 @@ __author__ = "Alejandro Garciadiego, Adam Atia"
 # Set up logger
 _log = idaeslog.getLogger(__name__)
 
+
 class ActivatedSludgeModelType(Enum):
     """
     ASM1: ASM1 model
@@ -60,6 +61,8 @@ class ActivatedSludgeModelType(Enum):
     ASM1 = auto()
     ASM2D = auto()
     modified_ASM2D = auto()
+
+
 @declare_process_block_class("DewateringUnit")
 class DewateringData(SeparatorData):
     """

--- a/watertap/unit_models/dewatering.py
+++ b/watertap/unit_models/dewatering.py
@@ -56,7 +56,6 @@ class DewateringData(SeparatorData):
     CONFIG.outlet_list = ["underflow", "overflow"]
     CONFIG.split_basis = SplittingType.componentFlow
 
-
     def build(self):
         """
         Begin building model.

--- a/watertap/unit_models/dewatering.py
+++ b/watertap/unit_models/dewatering.py
@@ -11,7 +11,8 @@
 #
 ###############################################################################
 """
-Dewatering unit model for BSM2. Based on IDAES separator unit
+Dewatering unit model for BSM2 and plant-wide wastewater treatment modeling. 
+This unit inherits from the IDAES separator unit.
 
 Model based on 
 
@@ -19,7 +20,11 @@ J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson,
 I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer and
 P. A. Vanrolleghem
 Benchmark Simulation Model no. 2 (BSM2)
+
+Modifications made to TSS formulation based on ASM type.
 """
+from enum import Enum, auto
+
 # Import IDAES cores
 from idaes.core import (
     declare_process_block_class,
@@ -32,20 +37,29 @@ import idaes.logger as idaeslog
 from pyomo.environ import (
     Param,
     units as pyunits,
-    Set,
 )
+from pyomo.common.config import ConfigValue, In
 
 from idaes.core.util.exceptions import (
     ConfigurationError,
 )
 
-__author__ = "Alejandro Garciadiego"
+__author__ = "Alejandro Garciadiego, Adam Atia"
 
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)
 
+class ActivatedSludgeModelType(Enum):
+    """
+    ASM1: ASM1 model
+    ASM2D: ASM2D model
+    modified_ASM2D: modified ASM2D model for ADM1 compatibility
+    """
 
+    ASM1 = auto()
+    ASM2D = auto()
+    modified_ASM2D = auto()
 @declare_process_block_class("DewateringUnit")
 class DewateringData(SeparatorData):
     """
@@ -55,6 +69,27 @@ class DewateringData(SeparatorData):
     CONFIG = SeparatorData.CONFIG()
     CONFIG.outlet_list = ["underflow", "overflow"]
     CONFIG.split_basis = SplittingType.componentFlow
+
+    CONFIG.declare(
+        "activated_sludge_model",
+        ConfigValue(
+            default=ActivatedSludgeModelType.ASM1,
+            domain=In(ActivatedSludgeModelType),
+            description="Activated Sludge Model used with unit",
+            doc="""
+        Options to account for version of activated sludge model property package.
+
+        **default** - ``ActivatedSludgeModelType.ASM1``
+
+    .. csv-table::
+        :header: "Configuration Options", "Description"
+
+        "``ActivatedSludgeModelType.ASM1``", "ASM1 model"
+        "``ActivatedSludgeModelType.ASM2D``", "ASM2D model"
+        "``ActivatedSludgeModelType.modified_ASM2D``", "modified ASM2D model for ADM1 compatibility"
+    """,
+        ),
+    )
 
     def build(self):
         """
@@ -91,43 +126,39 @@ class DewateringData(SeparatorData):
         )
 
         @self.Expression(self.flowsheet().time, doc="Suspended solid concentration")
-        def TSS(blk, t):
-            return 0.75 * (
-                blk.inlet.conc_mass_comp[t, "X_I"]
-                + blk.inlet.conc_mass_comp[t, "X_P"]
-                + blk.inlet.conc_mass_comp[t, "X_BH"]
-                + blk.inlet.conc_mass_comp[t, "X_BA"]
-                + blk.inlet.conc_mass_comp[t, "X_S"]
-            )
+        def TSS_in(blk, t):
+            if blk.config.activated_sludge_model == ActivatedSludgeModelType.ASM1:
+                return 0.75 * (
+                    sum(
+                        blk.inlet.conc_mass_comp[t, i]
+                        for i in blk.config.property_package.tss_component_set
+                    )
+                )
+            elif blk.config.activated_sludge_model == ActivatedSludgeModelType.ASM2D:
+                return blk.inlet.conc_mass_comp[
+                    t, blk.config.property_package.tss_component_set.first()
+                ]
+            elif (
+                blk.config.activated_sludge_model
+                == ActivatedSludgeModelType.modified_ASM2D
+            ):
+                return blk.mixed_state[t].TSS
+            else:
+                raise ConfigurationError(
+                    "The activated_sludge_model was not specified properly in configuration options."
+                )
 
         @self.Expression(self.flowsheet().time, doc="Dewatering factor")
         def f_dewat(blk, t):
-            return blk.p_dewat * (10 / (blk.TSS[t]))
+            return blk.p_dewat * (10 / (blk.TSS_in[t]))
 
         @self.Expression(self.flowsheet().time, doc="Remove factor")
         def f_q_du(blk, t):
             return blk.TSS_rem / (pyunits.kg / pyunits.m**3) / 100 / blk.f_dewat[t]
 
-        self.non_particulate_components = Set(
-            initialize=[
-                "S_I",
-                "S_S",
-                "S_O",
-                "S_NO",
-                "S_NH",
-                "S_ND",
-                "H2O",
-                "S_ALK",
-            ]
-        )
-
-        self.particulate_components = Set(
-            initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]
-        )
-
         @self.Constraint(
             self.flowsheet().time,
-            self.particulate_components,
+            self.config.property_package.particulate_component_set,
             doc="particulate fraction",
         )
         def overflow_particulate_fraction(blk, t, i):
@@ -135,7 +166,7 @@ class DewateringData(SeparatorData):
 
         @self.Constraint(
             self.flowsheet().time,
-            self.non_particulate_components,
+            self.config.property_package.non_particulate_component_set,
             doc="soluble fraction",
         )
         def non_particulate_components(blk, t, i):

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -81,7 +81,6 @@ def test_config():
     assert SplittingType.componentFlow is m.fs.unit.config.split_basis
 
 
-
 @pytest.mark.unit
 def test_list_error():
     m = ConcreteModel()

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -48,12 +48,20 @@ from idaes.core.util.exceptions import (
     ConfigurationError,
 )
 
-from watertap.unit_models.dewatering import DewateringUnit
+from watertap.unit_models.dewatering import DewateringUnit, ActivatedSludgeModelType
 from watertap.property_models.activated_sludge.asm1_properties import (
     ASM1ParameterBlock,
 )
 
+from watertap.property_models.activated_sludge.asm2d_properties import (
+    ASM2dParameterBlock,
+)
+from watertap.property_models.activated_sludge.modified_asm2d_properties import (
+    ModifiedASM2dParameterBlock,
+)    
 from pyomo.util.check_units import assert_units_consistent
+
+__author__ = "Alejandro Garciadiego, Adam Atia"
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -70,12 +78,14 @@ def test_config():
 
     m.fs.unit = DewateringUnit(property_package=m.fs.props)
 
-    assert len(m.fs.unit.config) == 15
+    assert len(m.fs.unit.config) == 16
 
     assert not m.fs.unit.config.dynamic
     assert not m.fs.unit.config.has_holdup
     assert m.fs.unit.config.material_balance_type == MaterialBalanceType.useDefault
     assert m.fs.unit.config.momentum_balance_type == MomentumBalanceType.pressureTotal
+    assert m.fs.unit.config.activated_sludge_model == ActivatedSludgeModelType.ASM1
+
     assert "underflow" in m.fs.unit.config.outlet_list
     assert "overflow" in m.fs.unit.config.outlet_list
     assert SplittingType.componentFlow is m.fs.unit.config.split_basis
@@ -270,3 +280,144 @@ class TestDu(object):
     @pytest.mark.unit
     def test_report(self, du):
         du.fs.unit.report()
+
+
+class TestDUASM2d(object):
+    @pytest.fixture(scope="class")
+    def du_asm2d(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+
+        m.fs.props = ASM2dParameterBlock()
+
+        m.fs.unit = DewateringUnit(
+            property_package=m.fs.props,
+            activated_sludge_model=ActivatedSludgeModelType.ASM2D,
+        )
+
+        # NOTE: Concentrations of exactly 0 result in singularities, use EPS instead
+        EPS = 1e-8
+
+        m.fs.unit.inlet.flow_vol.fix(300 * units.m**3 / units.day)
+        m.fs.unit.inlet.temperature.fix(308.15 * units.K)
+        m.fs.unit.inlet.pressure.fix(1 * units.atm)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_O2"].fix(7.9707 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_N2"].fix(29.0603 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_NH4"].fix(8.0209 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_NO3"].fix(6.6395 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_PO4"].fix(7.8953 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_F"].fix(0.4748 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_A"].fix(0.0336 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_I"].fix(30 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_I"].fix(1695.7695 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_S"].fix(68.2975 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_H"].fix(1855.5067 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PAO"].fix(
+            214.5319 * units.mg / units.liter
+        )
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PP"].fix(63.5316 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PHA"].fix(2.7381 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_AUT"].fix(
+            118.3582 * units.mg / units.liter
+        )
+        m.fs.unit.inlet.conc_mass_comp[0, "X_MeOH"].fix(EPS * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_MeP"].fix(EPS * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_TSS"].fix(
+            3525.429 * units.mg / units.liter
+        )
+        m.fs.unit.inlet.alkalinity[0].fix(4.6663 * units.mmol / units.liter)
+
+        return m
+    
+    @pytest.mark.unit
+    def test_dof(self, du_asm2d):
+        assert degrees_of_freedom(du_asm2d) == 0
+    
+    @pytest.mark.unit
+    def test_units(self, du_asm2d):
+        assert_units_consistent(du_asm2d)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_initialize(self, du_asm2d):
+
+        iscale.calculate_scaling_factors(du_asm2d)
+        initialization_tester(du_asm2d)
+    
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, du_asm2d):
+        solver = get_solver()
+        results = solver.solve(du_asm2d)
+        assert_optimal_termination(results)
+
+
+class TestDUModifiedASM2d(object):
+    @pytest.fixture(scope="class")
+    def du_mod_asm2d(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+
+        m.fs.props = ModifiedASM2dParameterBlock()
+
+        m.fs.unit = DewateringUnit(
+            property_package=m.fs.props,
+            activated_sludge_model=ActivatedSludgeModelType.modified_ASM2D,
+        )
+
+        # NOTE: Concentrations of exactly 0 result in singularities, use EPS instead
+        EPS = 1e-8
+
+        m.fs.unit.inlet.flow_vol.fix(300 * units.m**3 / units.day)
+        m.fs.unit.inlet.temperature.fix(308.15 * units.K)
+        m.fs.unit.inlet.pressure.fix(1 * units.atm)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_O2"].fix(7.9707 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_N2"].fix(29.0603 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_NH4"].fix(8.0209 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_NO3"].fix(6.6395 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_PO4"].fix(7.8953 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_F"].fix(0.4748 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_A"].fix(0.0336 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_I"].fix(30 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_K"].fix(7 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_Mg"].fix(6 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_IC"].fix(10 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_I"].fix(1695.7695 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_S"].fix(68.2975 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_H"].fix(1855.5067 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PAO"].fix(
+            214.5319 * units.mg / units.liter
+        )
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PP"].fix(63.5316 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PHA"].fix(2.7381 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_AUT"].fix(
+            118.3582 * units.mg / units.liter
+        )
+
+        return m
+    
+    @pytest.mark.unit
+    def test_dof(self, du_mod_asm2d):
+        assert degrees_of_freedom(du_mod_asm2d) == 0
+
+    @pytest.mark.unit
+    def test_units(self, du_mod_asm2d):
+        assert_units_consistent(du_mod_asm2d)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_initialize(self, du_mod_asm2d):
+
+        iscale.calculate_scaling_factors(du_mod_asm2d)
+        initialization_tester(du_mod_asm2d)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, du_mod_asm2d):
+        solver = get_solver()
+        results = solver.solve(du_mod_asm2d)
+        assert_optimal_termination(results)

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -86,6 +86,7 @@ def test_config():
     for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA"]:
         assert k in m.fs.unit.config.tss_components
 
+
 @pytest.mark.unit
 def test_list_error():
     m = ConcreteModel()

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -70,7 +70,7 @@ def test_config():
 
     m.fs.unit = DewateringUnit(property_package=m.fs.props)
 
-    assert len(m.fs.unit.config) == 18
+    assert len(m.fs.unit.config) == 15
 
     assert not m.fs.unit.config.dynamic
     assert not m.fs.unit.config.has_holdup
@@ -79,12 +79,7 @@ def test_config():
     assert "underflow" in m.fs.unit.config.outlet_list
     assert "overflow" in m.fs.unit.config.outlet_list
     assert SplittingType.componentFlow is m.fs.unit.config.split_basis
-    for k in ["S_I", "S_S", "S_O", "S_NO", "S_NH", "S_ND", "H2O", "S_ALK"]:
-        assert k in m.fs.unit.config.non_particulate_components_list
-    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]:
-        assert k in m.fs.unit.config.particulate_components_list
-    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA"]:
-        assert k in m.fs.unit.config.tss_components
+
 
 
 @pytest.mark.unit

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -70,7 +70,7 @@ def test_config():
 
     m.fs.unit = DewateringUnit(property_package=m.fs.props)
 
-    assert len(m.fs.unit.config) == 15
+    assert len(m.fs.unit.config) == 18
 
     assert not m.fs.unit.config.dynamic
     assert not m.fs.unit.config.has_holdup
@@ -79,7 +79,12 @@ def test_config():
     assert "underflow" in m.fs.unit.config.outlet_list
     assert "overflow" in m.fs.unit.config.outlet_list
     assert SplittingType.componentFlow is m.fs.unit.config.split_basis
-
+    for k in ["S_I", "S_S", "S_O", "S_NO", "S_NH", "S_ND", "H2O", "S_ALK"]:
+        assert k in m.fs.unit.config.non_particulate_components_list
+    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]:
+        assert k in m.fs.unit.config.particulate_components_list
+    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA"]:
+        assert k in m.fs.unit.config.tss_components
 
 @pytest.mark.unit
 def test_list_error():

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -58,7 +58,7 @@ from watertap.property_models.activated_sludge.asm2d_properties import (
 )
 from watertap.property_models.activated_sludge.modified_asm2d_properties import (
     ModifiedASM2dParameterBlock,
-)    
+)
 from pyomo.util.check_units import assert_units_consistent
 
 __author__ = "Alejandro Garciadiego, Adam Atia"
@@ -328,11 +328,11 @@ class TestDUASM2d(object):
         m.fs.unit.inlet.alkalinity[0].fix(4.6663 * units.mmol / units.liter)
 
         return m
-    
+
     @pytest.mark.unit
     def test_dof(self, du_asm2d):
         assert degrees_of_freedom(du_asm2d) == 0
-    
+
     @pytest.mark.unit
     def test_units(self, du_asm2d):
         assert_units_consistent(du_asm2d)
@@ -344,7 +344,7 @@ class TestDUASM2d(object):
 
         iscale.calculate_scaling_factors(du_asm2d)
         initialization_tester(du_asm2d)
-    
+
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -397,7 +397,7 @@ class TestDUModifiedASM2d(object):
         )
 
         return m
-    
+
     @pytest.mark.unit
     def test_dof(self, du_mod_asm2d):
         assert degrees_of_freedom(du_mod_asm2d) == 0

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -294,7 +294,8 @@ class TestThickASM2d(object):
 
         m.fs.props = ASM2dParameterBlock()
 
-        m.fs.unit = Thickener(property_package=m.fs.props)
+        m.fs.unit = Thickener(property_package=m.fs.props,
+                              activated_sludge_model=ActivatedSludgeModelType.ASM2D)
 
         m.fs.unit.inlet.flow_vol.fix(300 * units.m**3 / units.day)
         m.fs.unit.inlet.temperature.fix(308.15 * units.K)

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -60,6 +60,7 @@ from watertap.property_models.activated_sludge.modified_asm2d_properties import 
 )
 from pyomo.util.check_units import assert_units_consistent
 
+__author__ = "Alejandro Garciadiego, Adam Atia"
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -77,7 +77,7 @@ def test_config():
 
     m.fs.unit = Thickener(property_package=m.fs.props)
 
-    assert len(m.fs.unit.config) == 18
+    assert len(m.fs.unit.config) == 15
 
     assert not m.fs.unit.config.dynamic
     assert not m.fs.unit.config.has_holdup
@@ -86,12 +86,7 @@ def test_config():
     assert "underflow" in m.fs.unit.config.outlet_list
     assert "overflow" in m.fs.unit.config.outlet_list
     assert SplittingType.componentFlow is m.fs.unit.config.split_basis
-    for k in ["S_I", "S_S", "S_O", "S_NO", "S_NH", "S_ND", "H2O", "S_ALK"]:
-        assert k in m.fs.unit.config.non_particulate_components_list
-    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]:
-        assert k in m.fs.unit.config.particulate_components_list
-    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA"]:
-        assert k in m.fs.unit.config.tss_components
+
 
 
 @pytest.mark.unit

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -89,7 +89,6 @@ def test_config():
     assert SplittingType.componentFlow is m.fs.unit.config.split_basis
 
 
-
 @pytest.mark.unit
 def test_list_error():
     m = ConcreteModel()
@@ -294,13 +293,14 @@ class TestThickASM2d(object):
 
         m.fs.props = ASM2dParameterBlock()
 
-        m.fs.unit = Thickener(property_package=m.fs.props,
-                              activated_sludge_model=ActivatedSludgeModelType.ASM2D)
-
+        m.fs.unit = Thickener(
+            property_package=m.fs.props,
+            activated_sludge_model=ActivatedSludgeModelType.ASM2D,
+        )
 
         # NOTE: Concentrations of exactly 0 result in singularities, use EPS instead
         EPS = 1e-8
-        
+
         m.fs.unit.inlet.flow_vol.fix(300 * units.m**3 / units.day)
         m.fs.unit.inlet.temperature.fix(308.15 * units.K)
         m.fs.unit.inlet.pressure.fix(1 * units.atm)
@@ -315,18 +315,23 @@ class TestThickASM2d(object):
         m.fs.unit.inlet.conc_mass_comp[0, "X_I"].fix(1695.7695 * units.mg / units.liter)
         m.fs.unit.inlet.conc_mass_comp[0, "X_S"].fix(68.2975 * units.mg / units.liter)
         m.fs.unit.inlet.conc_mass_comp[0, "X_H"].fix(1855.5067 * units.mg / units.liter)
-        m.fs.unit.inlet.conc_mass_comp[0, "X_PAO"].fix(214.5319 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PAO"].fix(
+            214.5319 * units.mg / units.liter
+        )
         m.fs.unit.inlet.conc_mass_comp[0, "X_PP"].fix(63.5316 * units.mg / units.liter)
         m.fs.unit.inlet.conc_mass_comp[0, "X_PHA"].fix(2.7381 * units.mg / units.liter)
-        m.fs.unit.inlet.conc_mass_comp[0, "X_AUT"].fix(118.3582 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_AUT"].fix(
+            118.3582 * units.mg / units.liter
+        )
         m.fs.unit.inlet.conc_mass_comp[0, "X_MeOH"].fix(EPS * units.mg / units.liter)
         m.fs.unit.inlet.conc_mass_comp[0, "X_MeP"].fix(EPS * units.mg / units.liter)
-        m.fs.unit.inlet.conc_mass_comp[0, "X_TSS"].fix(3525.429 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_TSS"].fix(
+            3525.429 * units.mg / units.liter
+        )
         m.fs.unit.inlet.alkalinity[0].fix(4.6663 * units.mmol / units.liter)
 
         return m
-    
-    
+
     @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, tu_asm2d):
@@ -418,7 +423,7 @@ class TestThickASM2d(object):
         assert pytest.approx(0.007970701359416384, rel=1e-3) == value(
             tu_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_O2"]
         )
-        assert pytest.approx(0.007895301409926407 , rel=1e-3) == value(
+        assert pytest.approx(0.007895301409926407, rel=1e-3) == value(
             tu_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_PO4"]
         )
         assert pytest.approx(0.0024900686245326892, rel=1e-3) == value(
@@ -463,8 +468,10 @@ class TestThickASM2d(object):
             abs(
                 value(
                     tu_asm2d.fs.unit.inlet.flow_vol[0] * tu_asm2d.fs.props.dens_mass
-                    - tu_asm2d.fs.unit.overflow.flow_vol[0] * tu_asm2d.fs.props.dens_mass
-                    - tu_asm2d.fs.unit.underflow.flow_vol[0] * tu_asm2d.fs.props.dens_mass
+                    - tu_asm2d.fs.unit.overflow.flow_vol[0]
+                    * tu_asm2d.fs.props.dens_mass
+                    - tu_asm2d.fs.unit.underflow.flow_vol[0]
+                    * tu_asm2d.fs.props.dens_mass
                 )
             )
             <= 1e-6

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -87,6 +87,7 @@ def test_config():
     for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA"]:
         assert k in m.fs.unit.config.tss_components
 
+
 @pytest.mark.unit
 def test_list_error():
     m = ConcreteModel()

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -71,7 +71,7 @@ def test_config():
 
     m.fs.unit = Thickener(property_package=m.fs.props)
 
-    assert len(m.fs.unit.config) == 15
+    assert len(m.fs.unit.config) == 18
 
     assert not m.fs.unit.config.dynamic
     assert not m.fs.unit.config.has_holdup
@@ -80,7 +80,12 @@ def test_config():
     assert "underflow" in m.fs.unit.config.outlet_list
     assert "overflow" in m.fs.unit.config.outlet_list
     assert SplittingType.componentFlow is m.fs.unit.config.split_basis
-
+    for k in ["S_I", "S_S", "S_O", "S_NO", "S_NH", "S_ND", "H2O", "S_ALK"]:
+        assert k in m.fs.unit.config.non_particulate_components_list
+    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]:
+        assert k in m.fs.unit.config.particulate_components_list
+    for k in ["X_I", "X_S", "X_P", "X_BH", "X_BA"]:
+        assert k in m.fs.unit.config.tss_components
 
 @pytest.mark.unit
 def test_list_error():

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -539,7 +539,6 @@ class TestThickModifiedASM2d(object):
             118.3582 * units.mg / units.liter
         )
 
-
         return m
 
     @pytest.mark.build
@@ -671,7 +670,8 @@ class TestThickModifiedASM2d(object):
         assert (
             abs(
                 value(
-                    tu_mod_asm2d.fs.unit.inlet.flow_vol[0] * tu_mod_asm2d.fs.props.dens_mass
+                    tu_mod_asm2d.fs.unit.inlet.flow_vol[0]
+                    * tu_mod_asm2d.fs.props.dens_mass
                     - tu_mod_asm2d.fs.unit.overflow.flow_vol[0]
                     * tu_mod_asm2d.fs.props.dens_mass
                     - tu_mod_asm2d.fs.unit.underflow.flow_vol[0]

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -495,3 +495,206 @@ class TestThickASM2d(object):
     @pytest.mark.unit
     def test_report(self, tu_asm2d):
         tu_asm2d.fs.unit.report()
+
+
+class TestThickModifiedASM2d(object):
+    @pytest.fixture(scope="class")
+    def tu_mod_asm2d(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+
+        m.fs.props = ModifiedASM2dParameterBlock()
+
+        m.fs.unit = Thickener(
+            property_package=m.fs.props,
+            activated_sludge_model=ActivatedSludgeModelType.modified_ASM2D,
+        )
+
+        # NOTE: Concentrations of exactly 0 result in singularities, use EPS instead
+        EPS = 1e-8
+
+        m.fs.unit.inlet.flow_vol.fix(300 * units.m**3 / units.day)
+        m.fs.unit.inlet.temperature.fix(308.15 * units.K)
+        m.fs.unit.inlet.pressure.fix(1 * units.atm)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_O2"].fix(7.9707 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_N2"].fix(29.0603 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_NH4"].fix(8.0209 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_NO3"].fix(6.6395 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_PO4"].fix(7.8953 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_F"].fix(0.4748 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_A"].fix(0.0336 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_I"].fix(30 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_K"].fix(7 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_Mg"].fix(6 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "S_IC"].fix(10 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_I"].fix(1695.7695 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_S"].fix(68.2975 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_H"].fix(1855.5067 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PAO"].fix(
+            214.5319 * units.mg / units.liter
+        )
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PP"].fix(63.5316 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_PHA"].fix(2.7381 * units.mg / units.liter)
+        m.fs.unit.inlet.conc_mass_comp[0, "X_AUT"].fix(
+            118.3582 * units.mg / units.liter
+        )
+
+
+        return m
+
+    @pytest.mark.build
+    @pytest.mark.unit
+    def test_build(self, tu_mod_asm2d):
+
+        assert hasattr(tu_mod_asm2d.fs.unit, "inlet")
+        assert len(tu_mod_asm2d.fs.unit.inlet.vars) == 4
+        assert hasattr(tu_mod_asm2d.fs.unit.inlet, "flow_vol")
+        assert hasattr(tu_mod_asm2d.fs.unit.inlet, "conc_mass_comp")
+        assert hasattr(tu_mod_asm2d.fs.unit.inlet, "temperature")
+        assert hasattr(tu_mod_asm2d.fs.unit.inlet, "pressure")
+
+        assert hasattr(tu_mod_asm2d.fs.unit, "underflow")
+        assert len(tu_mod_asm2d.fs.unit.underflow.vars) == 4
+        assert hasattr(tu_mod_asm2d.fs.unit.underflow, "flow_vol")
+        assert hasattr(tu_mod_asm2d.fs.unit.underflow, "conc_mass_comp")
+        assert hasattr(tu_mod_asm2d.fs.unit.underflow, "temperature")
+        assert hasattr(tu_mod_asm2d.fs.unit.underflow, "pressure")
+
+        assert hasattr(tu_mod_asm2d.fs.unit, "overflow")
+        assert len(tu_mod_asm2d.fs.unit.overflow.vars) == 4
+        assert hasattr(tu_mod_asm2d.fs.unit.overflow, "flow_vol")
+        assert hasattr(tu_mod_asm2d.fs.unit.overflow, "conc_mass_comp")
+        assert hasattr(tu_mod_asm2d.fs.unit.overflow, "temperature")
+        assert hasattr(tu_mod_asm2d.fs.unit.overflow, "pressure")
+
+        assert number_variables(tu_mod_asm2d) == 110
+        assert number_total_constraints(tu_mod_asm2d) == 83
+        assert number_unused_variables(tu_mod_asm2d) == 0
+
+    @pytest.mark.unit
+    def test_dof(self, tu_mod_asm2d):
+        assert degrees_of_freedom(tu_mod_asm2d) == 0
+
+    @pytest.mark.unit
+    def test_units(self, tu_mod_asm2d):
+        assert_units_consistent(tu_mod_asm2d)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_initialize(self, tu_mod_asm2d):
+
+        iscale.calculate_scaling_factors(tu_mod_asm2d)
+        initialization_tester(tu_mod_asm2d)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, tu_mod_asm2d):
+        solver = get_solver()
+        results = solver.solve(tu_mod_asm2d)
+        assert_optimal_termination(results)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, tu_mod_asm2d):
+        assert pytest.approx(101325.0, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.pressure[0]
+        )
+        assert pytest.approx(308.15, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.temperature[0]
+        )
+        assert pytest.approx(0.0033139, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.flow_vol[0]
+        )
+        assert pytest.approx(3.36066764339686e-05, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_A"]
+        )
+        assert pytest.approx(0.0004748063808766291, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_F"]
+        )
+        assert pytest.approx(0.03, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_I"]
+        )
+        assert pytest.approx(0.029060299999999997, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_N2"]
+        )
+        assert pytest.approx(0.00802090132578769, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_NH4"]
+        )
+        tu_mod_asm2d.fs.unit.overflow.conc_mass_comp.pprint()
+        assert pytest.approx(0.006639502251179597, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_NO3"]
+        )
+        assert pytest.approx(0.007970701359416384, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_O2"]
+        )
+        assert pytest.approx(0.007895301409926407, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_PO4"]
+        )
+        assert pytest.approx(0.006999, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_K"]
+        )
+        assert pytest.approx(0.00599999, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_Mg"]
+        )
+        assert pytest.approx(0.0099999999, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "S_IC"]
+        )
+        assert pytest.approx(0.0024802, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "X_AUT"]
+        )
+        assert pytest.approx(0.0388828, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "X_H"]
+        )
+        assert pytest.approx(0.0355354585, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "X_I"]
+        )
+        assert pytest.approx(0.00449559, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "X_PAO"]
+        )
+        assert pytest.approx(5.737786825381196e-05, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "X_PHA"]
+        )
+        assert pytest.approx(0.001331327, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "X_PP"]
+        )
+        assert pytest.approx(0.0014311986, rel=1e-3) == value(
+            tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, "X_S"]
+        )
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_conservation(self, tu_mod_asm2d):
+        assert (
+            abs(
+                value(
+                    tu_mod_asm2d.fs.unit.inlet.flow_vol[0] * tu_mod_asm2d.fs.props.dens_mass
+                    - tu_mod_asm2d.fs.unit.overflow.flow_vol[0]
+                    * tu_mod_asm2d.fs.props.dens_mass
+                    - tu_mod_asm2d.fs.unit.underflow.flow_vol[0]
+                    * tu_mod_asm2d.fs.props.dens_mass
+                )
+            )
+            <= 1e-6
+        )
+        for i in tu_mod_asm2d.fs.props.solute_set:
+            assert (
+                abs(
+                    value(
+                        tu_mod_asm2d.fs.unit.inlet.flow_vol[0]
+                        * tu_mod_asm2d.fs.unit.inlet.conc_mass_comp[0, i]
+                        - tu_mod_asm2d.fs.unit.overflow.flow_vol[0]
+                        * tu_mod_asm2d.fs.unit.overflow.conc_mass_comp[0, i]
+                        - tu_mod_asm2d.fs.unit.underflow.flow_vol[0]
+                        * tu_mod_asm2d.fs.unit.underflow.conc_mass_comp[0, i]
+                    )
+                )
+                <= 1e-6
+            )
+
+    @pytest.mark.unit
+    def test_report(self, tu_mod_asm2d):
+        tu_mod_asm2d.fs.unit.report()

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -130,7 +130,7 @@ class ThickenerData(SeparatorData):
                     sum(blk.inlet.conc_mass_comp[t, i] for i in blk.config.property_package.tss_component_set)
                 )
             elif (self.config.activated_sludge_model == ActivatedSludgeModelType.ASM2D) | (self.config.activated_sludge_model == ActivatedSludgeModelType.modified_ASM2D):
-                return blk.inlet.conc_mass_comp[t, blk.config.property_package.tss_component_set[0]]
+                return blk.inlet.conc_mass_comp[t, blk.config.property_package.tss_component_set.first()]
             else:
                 raise ConfigurationError("The activated_sludge_model was not specified properly in configuration options.")
 

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -62,7 +62,7 @@ class ActivatedSludgeModelType(Enum):
 @declare_process_block_class("Thickener")
 class ThickenerData(SeparatorData):
     """
-    Thickener unit block for BSM2
+    Thickener unit model for BSM2
     """
 
     CONFIG = SeparatorData.CONFIG()
@@ -113,17 +113,17 @@ class ThickenerData(SeparatorData):
             initialize=0.07,
             units=pyunits.dimensionless,
             mutable=True,
-            doc="Percentage of suspended solids in the underflow",
+            doc="Fraction of suspended solids in the underflow",
         )
 
         self.TSS_rem = Param(
             initialize=0.98,
             units=pyunits.dimensionless,
             mutable=True,
-            doc="Percentage of suspended solids removed",
+            doc="Fraction of suspended solids removed",
         )
 
-        @self.Expression(self.flowsheet().time, doc="Suspended solid concentration")
+        @self.Expression(self.flowsheet().time, doc="Suspended solids concentration")
         def TSS(blk, t):
             if self.config.activated_sludge_model == ActivatedSludgeModelType.ASM1:
                 return 0.75 * (

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -37,7 +37,6 @@ import idaes.logger as idaeslog
 from pyomo.environ import (
     Param,
     units as pyunits,
-    Set,
 )
 from pyomo.common.config import ConfigValue, In
 
@@ -146,10 +145,6 @@ class ThickenerData(SeparatorData):
                 blk.config.activated_sludge_model
                 == ActivatedSludgeModelType.modified_ASM2D
             ):
-                # if not hasattr(blk, mixed_state):
-                #     mixed_block = self.add_mixed_state_block()
-                # else:
-                #     mixed_block = blk.mixed_state
                 return blk.mixed_state[t].TSS
             else:
                 raise ConfigurationError(

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -127,7 +127,7 @@ class ThickenerData(SeparatorData):
         )
 
         @self.Expression(self.flowsheet().time, doc="Suspended solids concentration")
-        def TSS(blk, t):
+        def TSS_in(blk, t):
             if self.config.activated_sludge_model == ActivatedSludgeModelType.ASM1:
                 return 0.75 * (
                     sum(
@@ -151,7 +151,7 @@ class ThickenerData(SeparatorData):
 
         @self.Expression(self.flowsheet().time, doc="Thickening factor")
         def f_thick(blk, t):
-            return blk.p_thick * (10 / (blk.TSS[t]))
+            return blk.p_thick * (10 / (blk.TSS_in[t]))
 
         @self.Expression(self.flowsheet().time, doc="Remove factor")
         def f_q_du(blk, t):

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -126,24 +126,26 @@ class ThickenerData(SeparatorData):
             doc="Fraction of suspended solids removed",
         )
 
+
         @self.Expression(self.flowsheet().time, doc="Suspended solids concentration")
         def TSS_in(blk, t):
-            if self.config.activated_sludge_model == ActivatedSludgeModelType.ASM1:
+            if blk.config.activated_sludge_model == ActivatedSludgeModelType.ASM1:
                 return 0.75 * (
                     sum(
                         blk.inlet.conc_mass_comp[t, i]
                         for i in blk.config.property_package.tss_component_set
                     )
                 )
-            elif (
-                self.config.activated_sludge_model == ActivatedSludgeModelType.ASM2D
-            ) | (
-                self.config.activated_sludge_model
-                == ActivatedSludgeModelType.modified_ASM2D
-            ):
+            elif blk.config.activated_sludge_model == ActivatedSludgeModelType.ASM2D:
                 return blk.inlet.conc_mass_comp[
                     t, blk.config.property_package.tss_component_set.first()
                 ]
+            elif blk.config.activated_sludge_model== ActivatedSludgeModelType.modified_ASM2D:
+                # if not hasattr(blk, mixed_state):
+                #     mixed_block = self.add_mixed_state_block()
+                # else:
+                #     mixed_block = blk.mixed_state
+                return blk.mixed_state[t].TSS
             else:
                 raise ConfigurationError(
                     "The activated_sludge_model was not specified properly in configuration options."

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -42,7 +42,7 @@ from idaes.core.util.exceptions import (
     ConfigurationError,
 )
 
-__author__ = "Alejandro Garciadiego"
+__author__ = "Alejandro Garciadiego, Adam Atia"
 
 
 # Set up logger

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -21,6 +21,7 @@ P. A. Vanrolleghem
 Benchmark Simulation Model no. 2 (BSM2)
 """
 from enum import Enum, auto
+
 # Import IDAES cores
 from idaes.core import (
     declare_process_block_class,
@@ -59,6 +60,7 @@ class ActivatedSludgeModelType(Enum):
     ASM2D = auto()
     modified_ASM2D = auto()
 
+
 @declare_process_block_class("Thickener")
 class ThickenerData(SeparatorData):
     """
@@ -68,13 +70,14 @@ class ThickenerData(SeparatorData):
     CONFIG = SeparatorData.CONFIG()
     CONFIG.outlet_list = ["underflow", "overflow"]
     CONFIG.split_basis = SplittingType.componentFlow
-    
-    CONFIG.declare("activated_sludge_model",
-    ConfigValue(
-        default=ActivatedSludgeModelType.ASM1,
-        domain=In(ActivatedSludgeModelType),
-        description="Activated Sludge Model used with unit",
-        doc="""
+
+    CONFIG.declare(
+        "activated_sludge_model",
+        ConfigValue(
+            default=ActivatedSludgeModelType.ASM1,
+            domain=In(ActivatedSludgeModelType),
+            description="Activated Sludge Model used with unit",
+            doc="""
         Options to account for version of activated sludge model property package.
 
         **default** - ``ActivatedSludgeModelType.ASM1``
@@ -86,8 +89,8 @@ class ThickenerData(SeparatorData):
         "``ActivatedSludgeModelType.ASM2D``", "ASM2D model"
         "``ActivatedSludgeModelType.modified_ASM2D``", "modified ASM2D model for ADM1 compatibility"
     """,
-    ),
-    )   
+        ),
+    )
 
     def build(self):
         """
@@ -127,12 +130,24 @@ class ThickenerData(SeparatorData):
         def TSS(blk, t):
             if self.config.activated_sludge_model == ActivatedSludgeModelType.ASM1:
                 return 0.75 * (
-                    sum(blk.inlet.conc_mass_comp[t, i] for i in blk.config.property_package.tss_component_set)
+                    sum(
+                        blk.inlet.conc_mass_comp[t, i]
+                        for i in blk.config.property_package.tss_component_set
+                    )
                 )
-            elif (self.config.activated_sludge_model == ActivatedSludgeModelType.ASM2D) | (self.config.activated_sludge_model == ActivatedSludgeModelType.modified_ASM2D):
-                return blk.inlet.conc_mass_comp[t, blk.config.property_package.tss_component_set.first()]
+            elif (
+                self.config.activated_sludge_model == ActivatedSludgeModelType.ASM2D
+            ) | (
+                self.config.activated_sludge_model
+                == ActivatedSludgeModelType.modified_ASM2D
+            ):
+                return blk.inlet.conc_mass_comp[
+                    t, blk.config.property_package.tss_component_set.first()
+                ]
             else:
-                raise ConfigurationError("The activated_sludge_model was not specified properly in configuration options.")
+                raise ConfigurationError(
+                    "The activated_sludge_model was not specified properly in configuration options."
+                )
 
         @self.Expression(self.flowsheet().time, doc="Thickening factor")
         def f_thick(blk, t):

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -35,7 +35,6 @@ from pyomo.environ import (
     units as pyunits,
     Set,
 )
-from pyomo.common.config import ConfigValue
 
 from idaes.core.util.exceptions import (
     ConfigurationError,
@@ -57,42 +56,6 @@ class ThickenerData(SeparatorData):
     CONFIG = SeparatorData.CONFIG()
     CONFIG.outlet_list = ["underflow", "overflow"]
     CONFIG.split_basis = SplittingType.componentFlow
-
-    CONFIG.declare(
-        "non_particulate_components_list",
-        ConfigValue(
-            default=[
-                "S_I",
-                "S_S",
-                "S_O",
-                "S_NO",
-                "S_NH",
-                "S_ND",
-                "H2O",
-                "S_ALK",
-            ],
-            domain=list,
-            doc="List of non particulate component list.",
-        ),
-    )
-
-    CONFIG.declare(
-        "particulate_components_list",
-        ConfigValue(
-            default=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"],
-            domain=list,
-            doc="List of particulate component list.",
-        ),
-    )
-
-    CONFIG.declare(
-        "tss_components",
-        ConfigValue(
-            default=["X_I", "X_S", "X_P", "X_BH", "X_BA"],
-            domain=list,
-            doc="List of TSS components.",
-        ),
-    )
 
     def build(self):
         """
@@ -131,7 +94,11 @@ class ThickenerData(SeparatorData):
         @self.Expression(self.flowsheet().time, doc="Suspended solid concentration")
         def TSS(blk, t):
             return 0.75 * (
-                sum(blk.inlet.conc_mass_comp[t, i] for i in self.config.tss_components)
+                blk.inlet.conc_mass_comp[t, "X_I"]
+                + blk.inlet.conc_mass_comp[t, "X_P"]
+                + blk.inlet.conc_mass_comp[t, "X_BH"]
+                + blk.inlet.conc_mass_comp[t, "X_BA"]
+                + blk.inlet.conc_mass_comp[t, "X_S"]
             )
 
         @self.Expression(self.flowsheet().time, doc="Thickening factor")
@@ -143,11 +110,20 @@ class ThickenerData(SeparatorData):
             return blk.TSS_rem / (pyunits.kg / pyunits.m**3) / 100 / blk.f_thick[t]
 
         self.non_particulate_components = Set(
-            initialize=self.config.non_particulate_components_list
+            initialize=[
+                "S_I",
+                "S_S",
+                "S_O",
+                "S_NO",
+                "S_NH",
+                "S_ND",
+                "H2O",
+                "S_ALK",
+            ]
         )
 
         self.particulate_components = Set(
-            initialize=self.config.particulate_components_list
+            initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]
         )
 
         @self.Constraint(

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -92,7 +92,8 @@ class ThickenerData(SeparatorData):
             domain=list,
             doc="List of TSS components.",
         ),
-    )   
+    )
+
     def build(self):
         """
         Begin building model.
@@ -129,8 +130,10 @@ class ThickenerData(SeparatorData):
 
         @self.Expression(self.flowsheet().time, doc="Suspended solid concentration")
         def TSS(blk, t):
-            return 0.75 * (sum(blk.inlet.conc_mass_comp[t, i] for i in self.config.tss_components))
-        
+            return 0.75 * (
+                sum(blk.inlet.conc_mass_comp[t, i] for i in self.config.tss_components)
+            )
+
         @self.Expression(self.flowsheet().time, doc="Thickening factor")
         def f_thick(blk, t):
             return blk.p_thick * (10 / (blk.TSS[t]))

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -126,7 +126,6 @@ class ThickenerData(SeparatorData):
             doc="Fraction of suspended solids removed",
         )
 
-
         @self.Expression(self.flowsheet().time, doc="Suspended solids concentration")
         def TSS_in(blk, t):
             if blk.config.activated_sludge_model == ActivatedSludgeModelType.ASM1:
@@ -140,7 +139,10 @@ class ThickenerData(SeparatorData):
                 return blk.inlet.conc_mass_comp[
                     t, blk.config.property_package.tss_component_set.first()
                 ]
-            elif blk.config.activated_sludge_model== ActivatedSludgeModelType.modified_ASM2D:
+            elif (
+                blk.config.activated_sludge_model
+                == ActivatedSludgeModelType.modified_ASM2D
+            ):
                 # if not hasattr(blk, mixed_state):
                 #     mixed_block = self.add_mixed_state_block()
                 # else:

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -35,6 +35,7 @@ from pyomo.environ import (
     units as pyunits,
     Set,
 )
+from pyomo.common.config import ConfigValue
 
 from idaes.core.util.exceptions import (
     ConfigurationError,
@@ -57,6 +58,41 @@ class ThickenerData(SeparatorData):
     CONFIG.outlet_list = ["underflow", "overflow"]
     CONFIG.split_basis = SplittingType.componentFlow
 
+    CONFIG.declare(
+        "non_particulate_components_list",
+        ConfigValue(
+            default=[
+                "S_I",
+                "S_S",
+                "S_O",
+                "S_NO",
+                "S_NH",
+                "S_ND",
+                "H2O",
+                "S_ALK",
+            ],
+            domain=list,
+            doc="List of non particulate component list.",
+        ),
+    )
+
+    CONFIG.declare(
+        "particulate_components_list",
+        ConfigValue(
+            default=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"],
+            domain=list,
+            doc="List of particulate component list.",
+        ),
+    )
+
+    CONFIG.declare(
+        "tss_components",
+        ConfigValue(
+            default=["X_I", "X_S", "X_P", "X_BH", "X_BA"],
+            domain=list,
+            doc="List of TSS components.",
+        ),
+    )   
     def build(self):
         """
         Begin building model.
@@ -93,14 +129,8 @@ class ThickenerData(SeparatorData):
 
         @self.Expression(self.flowsheet().time, doc="Suspended solid concentration")
         def TSS(blk, t):
-            return 0.75 * (
-                blk.inlet.conc_mass_comp[t, "X_I"]
-                + blk.inlet.conc_mass_comp[t, "X_P"]
-                + blk.inlet.conc_mass_comp[t, "X_BH"]
-                + blk.inlet.conc_mass_comp[t, "X_BA"]
-                + blk.inlet.conc_mass_comp[t, "X_S"]
-            )
-
+            return 0.75 * (sum(blk.inlet.conc_mass_comp[t, i] for i in self.config.tss_components))
+        
         @self.Expression(self.flowsheet().time, doc="Thickening factor")
         def f_thick(blk, t):
             return blk.p_thick * (10 / (blk.TSS[t]))
@@ -110,20 +140,11 @@ class ThickenerData(SeparatorData):
             return blk.TSS_rem / (pyunits.kg / pyunits.m**3) / 100 / blk.f_thick[t]
 
         self.non_particulate_components = Set(
-            initialize=[
-                "S_I",
-                "S_S",
-                "S_O",
-                "S_NO",
-                "S_NH",
-                "S_ND",
-                "H2O",
-                "S_ALK",
-            ]
+            initialize=self.config.non_particulate_components_list
         )
 
         self.particulate_components = Set(
-            initialize=["X_I", "X_S", "X_P", "X_BH", "X_BA", "X_ND"]
+            initialize=self.config.particulate_components_list
         )
 
         @self.Constraint(

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -11,7 +11,8 @@
 #
 ###############################################################################
 """
-Thickener unit model for BSM2. Based on IDAES separator unit
+Thickener unit model for BSM2 and plant-wide wastewater treatment modeling. 
+This unit inherits from the IDAES separator unit.
 
 Model based on 
 
@@ -19,6 +20,8 @@ J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson,
 I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer and
 P. A. Vanrolleghem
 Benchmark Simulation Model no. 2 (BSM2)
+
+Modifications made to TSS formulation based on ASM type.
 """
 from enum import Enum, auto
 

--- a/watertap/unit_models/translators/tests/test_translator_adm1_asm2d.py
+++ b/watertap/unit_models/translators/tests/test_translator_adm1_asm2d.py
@@ -178,7 +178,7 @@ class TestAsm2dAdm1(object):
         assert hasattr(asmadm.fs.unit.outlet, "temperature")
         assert hasattr(asmadm.fs.unit.outlet, "pressure")
 
-        assert number_variables(asmadm) == 186
+        assert number_variables(asmadm) == 194
         assert number_total_constraints(asmadm) == 21
 
         assert number_unused_variables(asmadm.fs.unit) == 12

--- a/watertap/unit_models/translators/tests/test_translator_adm1_asm2d.py
+++ b/watertap/unit_models/translators/tests/test_translator_adm1_asm2d.py
@@ -178,7 +178,7 @@ class TestAsm2dAdm1(object):
         assert hasattr(asmadm.fs.unit.outlet, "temperature")
         assert hasattr(asmadm.fs.unit.outlet, "pressure")
 
-        assert number_variables(asmadm) == 180
+        assert number_variables(asmadm) == 186
         assert number_total_constraints(asmadm) == 21
 
         assert number_unused_variables(asmadm.fs.unit) == 12

--- a/watertap/unit_models/translators/tests/test_translator_adm1_simple_asm2d.py
+++ b/watertap/unit_models/translators/tests/test_translator_adm1_simple_asm2d.py
@@ -184,7 +184,7 @@ class TestAsm2dAdm1(object):
         assert hasattr(asmadm.fs.unit.outlet, "pressure")
         assert hasattr(asmadm.fs.unit.outlet, "alkalinity")
 
-        assert number_variables(asmadm) == 183
+        assert number_variables(asmadm) == 191
         assert number_total_constraints(asmadm) == 24
 
         assert number_unused_variables(asmadm.fs.unit) == 12


### PR DESCRIPTION
## Summary/Motivation:

- Created CONFIG list and gives the ability to use other property package other than ASM1

## Changes proposed in this PR:
- deleted initialize lists for sets and TSS sums
- gives ability to user to give lists to initialize set and the TSS sum

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
