### PR TITLE
Add concurrency group for GHA workflows to avoid redundant runs for PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,6 +28,7 @@ env:
   # --color=yes needed for colorized output to be shown in GHA logs
   # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py
   PYTEST_ADDOPTS: "--color=yes"
+  PIP_PROGRESS_BAR: "off"
 
 jobs:
 
@@ -46,7 +47,7 @@ jobs:
         # so we extract the relevant line and pass it to a simple `pip install`
         run: |
           black_requirement="$(grep '^black==' requirements-dev.txt)"
-          pip --no-cache-dir install --progress-bar off "$black_requirement"
+          pip --no-cache-dir install "$black_requirement"
       - name: Run Black to verify that the committed code is formatted
         run: |
           black --check .
@@ -62,7 +63,7 @@ jobs:
           python-version: '3.8'
       - name: Install dev dependencies
         run: |
-          pip install --progress-bar off -r requirements-dev.txt
+          pip install -r requirements-dev.txt
           pip list
       - name: Run pylint
         run: |
@@ -113,7 +114,7 @@ jobs:
         conda install --quiet --yes pip setuptools wheel pandoc
         echo '::endgroup::'
         echo '::group::Output of "pip install" commands'
-        pip install --progress-bar off -r requirements-dev.txt
+        pip install -r requirements-dev.txt
         echo '::endgroup::'
         echo '::group::Output of "pip install -U ray" command'
         pip install -U ray
@@ -216,7 +217,7 @@ jobs:
     - name: Install watertap and testing dependencies
       run: |
         echo '::group::Output of "pip install" commands'
-        pip install --progress-bar off "watertap @ ${_install_url}" pytest
+        pip install "watertap @ ${_install_url}" pytest
         echo '::endgroup::'
         echo '::group::Display installed packages'
         conda list
@@ -260,7 +261,7 @@ jobs:
         conda install --quiet --yes pip setuptools wheel pandoc
         echo '::endgroup::'
         echo '::group::Output of "pip install" commands'
-        pip install --progress-bar off -r requirements-dev.txt
+        pip install -r requirements-dev.txt
         echo '::endgroup::'
         echo '::group::Display installed packages'
         conda list
@@ -295,7 +296,7 @@ jobs:
         conda install --quiet --yes pip=21.1 wheel setuptools pandoc
         echo '::endgroup::'
         echo '::group::Output of "pip install" commands'
-        pip install --progress-bar off -r requirements-dev.txt
+        pip install -r requirements-dev.txt
         echo '::endgroup::'
         echo '::group::Display installed packages'
         conda list

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,15 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  # NOTE: the value of `group` should be chosen carefully,
+  # otherwise we might end up over- or under-canceling workflow runs
+  # github.head_ref is only defined for pull request events
+  # so, if it's not present (i.e. event was triggered by push)
+  # we use github.ref instead
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     # important to make sure that all commands on Windows are run using Bash

--- a/.github/workflows/mpi4py-test.yml
+++ b/.github/workflows/mpi4py-test.yml
@@ -9,6 +9,15 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  # NOTE: the value of `group` should be chosen carefully,
+  # otherwise we might end up over- or under-canceling workflow runs
+  # github.head_ref is only defined for pull request events
+  # so, if it's not present (i.e. event was triggered by push)
+  # we use github.ref instead
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   # --color=yes needed for colorized output to be shown in GHA logs
   # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py

--- a/.github/workflows/mpi4py-test.yml
+++ b/.github/workflows/mpi4py-test.yml
@@ -22,6 +22,7 @@ env:
   # --color=yes needed for colorized output to be shown in GHA logs
   # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py
   PYTEST_ADDOPTS: "--color=yes"
+  PIP_PROGRESS_BAR: "off"
 
 jobs:
   build:
@@ -56,8 +57,8 @@ jobs:
     - name: Install dependencies
       run: |
         conda install --quiet --yes -c conda-forge mpi4py
-        python -m pip install --progress-bar off --upgrade pip
-        pip install --progress-bar off -r requirements-dev.txt
+        python -m pip install --upgrade pip
+        pip install -r requirements-dev.txt
         idaes get-extensions --verbose
     - name: Conda info
       run: conda info


### PR DESCRIPTION
## Fixes/Resolves: PR congestion

This addresses a request/suggestion by @agarciadiego pointing out workflow runs "piling up" when commits are pushed to the same PR, which results in long queues, the need to manage runs manually, and/or wasted computation (for all runs except the one for the latest commit).

## Summary/Motivation:

- Once this is merged, when a workflow is triggered, in-progress runs of that workflow will be automatically canceled if the concurrency group is the same as the new workflow
- The concurrency group contains the workflow name, plus:
  - For PR triggers: the name of the PR's head branch (i.e. the "source" branch)
  - For non-PR triggers: the full commit SHA

## Caveats

- Canceled workflow runs will still trigger notifications; in other words, cancellations due to concurrency are not treated differently from other cancellations
- The new workflow run starts from the beginning, so the previous workflow run is still "wasted"
- With the current concurrency group settings, pushing to a non-PR branch will _not_ cancel in-progress runs for previous commits (since the commit SHA is different). This is on purpose so that every commit on `main` gets its own workflow run for Codecov

## Example: pushing a commit to the same PR

#### Immediately after pushing

![2023-08-25_12-57](https://github.com/watertap-org/watertap/assets/48035537/60fffbce-2bcb-44a2-be97-82379579214d)

- Existing runs in progress
- New (most recent) runs are queued (clock icon)

#### After a few seconds

![2023-08-25_12-57_1](https://github.com/watertap-org/watertap/assets/48035537/9eb8ef8a-58e1-4f47-b8cd-10874f462f5b)

- Previous runs are canceled automatically
- New runs start running (from the beginning)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
