### PR TITLE
Allow passing build_outputs=None to parameter sweep

### DIFF
--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -814,6 +814,9 @@ class ParameterSweep(_ParameterSweepBase):
                 version="0.10.0",
             )
 
+        if build_outputs is None:
+            build_outputs = return_none
+
         if not callable(build_outputs):
             _combined_outputs = build_outputs
             build_outputs = lambda model, sweep_params: _combined_outputs
@@ -1136,3 +1139,11 @@ def do_execute(
     return param_sweep_instance._do_param_sweep(
         model, sweep_params, outputs, local_combo_array
     )
+
+
+def return_none(model, sweep_params):
+    """
+    Used so that build_outputs=None is a valid usage of the parameter sweep tool
+    without requiring the user to wrap it in a function.
+    """
+    return None


### PR DESCRIPTION
## Fixes/Resolves:

Right now build_outputs=None breaks the concurrent futures parallel manager implementation because it tries to pickle a "return None" lambda on the fly. This is a bit confusing to the user, so build_outputs=None should probably still be allowed.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
