### PR TITLE
Eliminate suffix warnings by hot patching Pyomo's NL Writer

### DIFF
--- a/docs/how_to_guides/how_to_use_a_property_model.rst
+++ b/docs/how_to_guides/how_to_use_a_property_model.rst
@@ -70,12 +70,6 @@ A portion of the displayed output is shown below.
 
 .. testoutput::
 
-   WARNING: model contains export suffix 'fs.state_block[0].scaling_factor' that
-   contains 4 component keys that are not exported as part of the NL file.
-   Skipping.
-   WARNING: model contains export suffix 'fs.state_block[0].scaling_factor' that
-   contains 4 component keys that are not exported as part of the NL file.
-   Skipping.
    Block fs.state_block[0]
 
      Variables:

--- a/watertap/core/plugins/solvers.py
+++ b/watertap/core/plugins/solvers.py
@@ -14,6 +14,7 @@ import pyomo.environ as pyo
 from pyomo.core.base.block import _BlockData
 from pyomo.core.kernel.block import IBlock
 from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
+import pyomo.repn.plugins.nl_writer as _nl_writer
 
 import idaes.core.util.scaling as iscale
 from idaes.core.util.scaling import (
@@ -24,6 +25,17 @@ from idaes.core.util.scaling import (
 from idaes.logger import getLogger
 
 _log = getLogger("watertap.core")
+_SuffixData = _nl_writer._SuffixData
+
+
+class _WTSuffixData(_SuffixData):
+    def update(self, suffix):
+        self.datatype.add(suffix.datatype)
+        for obj, val in suffix.items():
+            self._store(obj, val)
+
+    def store(self, obj, val):
+        self._store(obj, val)
 
 
 @pyo.SolverFactory.register(
@@ -46,6 +58,13 @@ class IpoptWaterTAP(IPOPT):
                 "IpoptWaterTAP.solve takes 1 positional argument: a Pyomo ConcreteModel or Block"
             )
 
+        # hot patch _SuffixData to prevent an overload
+        # on error reporting about `scaling_factor`
+        _nl_writer._SuffixData = _WTSuffixData
+
+        # until proven otherwise
+        self._cleanup_needed = False
+
         self._tee = kwds.get("tee", False)
 
         # Set the default watertap options
@@ -55,8 +74,9 @@ class IpoptWaterTAP(IPOPT):
             self.options["constr_viol_tol"] = 1e-08
 
         if not self._is_user_scaling():
-            self._cleanup_needed = False
-            return super()._presolve(*args, **kwds)
+            super()._presolve(*args, **kwds)
+            self._cleanup()
+            return
 
         if self._tee:
             print(
@@ -65,6 +85,7 @@ class IpoptWaterTAP(IPOPT):
 
         bound_relax_factor = self._get_option("bound_relax_factor", 1e-10)
         if bound_relax_factor < 0.0:
+            self._cleanup()
             raise ValueError(
                 f"Option bound_relax_factor must be non-negative; bound_relax_factor={bound_relax_factor}"
             )
@@ -75,6 +96,7 @@ class IpoptWaterTAP(IPOPT):
 
         # raise an error if "honor_original_bounds" is set to "yes" (for now)
         if self.options.get("honor_original_bounds", "no") == "yes":
+            self._cleanup()
             raise ValueError(
                 f"""Option honor_original_bounds must be set to "no" -- ipopt-watertap does not presently implement this option"""
             )
@@ -147,6 +169,7 @@ class IpoptWaterTAP(IPOPT):
             raise
 
     def _cleanup(self):
+        _nl_writer._SuffixData = _SuffixData
         if self._cleanup_needed:
             self._reset_scaling_factors()
             self._reset_bounds()

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -16,12 +16,13 @@ import idaes.core.util.scaling as iscale
 
 from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
 from pyomo.common.errors import ApplicationError
+import pyomo.repn.plugins.nl_writer as _nl_writer
 from idaes.core.util.scaling import (
     set_scaling_factor,
     constraints_with_scale_factor_generator,
 )
 from idaes.core.solvers import get_solver
-from watertap.core.plugins.solvers import IpoptWaterTAP
+from watertap.core.plugins.solvers import IpoptWaterTAP, _SuffixData
 
 
 class TestIpoptWaterTAP:
@@ -108,6 +109,7 @@ class TestIpoptWaterTAP:
         assert cons_with_sf == [(m.b.d, 1e6)]
 
         assert not hasattr(s, "_model")
+        assert _nl_writer._SuffixData is _SuffixData
 
     @pytest.mark.unit
     def test_option_absorption(self, m, s):
@@ -116,6 +118,7 @@ class TestIpoptWaterTAP:
         pyo.assert_optimal_termination(results)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         del s.options["ignore_variable_scaling"]
 
     @pytest.mark.unit
@@ -132,6 +135,7 @@ class TestIpoptWaterTAP:
         s._presolve(m, tee=True)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         s.options["nlp_scaling_method"] = "user-scaling"
 
     @pytest.mark.unit
@@ -141,6 +145,7 @@ class TestIpoptWaterTAP:
         del s.options["nlp_scaling_method"]
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
 
     @pytest.mark.unit
     def test_passthrough_negative(self, m, s):
@@ -152,6 +157,7 @@ class TestIpoptWaterTAP:
         del s.options["ignore_variable_scaling"]
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
 
     @pytest.mark.unit
     def test_presolve_incorrect_number_of_arguments(self, m, s):
@@ -172,6 +178,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         m.a.value = 1
 
     @pytest.mark.unit
@@ -189,6 +196,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         m.a.value = 1
 
     @pytest.mark.unit
@@ -206,6 +214,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         IPOPT._presolve = IPOPT_presolve
 
     @pytest.mark.unit
@@ -223,6 +232,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         iscale.constraint_autoscale_large_jac = constraint_autoscale_large_jac
 
     @pytest.mark.unit
@@ -232,6 +242,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         del s.options["honor_original_bounds"]
 
     @pytest.mark.unit
@@ -241,6 +252,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _nl_writer._SuffixData is _SuffixData
         del s.options["bound_relax_factor"]
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
@hunterbarber reports that the warnings from Pyomo about unexported suffixes for scaling factors are dominating his log file. We could simply turn down the logger for the NLWriter, but it also can report other useful things. Therefore, this PR would eliminate these warnings by hot-patching the class that generates them.

Note that the hot-patch is undone after a call to the watertap-ipopt wrapper.

## Changes proposed in this PR:
- Hot patch `_SuffixData` to eliminate spurious warnings from Pyomo

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
