### PR TITLE
Modify tutorials section to include direct link to Binder

### DIFF
--- a/docs/how_to_guides/notebooks.rst
+++ b/docs/how_to_guides/notebooks.rst
@@ -33,7 +33,7 @@ Local (developer) installation
 Online using Binder.org
 -----------------------
 
-`Binder <https://mybinder.org>`_ is an online service providng a **short-lived temporary sandbox environment on public cloud resources** where Jupyter notebooks can be run, free of charge, without having to install any software locally.
+`Binder <https://mybinder.org>`_ is an online service providing a **short-lived temporary sandbox environment on public cloud resources** where Jupyter notebooks can be run, free of charge, without having to install any software locally.
 
 Click on this button to launch an environment pointing to the current ``main`` branch of the WaterTAP repository:
 
@@ -47,8 +47,8 @@ Click on this button to launch an environment pointing to the current ``main`` b
 Customization
 ^^^^^^^^^^^^^
 
-Binder uses a Git repository hosted on e.g. GitHub to fetch the notebooks and create the runtime environment.
-Users can specify a specific fork, branch, and Git ref (e.g. a particular commit hash), as well as the path to a particular directory or notebook file within the repository, that will be used
+Binder uses a Git repository hosted on, e.g., GitHub to fetch the notebooks and create the runtime environment.
+Users can specify a specific fork, branch, and Git ref (e.g., a particular commit hash), as well as the path to a particular directory or notebook file within the repository, that will be used
 when first starting the environment.
 
 These options can be specified interactively on the `Binder homepage <https://mybinder.org/>`_, which will create a URL that can then be shared with others to generate a (separate) instance of the environment with the same repository settings.

--- a/docs/how_to_guides/notebooks.rst
+++ b/docs/how_to_guides/notebooks.rst
@@ -28,7 +28,7 @@ Local (developer) installation
 
 #. If prompted to select a kernel, select ``watertap-dev`` from the menu. Otherwise, ensure ``watertap-dev`` appears in the kernel box in the top-right corner of the notebook interface
 
-.. _noteboks-online:
+.. _notebooks-online:
 
 Online using Binder.org
 -----------------------

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -12,9 +12,10 @@ the IDAES tutorials `Short introduction to Python and Pyomo <https://idaes.githu
 The tutorials included with WaterTAP are available in the "tutorials" directory
 on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree/main/tutorials>`_.
 
-To run the WaterTAP tutorials online (no installation required), click on the button below to launch an environment pointing to the current ``main`` branch of the WaterTAP repository:
+.. note::
+    **To run WaterTAP tutorials online (no installation required), click on the "launch binder" button below to launch an environment pointing to the current ``main`` branch of the WaterTAP repository:**
 
-.. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/watertap-org/watertap/main?labpath=tutorials%2Fintroduction.ipynb
+    .. image:: https://mybinder.org/badge_logo.svg
+     :target: https://mybinder.org/v2/gh/watertap-org/watertap/main?labpath=tutorials%2Fintroduction.ipynb
 
-For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`.
+    For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -13,10 +13,11 @@ The tutorials included with WaterTAP are available in the "tutorials" directory
 on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree/main/tutorials>`_.
 
 .. note::
+    For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`_.
+
     **To run WaterTAP tutorials online (no installation required), click on the "launch binder" button below to launch an environment pointing to the current** ``main`` **branch of the WaterTAP repository:**
     
     .. image:: https://mybinder.org/badge_logo.svg
      :target: https://mybinder.org/v2/gh/watertap-org/watertap/main?labpath=tutorials%2Fintroduction.ipynb
 
-
-    For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`_.
+    

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -13,7 +13,7 @@ The tutorials included with WaterTAP are available in the "tutorials" directory
 on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree/main/tutorials>`_.
 
 .. note::
-    For important details on running tutorial notebooks, refer to :ref:`this guide<notebooks-online>`.
+    For important details on running tutorial notebooks, refer to :ref:`this guide<notebooks>`.
 
     **To run WaterTAP tutorials online (no installation required), click on the "launch binder" button below to launch an environment pointing to the current** ``main`` **branch of the WaterTAP repository:**
     

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -13,9 +13,10 @@ The tutorials included with WaterTAP are available in the "tutorials" directory
 on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree/main/tutorials>`_.
 
 .. note::
-    **To run WaterTAP tutorials online (no installation required), click on the "launch binder" button below to launch an environment pointing to the current ``main`` branch of the WaterTAP repository:**
-
+    **To run WaterTAP tutorials online (no installation required), click on the "launch binder" button below to launch an environment pointing to the current** ``main`` **branch of the WaterTAP repository:**
+    
     .. image:: https://mybinder.org/badge_logo.svg
      :target: https://mybinder.org/v2/gh/watertap-org/watertap/main?labpath=tutorials%2Fintroduction.ipynb
 
-    For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`.
+
+    For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`_.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -11,3 +11,10 @@ the IDAES tutorials `Short introduction to Python and Pyomo <https://idaes.githu
 
 The tutorials included with WaterTAP are available in the "tutorials" directory
 on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree/main/tutorials>`_.
+
+To run the WaterTAP tutorials online (no installation required), click on the button below to launch an environment pointing to the current ``main`` branch of the WaterTAP repository:
+
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/watertap-org/watertap/main?labpath=tutorials%2Fintroduction.ipynb
+
+For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -13,7 +13,7 @@ The tutorials included with WaterTAP are available in the "tutorials" directory
 on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree/main/tutorials>`_.
 
 .. note::
-    For important details on running tutorial notebooks, refer to `this guide<https://watertap.readthedocs.io/en/stable/how_to_guides/notebooks.html#online-using-binder-org>`_.
+    For important details on running tutorial notebooks, refer to :ref:`this guide<notebooks-online>`.
 
     **To run WaterTAP tutorials online (no installation required), click on the "launch binder" button below to launch an environment pointing to the current** ``main`` **branch of the WaterTAP repository:**
     


### PR DESCRIPTION
## Fixes/Resolves: #1168 
## Summary/Motivation:
Add links to Binder in Tutorials section of readthedocs.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
