### PR TITLE
Solve ASM2D Flowsheet without bound_push and autoscale function

### DIFF
--- a/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet.py
@@ -18,7 +18,7 @@ assumptions", 2012, Wat. Sci. Tech., Vol. 65 No. 8, pp. 1496-1505
 """
 
 # Some more information about this module
-__author__ = "Alejandro Garciadiego, Andrew Lee"
+__author__ = "Alejandro Garciadiego, Andrew Lee, Adam Atia"
 
 import pyomo.environ as pyo
 from pyomo.network import Arc, SequentialDecomposition
@@ -54,15 +54,6 @@ from watertap.core.util.initialization import check_solve
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)
-
-
-def automate_rescale_variables(m):
-    for var, sv in iscale.badly_scaled_var_generator(m):
-        if iscale.get_scaling_factor(var) is None:
-            continue
-        sf = iscale.get_scaling_factor(var)
-        iscale.set_scaling_factor(var, sf / sv)
-        iscale.calculate_scaling_factors(m)
 
 
 def build_flowsheet():
@@ -389,10 +380,10 @@ def build_flowsheet():
     seq.set_guesses_for(m.fs.R3.inlet, tear_guesses)
 
     def function(unit):
-        unit.initialize(outlvl=idaeslog.INFO, optarg={"bound_push": 1e-8})
-        badly_scaled_vars = list(iscale.badly_scaled_var_generator(unit))
-        if len(badly_scaled_vars) > 0:
-            automate_rescale_variables(unit)
+        unit.initialize(outlvl=idaeslog.INFO)
+        # badly_scaled_vars = list(iscale.badly_scaled_var_generator(unit))
+        # if len(badly_scaled_vars) > 0:
+        #     automate_rescale_variables(unit)
 
     seq.run(m, function)
 

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/tests/test_asm2d_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/tests/test_asm2d_flowsheet.py
@@ -57,7 +57,7 @@ class TestASM2DFlowsheet:
         assert value(model.fs.Treated.temperature[0]) == pytest.approx(298.15, rel=1e-4)
         assert value(model.fs.Treated.pressure[0]) == pytest.approx(101325, rel=1e-4)
         assert value(model.fs.Treated.conc_mass_comp[0, "S_A"]) == pytest.approx(
-            5.4560e-5, rel=1e-4
+            5.4560e-5, rel=1e-3
         )
         assert value(model.fs.Treated.conc_mass_comp[0, "S_F"]) == pytest.approx(
             2.5736e-3, rel=1e-2


### PR DESCRIPTION
## Fixes/Resolves:

## Summary/Motivation:
An existing flowsheet example for the conventional ASM2D model uses bound_push and an autoscale function. Neither should be used to solve the model in the main codebase. Moreover, the modified version of ASM2D, a trickier variant of conventional ASM2D, will subsequently be implemented in a similar flowsheet example, but we should make sure the original version works first.

**TODO:** 

- [ ] Adjust regression test values and review to make sure we accept the variations in results

## Changes proposed in this PR:
- remove bound_push
- remove autoscaling

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
