### PR TITLE
Correct units in GAC costing `energy_consumption_constraint`

### DIFF
--- a/watertap/costing/units/gac.py
+++ b/watertap/costing/units/gac.py
@@ -318,10 +318,17 @@ def cost_gac(blk, contactor_type=ContactorType.pressure):
     )
 
     blk.energy_consumption_constraint = pyo.Constraint(
-        expr=blk.energy_consumption
-        == blk.costing_package.gac.energy_consumption_coeff[2] * total_bed_volume**2
-        + blk.costing_package.gac.energy_consumption_coeff[1] * total_bed_volume
-        + blk.costing_package.gac.energy_consumption_coeff[0]
+        expr=pyo.units.convert(blk.energy_consumption, to_units=pyo.units.kW)
+        == pyo.units.kW
+        * (
+            blk.costing_package.gac.energy_consumption_coeff[2]
+            * total_bed_volume**2
+            * (pyo.units.m**3) ** -2
+            + blk.costing_package.gac.energy_consumption_coeff[1]
+            * total_bed_volume
+            * (pyo.units.m**3) ** -1
+            + blk.costing_package.gac.energy_consumption_coeff[0]
+        )
     )
 
     blk.costing_package.cost_flow(

--- a/watertap/unit_models/tests/test_gac.py
+++ b/watertap/unit_models/tests/test_gac.py
@@ -384,6 +384,7 @@ class TestGACRobust:
         mr.fs.unit.costing = UnitModelCostingBlock(
             flowsheet_costing_block=mr.fs.costing
         )
+        mr.fs.costing.cost_process()
 
         # testing gac costing block dof and initialization
         assert assert_units_consistent(mr) is None

--- a/watertap/unit_models/tests/test_gac.py
+++ b/watertap/unit_models/tests/test_gac.py
@@ -386,6 +386,7 @@ class TestGACRobust:
         )
 
         # testing gac costing block dof and initialization
+        assert assert_units_consistent(mr) is None
         assert istat.degrees_of_freedom(mr) == 0
         mr.fs.unit.costing.initialize()
 
@@ -421,6 +422,13 @@ class TestGACRobust:
             costing_method_arguments={"contactor_type": "gravity"},
         )
         mr_grav.fs.costing.cost_process()
+
+        # testing gac costing block dof and initialization
+        assert assert_units_consistent(mr_grav) is None
+        assert istat.degrees_of_freedom(mr_grav) == 0
+        mr_grav.fs.unit.costing.initialize()
+
+        # solve
         results = solver.solve(mr_grav)
 
         # Check for optimal solution


### PR DESCRIPTION
## Fixes/Resolves:
The costing results were validated for the GAC costing package but `assert_units_consistent` was never checked (could be a larger issue of no costing test conventions). The units for the regressed costing parameters were never embedded into the equation, resulting in a units error. This adds those units and the check into the test file.

## Summary/Motivation:
Correct units error in GAC costing.

## Changes proposed in this PR:
- Adds `assert_units_consistent` for costing package, previously unchecked
- Adds embedded units for cost equation parameters

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
