### PR TITLE
Remove lingering uses of MPI from parallel manager

### DIFF
--- a/watertap/tools/parallel/concurrent_futures_parallel_manager.py
+++ b/watertap/tools/parallel/concurrent_futures_parallel_manager.py
@@ -43,8 +43,26 @@ class ConcurrentFuturesParallelManager(ParallelManager):
     def sync_with_peers(self):
         pass
 
-    def sync_data_with_peers(self, data):
+    def sync_array_with_peers(self, data):
         pass
+
+    def sync_pyobject_with_peers(self, obj):
+        return obj
+
+    def combine_data_with_peers(self, data):
+        return [data]
+
+    def sum_values_and_sync(self, sendbuf, recvbuf):
+        recvbuf[0][:] = sendbuf[0][:]
+
+    def gather_arrays_to_root(self, sendbuf, recvbuf_spec):
+        receive_arr = recvbuf_spec[0]
+        receive_sizes = recvbuf_spec[1]
+
+        assert len(receive_arr) == sum(
+            receive_sizes
+        ), "Gathering arrays to root cannot be done with mismatched sizes"
+        receive_arr[:] = sendbuf[:]
 
     def scatter(
         self,

--- a/watertap/tools/parallel/mpi_parallel_manager.py
+++ b/watertap/tools/parallel/mpi_parallel_manager.py
@@ -37,13 +37,29 @@ class MPIParallelManager(ParallelManager):
     def sync_with_peers(self):
         self.comm.Barrier()
 
-    def sync_data_with_peers(self, data):
+    def sync_array_with_peers(self, data):
         """
         Broadcast the array to all processes. this call acts as a synchronization point
         when run by multiple peer mpi processes.
         """
         if self.num_procs > 1:
             self.comm.Bcast(data, root=self.ROOT_PROCESS_RANK)
+
+    def sync_pyobject_with_peers(self, obj):
+        """
+        Broadcast the object to all processes from the root. this call acts as a synchronization point
+        when run by multiple peer mpi processes.
+        """
+        return self.comm.bcast(obj, root=self.ROOT_PROCESS_RANK)
+
+    def combine_data_with_peers(self, data):
+        return self.comm.allgather(data)
+
+    def gather_arrays_to_root(self, sendbuf, recvbuf_spec):
+        self.comm.Gatherv(sendbuf, recvbuf_spec, root=self.ROOT_PROCESS_RANK)
+
+    def sum_values_and_sync(self, sendbuf, recvbuf):
+        self.comm.Allreduce(sendbuf, recvbuf)
 
     def scatter(
         self,

--- a/watertap/tools/parallel/single_process_parallel_manager.py
+++ b/watertap/tools/parallel/single_process_parallel_manager.py
@@ -30,8 +30,26 @@ class SingleProcessParallelManager(ParallelManager):
     def sync_with_peers(self):
         pass
 
-    def sync_data_with_peers(self, data):
+    def sync_array_with_peers(self, data):
         pass
+
+    def sync_pyobject_with_peers(self, obj):
+        return obj
+
+    def combine_data_with_peers(self, data):
+        return [data]
+
+    def gather_arrays_to_root(self, sendbuf, recvbuf_spec):
+        receive_arr = recvbuf_spec[0]
+        receive_sizes = recvbuf_spec[1]
+
+        assert len(receive_arr) == sum(
+            receive_sizes
+        ), "Gathering arrays to root cannot be done with mismatched sizes"
+        receive_arr[:] = sendbuf[:]
+
+    def sum_values_and_sync(self, sendbuf, recvbuf):
+        recvbuf[0][:] = sendbuf[0][:]
 
     def scatter(
         self,

--- a/watertap/tools/parallel/tests/test_concurrent_futures_parallel_manager.py
+++ b/watertap/tools/parallel/tests/test_concurrent_futures_parallel_manager.py
@@ -1,0 +1,42 @@
+#################################################################################
+# WaterTAP Copyright (c) 2020-2023, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National Laboratory,
+# National Renewable Energy Laboratory, and National Energy Technology
+# Laboratory (subject to receipt of any required approvals from the U.S. Dept.
+# of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#################################################################################
+
+import pytest
+
+from watertap.tools.parallel.concurrent_futures_parallel_manager import (
+    ConcurrentFuturesParallelManager,
+)
+
+
+class TestConcurrentFuturesParallelManager:
+    @pytest.mark.component
+    def test_combine_data_with_peers(self):
+        parallel_manager = ConcurrentFuturesParallelManager(number_of_subprocesses=1)
+        assert parallel_manager.combine_data_with_peers("test_data") == ["test_data"]
+
+    @pytest.mark.component
+    def test_gather_arrays_to_root(self):
+        parallel_manager = ConcurrentFuturesParallelManager(number_of_subprocesses=1)
+
+        sendbuf = [1, 2, 3]
+        recvbuf_spec = [[0, 0, 0], [1, 2]]
+        parallel_manager.gather_arrays_to_root(sendbuf, recvbuf_spec)
+        assert recvbuf_spec[0] == [1, 2, 3]
+
+    @pytest.mark.component
+    def test_sum_values_and_sync(self):
+        parallel_manager = ConcurrentFuturesParallelManager(number_of_subprocesses=1)
+
+        sendbuf = [[1, 2, 3]]
+        recvbuf = [[]]
+        parallel_manager.sum_values_and_sync(sendbuf, recvbuf)
+        assert recvbuf[0] == [1, 2, 3]

--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -31,7 +31,7 @@ from pyomo.core.base.param import _ParamData
 from watertap.tools.parameter_sweep.parameter_sweep_writer import ParameterSweepWriter
 from watertap.tools.parameter_sweep.sampling_types import SamplingType, LinearSample
 
-import watertap.tools.MPI as MPI
+from watertap.tools.parallel.parallel_manager import ParallelManager
 from watertap.tools.parallel.parallel_manager_factory import create_parallel_manager
 
 
@@ -161,10 +161,8 @@ class _ParameterSweepBase(ABC):
         **options,
     ):
 
-        self.comm = options.pop("comm", MPI.COMM_WORLD)
         parallel_manager_class = options.pop("parallel_manager_class", None)
 
-        self.rank = self.comm.Get_rank()
         self.config = self.CONFIG(options)
 
         self.parallel_manager = create_parallel_manager(
@@ -295,7 +293,7 @@ class _ParameterSweepBase(ABC):
             )
 
         # make sure all processes running in parallel have an identical copy of the data
-        self.parallel_manager.sync_data_with_peers(global_combo_array)
+        self.parallel_manager.sync_array_with_peers(global_combo_array)
 
         return global_combo_array
 
@@ -340,7 +338,7 @@ class _ParameterSweepBase(ABC):
             for i, (key, item) in enumerate(global_results_dict["outputs"].items()):
                 global_results[:, i] = item["value"][:num_cases]
 
-        self.parallel_manager.sync_data_with_peers(global_results)
+        self.parallel_manager.sync_array_with_peers(global_results)
 
         return global_results
 
@@ -455,8 +453,11 @@ class _ParameterSweepBase(ABC):
         # local_output_dict remains the same across all mpi_ranks
         local_num_cases = len(local_output_dict["solve_successful"])
 
-        # Gather the size of the value array on each MPI rank
-        sample_split_arr = self.comm.allgather(local_num_cases)
+        # Gather the size of the value array for each peer process
+        sample_split_arr = self.parallel_manager.combine_data_with_peers(
+            local_num_cases
+        )
+
         num_total_samples = sum(sample_split_arr)
         if req_num_samples is None:
             req_num_samples = num_total_samples
@@ -477,13 +478,12 @@ class _ParameterSweepBase(ABC):
         for key, item in local_output_dict.items():
             if key != "solve_successful":
                 for subkey, subitem in item.items():
-                    self.comm.Gatherv(
+                    self.parallel_manager.gather_arrays_to_root(
                         sendbuf=subitem["value"],
-                        recvbuf=(
+                        recvbuf_spec=(
                             global_output_dict[key][subkey]["value"],
                             sample_split_arr,
                         ),
-                        root=0,
                     )
 
                     # Trim to the exact number
@@ -499,10 +499,9 @@ class _ParameterSweepBase(ABC):
                 else:
                     global_solve_successful = None
 
-                self.comm.Gatherv(
+                self.parallel_manager.gather_arrays_to_root(
                     sendbuf=local_solve_successful,
-                    recvbuf=(global_solve_successful, sample_split_arr),
-                    root=0,
+                    recvbuf_spec=(global_solve_successful, sample_split_arr),
                 )
 
                 if self.parallel_manager.is_root_process():
@@ -664,12 +663,10 @@ class ParameterSweep(_ParameterSweepBase):
         """
         saved_state = {
             "parallel_manager": parameter_sweep_instance.parallel_manager,
-            "comm": parameter_sweep_instance.comm,
             "writer": parameter_sweep_instance.writer,
         }
 
         parameter_sweep_instance.parallel_manager = None
-        parameter_sweep_instance.comm = None
         parameter_sweep_instance.writer = None
         return saved_state
 
@@ -680,7 +677,6 @@ class ParameterSweep(_ParameterSweepBase):
         the ParameterSweep object.
         """
         parameter_sweep_instance.parallel_manager = state.get("parallel_manager", None)
-        parameter_sweep_instance.comm = state.get("comm", None)
         parameter_sweep_instance.writer = state.get("writer", None)
 
     """
@@ -946,7 +942,7 @@ class RecursiveParameterSweep(_ParameterSweepBase):
             ):
                 global_filtered_values[:, i] = item["value"][:req_num_samples]
 
-        self.parallel_manager.sync_data_with_peers(global_filtered_values)
+        self.parallel_manager.sync_array_with_peers(global_filtered_values)
 
         return global_filtered_values
 
@@ -1040,11 +1036,15 @@ class RecursiveParameterSweep(_ParameterSweepBase):
             ):  # pragma: no cover
                 global_success_count = np.zeros(1, dtype=float)
                 global_failure_count = np.zeros(1, dtype=float)
-                self.comm.Allreduce(
-                    np.array(success_count, dtype=float), global_success_count
+
+                self.parallel_manager.sum_values_and_sync(
+                    sendbuf=np.array(success_count, dtype=float),
+                    recvbuf=global_success_count,
                 )
-                self.comm.Allreduce(
-                    np.array(failure_count, dtype=float), global_failure_count
+
+                self.parallel_manager.sum_values_and_sync(
+                    sendbuf=np.array(failure_count, dtype=float),
+                    recvbuf=global_failure_count,
                 )
             else:
                 global_success_count = success_count
@@ -1093,7 +1093,7 @@ class RecursiveParameterSweep(_ParameterSweepBase):
         ) = self._aggregate_filtered_results(local_filtered_dict, req_num_samples)
 
         # Now we can save this
-        self.comm.Barrier()
+        self.parallel_manager.sync_with_peers()
 
         # Save to file
         global_save_data = self.writer.save_results(

--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -31,7 +31,6 @@ from pyomo.core.base.param import _ParamData
 from watertap.tools.parameter_sweep.parameter_sweep_writer import ParameterSweepWriter
 from watertap.tools.parameter_sweep.sampling_types import SamplingType, LinearSample
 
-from watertap.tools.parallel.parallel_manager import ParallelManager
 from watertap.tools.parallel.parallel_manager_factory import create_parallel_manager
 
 

--- a/watertap/tools/parameter_sweep/parameter_sweep_differential.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep_differential.py
@@ -17,7 +17,6 @@ from watertap.tools.parameter_sweep.parameter_sweep import (
     _ParameterSweepBase,
     ParameterSweep,
 )
-from watertap.tools.MPI.dummy_mpi import DummyCOMM
 from watertap.tools.parallel.single_process_parallel_manager import (
     SingleProcessParallelManager,
 )
@@ -205,13 +204,13 @@ class DifferentialParameterSweep(_ParameterSweepBase):
             dtype=float,
         )
 
-        if self.rank == 0:
+        if self.parallel_manager.is_root_process():
             for i, (key, item) in enumerate(
                 global_results_dict["sweep_params"].items()
             ):
                 global_values[:, i] = item["value"]
 
-        self.comm.Bcast(global_values, root=0)
+        self.parallel_manager.sync_array_with_peers(global_values)
 
         return global_values
 
@@ -222,7 +221,9 @@ class DifferentialParameterSweep(_ParameterSweepBase):
 
         # Broadcast the number of global samples to all ranks
         num_global_samples = len(global_results_dict["solve_successful"])
-        num_global_samples = self.comm.bcast(num_global_samples, root=0)
+        num_global_samples = self.parallel_manager.sync_pyobject_with_peers(
+            num_global_samples
+        )
 
         global_results_arr = self._aggregate_results_arr(
             global_results_dict, num_global_samples
@@ -250,7 +251,6 @@ class DifferentialParameterSweep(_ParameterSweepBase):
             reinitialize_kwargs=self.config.reinitialize_kwargs,
             reinitialize_before_sweep=self.config.reinitialize_before_sweep,
             parallel_manager_class=SingleProcessParallelManager,
-            comm=DummyCOMM,
         )
 
         _, differential_sweep_output_dict = diff_ps.parameter_sweep(

--- a/watertap/tools/parameter_sweep/parameter_sweep_functions.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep_functions.py
@@ -32,7 +32,6 @@ def parameter_sweep(
     reinitialize_kwargs=None,
     reinitialize_before_sweep=False,
     probe_function=None,
-    mpi_comm=None,
     debugging_data_dir=None,
     interpolate_nan_outputs=False,
     num_samples=None,
@@ -109,10 +108,6 @@ def parameter_sweep(
         probe_function (optional): A user-defined function that can cheaply check if a current model
                                   configuration is solvable without actually reinitializing or solving.
 
-        mpi_comm (optional) : User-provided MPI communicator for parallel parameter sweeps.
-                              If None COMM_WORLD will be used. The default is sufficient for most
-                              users.
-
         debugging_data_dir (optional) : Save results on a per-process basis for parallel debugging
                                         purposes. If None no `debugging` data will be saved.
 
@@ -143,8 +138,6 @@ def parameter_sweep(
     """
 
     kwargs = {}
-    if mpi_comm is not None:
-        kwargs["comm"] = mpi_comm
     if csv_results_file_name is not None:
         kwargs["csv_results_file_name"] = csv_results_file_name
     if h5_results_file_name is not None:
@@ -195,7 +188,6 @@ def recursive_parameter_sweep(
     reinitialize_kwargs=None,
     reinitialize_before_sweep=False,
     probe_function=None,
-    mpi_comm=None,
     debugging_data_dir=None,
     interpolate_nan_outputs=False,
     req_num_samples=None,
@@ -267,10 +259,6 @@ def recursive_parameter_sweep(
         probe_function (optional): A user-defined function that can cheaply check if a current model
                                   configuration is solvable without actually reinitializing or solving.
 
-        mpi_comm (optional) : User-provided MPI communicator for parallel parameter sweeps.
-                              If None COMM_WORLD will be used. The default is sufficient for most
-                              users.
-
         debugging_data_dir (optional) : Save results on a per-process basis for parallel debugging
                                         purposes. If None no `debugging` data will be saved.
 
@@ -294,8 +282,6 @@ def recursive_parameter_sweep(
     """
 
     kwargs = {}
-    if mpi_comm is not None:
-        kwargs["comm"] = mpi_comm
     if csv_results_file_name is not None:
         kwargs["csv_results_file_name"] = csv_results_file_name
     if h5_results_file_name is not None:
@@ -339,7 +325,6 @@ def differential_parameter_sweep(
     reinitialize_kwargs=None,
     reinitialize_before_sweep=False,
     probe_function=None,
-    mpi_comm=None,
     debugging_data_dir=None,
     interpolate_nan_outputs=False,
     num_samples=None,
@@ -436,10 +421,6 @@ def differential_parameter_sweep(
         probe_function (optional): A user-defined function that can cheaply check if a current model
                                   configuration is solvable without actually reinitializing or solving.
 
-        mpi_comm (optional) : User-provided MPI communicator for parallel parameter sweeps.
-                              If None COMM_WORLD will be used. The default is sufficient for most
-                              users.
-
         debugging_data_dir (optional) : Save results on a per-process basis for parallel debugging
                                         purposes. If None no `debugging` data will be saved.
 
@@ -467,8 +448,6 @@ def differential_parameter_sweep(
 
     kwargs = {}
     kwargs["differential_sweep_specs"] = differential_sweep_specs
-    if mpi_comm is not None:
-        kwargs["comm"] = mpi_comm
     if csv_results_file_name is not None:
         kwargs["csv_results_file_name"] = csv_results_file_name
     if h5_results_file_name is not None:

--- a/watertap/tools/parameter_sweep/tests/test_differential_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_differential_parameter_sweep.py
@@ -239,8 +239,6 @@ def test_bad_differential_sweep_specs(model, tmp_path):
 @pytest.mark.component
 def test_differential_sweep_outputs(model):
 
-    comm = MPI.COMM_WORLD
-
     m = model
     m.fs.slack_penalty = 1000.0
     m.fs.slack.setub(0)
@@ -262,7 +260,6 @@ def test_differential_sweep_outputs(model):
     outputs = {"fs.output[c]": m.fs.output["c"]}
 
     ps = DifferentialParameterSweep(
-        comm=comm,
         optimize_function=_optimization,
         reinitialize_function=_reinitialize,
         reinitialize_kwargs={"slack_penalty": 10.0},
@@ -314,7 +311,6 @@ def test_differential_parameter_sweep(model, tmp_path):
     }
 
     ps = DifferentialParameterSweep(
-        comm=comm,
         csv_results_file_name=csv_results_file_name,
         h5_results_file_name=h5_results_file_name,
         debugging_data_dir=tmp_path,
@@ -333,7 +329,7 @@ def test_differential_parameter_sweep(model, tmp_path):
         seed=0,
     )
 
-    if ps.rank == 0:
+    if ps.parallel_manager.is_root_process():
 
         truth_dict = {
             "outputs": {
@@ -705,7 +701,6 @@ def test_differential_parameter_sweep_selective(model, tmp_path):
     }
 
     ps = DifferentialParameterSweep(
-        comm=comm,
         csv_results_file_name=csv_results_file_name,
         h5_results_file_name=h5_results_file_name,
         debugging_data_dir=tmp_path,
@@ -725,7 +720,7 @@ def test_differential_parameter_sweep_selective(model, tmp_path):
         seed=0,
     )
 
-    if ps.rank == 0:
+    if ps.parallel_manager.is_root_process():
 
         truth_dict = {
             "outputs": {
@@ -1216,7 +1211,6 @@ def test_differential_parameter_sweep_function(model, tmp_path):
         sweep_params,
         differential_sweep_specs,
         outputs=None,
-        mpi_comm=comm,
         csv_results_file_name=csv_results_file_name,
         h5_results_file_name=h5_results_file_name,
         debugging_data_dir=tmp_path,

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -300,7 +300,7 @@ class TestParameterSweep:
         )
 
         num_procs = ps.parallel_manager.number_of_worker_processes()
-        rank = ps.rank
+        rank = ps.parallel_manager.get_rank()
         test = np.array_split(global_combo_array, num_procs, axis=0)[rank]
 
         local_combo_array = ps._divide_combinations(global_combo_array)
@@ -531,7 +531,7 @@ class TestParameterSweep:
         # Manually update the values in the numpy array
         for key, value in local_output_dict.items():
             for subkey, subvalue in value.items():
-                subvalue["value"][:] = ps.rank
+                subvalue["value"][:] = ps.parallel_manager.get_rank()
 
         # Local output dict also contains the solve_successful. The solve status is
         # based on the
@@ -542,7 +542,7 @@ class TestParameterSweep:
             local_output_dict, global_num_cases
         )
 
-        if ps.rank > 0:
+        if ps.parallel_manager.get_rank() > 0:
             assert global_output_dict == local_output_dict
         else:
             test_array = np.repeat(
@@ -558,7 +558,6 @@ class TestParameterSweep:
                         assert np.allclose(subvalue["value"], test_array)
                 elif key == "solve_successful":
                     assert list(value) == test_list
-        ps.comm.Barrier()
 
     @pytest.mark.component
     @pytest.mark.parametrize("number_of_subprocesses", [1, 2, 3])
@@ -573,7 +572,6 @@ class TestParameterSweep:
         h5_results_file_name = str(results_fname) + ".h5"
 
         ps = ParameterSweep(
-            comm=comm,
             optimize_function=_optimization,
             csv_results_file_name=csv_results_file_name,
             h5_results_file_name=h5_results_file_name,
@@ -593,7 +591,7 @@ class TestParameterSweep:
         #       responsible for doing any output file checking
         #       tmp_path can be deleted as soon as this method
         #       returns
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
             # Check that the global results file is created
             assert os.path.isfile(csv_results_file_name)
             assert os.path.isfile(
@@ -617,7 +615,7 @@ class TestParameterSweep:
             assert np.allclose(data[-1], truth_data, equal_nan=True)
 
         # Check for the h5 output
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
             truth_dict = {
                 "outputs": {
                     "output_c": {
@@ -760,7 +758,7 @@ class TestParameterSweep:
         #       responsible for doing any output file checking
         #       tmp_path can be deleted as soon as this method
         #       returns
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
             # Check that the global results file is created
             assert os.path.isfile(csv_results_file_name)
 
@@ -778,7 +776,7 @@ class TestParameterSweep:
             assert np.allclose(data[-1], truth_data, equal_nan=True)
 
         # Check the h5
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
 
             truth_dict = {
                 "outputs": {
@@ -927,7 +925,7 @@ class TestParameterSweep:
         #       responsible for doing any output file checking
         #       tmp_path can be deleted as soon as this method
         #       returns
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
             # Check that the global results file is created
             assert os.path.isfile(csv_results_file_name)
 
@@ -1150,7 +1148,7 @@ class TestParameterSweep:
         #       responsible for doing any output file checking
         #       tmp_path can be deleted as soon as this method
         #       returns
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
             # Check that the global results file is created
             assert os.path.isfile(csv_results_file_name)
 
@@ -1338,7 +1336,7 @@ class TestParameterSweep:
         #       responsible for doing any output file checking
         #       tmp_path can be deleted as soon as this method
         #       returns
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
             # Check that the global results file is created
             assert os.path.isfile(csv_results_file_name)
 
@@ -1649,7 +1647,7 @@ class TestParameterSweep:
         #       responsible for doing any output file checking
         #       tmp_path can be deleted as soon as this method
         #       returns
-        if ps.rank == 0:
+        if ps.parallel_manager.is_root_process():
             # Check that the global results file is created
             assert os.path.isfile(csv_results_file_name)
 
@@ -1747,7 +1745,6 @@ class TestParameterSweep:
             optimize_function=_optimization,
             debugging_data_dir=tmp_path,
             interpolate_nan_outputs=True,
-            mpi_comm=comm,
         )
 
         # NOTE: rank 0 "owns" tmp_path, so it needs to be
@@ -1877,8 +1874,6 @@ class TestParameterSweep:
     def test_parameter_sweep_custom_do_param_sweep(self, model, tmp_path):
         def custom_do_param_sweep(model, sweep_params, outputs, local_values, **kwargs):
             return kwargs
-
-        comm = MPI.COMM_WORLD
 
         custom_kwargs = {"val1": 2.0}
         ps = ParameterSweep(

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep_writer.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep_writer.py
@@ -100,8 +100,8 @@ class TestParallelWriterManager:
     def test_h5_read_write(self, tmp_path):
         ps = ParameterSweep()
 
-        tmp_path = _get_rank0_path(ps.comm, tmp_path)
-        h5_fname = "h5_test_{0}.h5".format(ps.rank)
+        tmp_path = _get_rank0_path(None, tmp_path)
+        h5_fname = "h5_test_{0}.h5".format(ps.parallel_manager.get_rank())
 
         ps_writer = ParameterSweepWriter(
             ps.parallel_manager,
@@ -180,8 +180,8 @@ class TestParallelWriterManager:
     def test_h5_parents(self, tmp_path):
         ps = ParameterSweep()
 
-        tmp_path = _get_rank0_path(ps.comm, tmp_path)
-        h5_fname = "h5_test_{0}.h5".format(ps.rank)
+        tmp_path = _get_rank0_path(None, tmp_path)
+        h5_fname = "h5_test_{0}.h5".format(ps.parallel_manager.get_rank())
         h5_parent_groups = ["loop1", "loop2"]
 
         embedded_dict = {

--- a/watertap/tools/parameter_sweep/tests/test_recursive_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_recursive_parameter_sweep.py
@@ -219,7 +219,7 @@ def test_recursive_parameter_sweep(model, tmp_path):
     assert np.allclose(reference_save_data, data, equal_nan=True)
     assert np.allclose(np.sum(data, axis=1), value(m.fs.success_prob))
 
-    if ps.rank == 0:
+    if ps.parallel_manager.is_root_process():
         # Check that the global results file is created
         assert os.path.isfile(csv_results_file)
 


### PR DESCRIPTION
## Fixes/Resolves:

Gets rid of the remaining explicit uses of MPI from the base parameter sweep class. There's a bit of awkwardness in replacing MPI functions with ones on the parallel manager class, since a lot of the functions are similar to each other, but I wanted to keep as close as possible to how the code currently works.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
