### PR TITLE
Fix Pydantic 2 failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         # for parameter_sweep
         "h5py",
         # for watertap.ui.api_model (though may be generally useful)
-        "pydantic",
+        "pydantic < 2",
         "numpy",
         # for importlib.metadata.entry_points()
         "importlib_metadata; python_version < '3.8' ",


### PR DESCRIPTION
## Fixes/Resolves:

Failures due to breaking changes in Pydantic 2 (used by `watertap.ui.fsapi`).

## Changes proposed in this PR:
- Add `<2` constraint to pydantic requirement

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
