### PR TITLE
Costing Unification: move from `factor_total_investment` to `TIC`

### DIFF
--- a/tutorials/unit_model_customization_example.ipynb
+++ b/tutorials/unit_model_customization_example.ipynb
@@ -708,7 +708,7 @@
     "    pressure.append(m.fs.RO.inlet.pressure[0].value/1e5)\n",
     "    sh_avg=np.average([m.fs.RO.feed_side.N_Sh_comp[t,x,j].value for (t,x,j) in m.fs.RO.feed_side.N_Sh_comp])\n",
     "    avg_sh.append(sh_avg)\n",
-    "    lcow.append(m.fs.costing.LCOW.value)\n",
+    "    lcow.append(value(m.fs.costing.LCOW))\n",
     "    print(\"Solved multiplier {}\".format(adj))"
    ]
   },
@@ -818,7 +818,7 @@
     "    result = solver.solve(m, tee=False)\n",
     "    assert_optimal_termination(result)\n",
     "    pressures.append(m.fs.RO.inlet.pressure[0].value/1e5)    \n",
-    "    lcow_fixed_mem_cost.append(m.fs.costing.LCOW.value)\n",
+    "    lcow_fixed_mem_cost.append(value(m.fs.costing.LCOW))\n",
     "    mem_cost_fixed.append(m.fs.costing.reverse_osmosis.membrane_cost.value)\n",
     "    # second unfix our membrane cost and activate variable cost constraint and solve\n",
     "    m.fs.costing.reverse_osmosis.membrane_cost.unfix()\n",
@@ -826,7 +826,7 @@
     "    assert degrees_of_freedom(m) == 0\n",
     "    result = solver.solve(m, tee=False)\n",
     "    assert_optimal_termination(result)\n",
-    "    lcow_variable_mem_cost.append(m.fs.costing.LCOW.value)\n",
+    "    lcow_variable_mem_cost.append(value(m.fs.costing.LCOW))\n",
     "    mem_cost_variable.append(m.fs.costing.reverse_osmosis.membrane_cost.value)\n",
     "\n",
     "    print(\"Solved con {}\".format(con))"

--- a/watertap/core/zero_order_base.py
+++ b/watertap/core/zero_order_base.py
@@ -330,22 +330,6 @@ class ZeroOrderBaseData(UnitModelBlockData):
     # -------------------------------------------------------------------------
     # Unit operation costing methods
     @staticmethod
-    def _add_cost_factor(blk, factor):
-        if factor == "TPEC":
-            blk.cost_factor = pyo.Expression(
-                expr=blk.config.flowsheet_costing_block.TPEC
-            )
-        elif factor == "TIC":
-            blk.cost_factor = pyo.Expression(
-                expr=blk.config.flowsheet_costing_block.TIC
-            )
-        else:
-            blk.cost_factor = pyo.Expression(expr=1.0)
-        blk.direct_capital_cost = pyo.Expression(
-            expr=blk.capital_cost / blk.cost_factor
-        )
-
-    @staticmethod
     def _get_unit_cost_method(blk):
         """
         Get a specified cost_method if one is defined in the YAML file.
@@ -462,7 +446,7 @@ class ZeroOrderBaseData(UnitModelBlockData):
 
         expr *= number_of_parallel_units
 
-        blk.unit_model._add_cost_factor(blk, factor)
+        blk.costing_package.add_cost_factor(blk, factor)
 
         blk.capital_cost_constraint = pyo.Constraint(
             expr=blk.capital_cost == blk.cost_factor * expr

--- a/watertap/costing/costing_base.py
+++ b/watertap/costing/costing_base.py
@@ -212,7 +212,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         )
 
         self.TIC = pyo.Var(
-            initialize=1.65,
+            initialize=2.0,
             doc="Total Installed Cost (TIC)",
             units=pyo.units.dimensionless,
         )

--- a/watertap/costing/costing_base.py
+++ b/watertap/costing/costing_base.py
@@ -206,7 +206,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         )
 
         self.TPEC = pyo.Var(
-            initialize=3.4,
+            initialize=3.4 * (2.0 / 1.65),
             doc="Total Purchased Equipment Cost (TPEC)",
             units=pyo.units.dimensionless,
         )
@@ -219,6 +219,22 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
 
         self.fix_all_vars()
 
+    @staticmethod
+    def add_cost_factor(blk, factor):
+        if factor == "TPEC":
+            blk.cost_factor = pyo.Expression(
+                expr=blk.config.flowsheet_costing_block.TPEC
+            )
+        elif factor == "TIC":
+            blk.cost_factor = pyo.Expression(
+                expr=blk.config.flowsheet_costing_block.TIC
+            )
+        else:
+            blk.cost_factor = pyo.Expression(expr=1.0)
+        blk.direct_capital_cost = pyo.Expression(
+            expr=blk.capital_cost / blk.cost_factor
+        )
+
     def _get_costing_method_for(self, unit_model):
         """
         Allow the unit model to register its default costing method,
@@ -228,6 +244,44 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         if hasattr(unit_model, "default_costing_method"):
             return unit_model.default_costing_method
         return super()._get_costing_method_for(unit_model)
+
+    def aggregate_costs(self):
+        """
+        This method aggregates costs from all the unit models and flows
+        registered with this FlowsheetCostingBlock and creates aggregate
+        variables for these on the FlowsheetCostingBlock that can be used for
+        further process-wide costing calculations.
+
+        The following costing variables are aggregated from all the registered
+        UnitModelCostingBlocks (if they exist):
+
+        * capital_cost,
+        * direct_capital_cost,
+        * fixed_operating_cost, and
+        * variable_operating_cost
+
+        Additionally, aggregate flow variables are created for all registered
+        flow types along with aggregate costs associated with each of these.
+
+        Args:
+            None
+        """
+        super().aggregate_costs()
+        c_units = self.base_currency
+
+        @self.Expression(doc="Aggregation Expression for direct capital cost")
+        def aggregate_direct_capital_cost(blk):
+            e = 0
+            for u in self._registered_unit_costing:
+                # Allow for units that might only have a subset of cost Vars
+                if hasattr(u, "direct_capital_cost"):
+                    e += pyo.units.convert(u.direct_capital_cost, to_units=c_units)
+                elif hasattr(u, "capital_cost"):
+                    raise RuntimeError(
+                        f"WaterTAP models with a capital_cost must also supply a direct_capital_cost. Found unit {u.unit_model} with `capital_cost` but no `direct_capital_cost`."
+                    )
+
+            return e
 
     def register_flow_type(self, flow_type, cost):
         """

--- a/watertap/costing/costing_base.py
+++ b/watertap/costing/costing_base.py
@@ -211,13 +211,9 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
     @staticmethod
     def add_cost_factor(blk, factor):
         if factor == "TPEC":
-            blk.cost_factor = pyo.Expression(
-                expr=blk.config.flowsheet_costing_block.TPEC
-            )
+            blk.cost_factor = pyo.Expression(expr=blk.costing_package.TPEC)
         elif factor == "TIC":
-            blk.cost_factor = pyo.Expression(
-                expr=blk.config.flowsheet_costing_block.TIC
-            )
+            blk.cost_factor = pyo.Expression(expr=blk.costing_package.TIC)
         else:
             blk.cost_factor = pyo.Expression(expr=1.0)
         blk.direct_capital_cost = pyo.Expression(

--- a/watertap/costing/tests/test_costing_interop.py
+++ b/watertap/costing/tests/test_costing_interop.py
@@ -96,15 +96,18 @@ def add_wt_costing(m):
 def test_hrcs_case_1575_wtcosting():
     hrcs.add_costing = add_wt_costing
 
-    m, results = simple_main()
-    pyo.assert_optimal_termination(results)
+    try:
+        m, results = simple_main()
+        pyo.assert_optimal_termination(results)
 
-    # check costing -- baseline is 0.02003276
-    assert pyo.value(m.fs.costing.LCOW) == pytest.approx(
-        0.02605311, rel=1e-3
-    )  # in $/m**3
-
-    hrcs.add_costing = hrcs_original_costing
+        # check costing -- baseline is 0.02003276
+        assert pyo.value(m.fs.costing.LCOW) == pytest.approx(
+            0.02419106, rel=1e-3
+        )  # in $/m**3
+    except:
+        raise
+    finally:
+        hrcs.add_costing = hrcs_original_costing
 
 
 def add_zo_costing(m):
@@ -167,12 +170,15 @@ def add_zo_costing(m):
 def test_hrcs_case_1575_zocosting():
     hrcs.add_costing = add_zo_costing
 
-    m, results = simple_main()
-    pyo.assert_optimal_termination(results)
+    try:
+        m, results = simple_main()
+        pyo.assert_optimal_termination(results)
 
-    # check costing -- baseline is 0.02003276
-    assert pyo.value(m.fs.costing.LCOW) == pytest.approx(
-        0.02087999, rel=1e-3
-    )  # in $/m**3
-
-    hrcs.add_costing = hrcs_original_costing
+        # check costing -- baseline is 0.02003276
+        assert pyo.value(m.fs.costing.LCOW) == pytest.approx(
+            0.02172723, rel=1e-3
+        )  # in $/m**3
+    except:
+        raise
+    finally:
+        hrcs.add_costing = hrcs_original_costing

--- a/watertap/costing/tests/test_multiple_choice_costing_block.py
+++ b/watertap/costing/tests/test_multiple_choice_costing_block.py
@@ -238,7 +238,7 @@ def test_multiple_choice_costing_block():
         m.fs.RO2.costing.costing_blocks["high_pressure"].capital_cost
     )
 
-    assert m.fs.costing.total_capital_cost.value == 2 * (
+    assert m.fs.costing.total_capital_cost.value == (
         m.fs.RO.costing.costing_blocks["normal_pressure"].capital_cost.value
         + m.fs.RO2.costing.costing_blocks["high_pressure"].capital_cost.value
     )
@@ -250,13 +250,13 @@ def test_multiple_choice_costing_block():
     )
 
     # need to re-initialize
-    assert m.fs.costing.total_capital_cost.value == 2 * (
+    assert m.fs.costing.total_capital_cost.value == (
         m.fs.RO.costing.costing_blocks["normal_pressure"].capital_cost.value
         + m.fs.RO2.costing.costing_blocks["high_pressure"].capital_cost.value
     )
 
     m.fs.costing.initialize()
-    assert m.fs.costing.total_capital_cost.value == 2 * (
+    assert m.fs.costing.total_capital_cost.value == (
         m.fs.RO.costing.costing_blocks["high_pressure"].capital_cost.value
         + m.fs.RO2.costing.costing_blocks["high_pressure"].capital_cost.value
     )
@@ -264,7 +264,7 @@ def test_multiple_choice_costing_block():
 
     m.fs.RO3.costing.select_costing_block("high_pressure")
     m.fs.costing.initialize()
-    assert m.fs.costing.total_capital_cost.value == 2 * (
+    assert m.fs.costing.total_capital_cost.value == (
         m.fs.RO.costing.costing_blocks["high_pressure"].capital_cost.value
         + m.fs.RO2.costing.costing_blocks["high_pressure"].capital_cost.value
         + m.fs.RO3.costing.costing_blocks["high_pressure"].capital_cost.value

--- a/watertap/costing/tests/test_util.py
+++ b/watertap/costing/tests/test_util.py
@@ -136,6 +136,7 @@ def build_dummy_cost_rectifier(blk):
 )
 def dummy_cost_rectifier(blk):
     cost_rectifier(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost == blk.capital_cost_rectifier
     )

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -426,8 +426,7 @@ class TestWorkflow:
     def test_add_LCOW(self, model):
         model.fs.costing.add_LCOW(model.fs.unit1.properties_in[0].flow_vol)
 
-        assert isinstance(model.fs.costing.LCOW, Var)
-        assert isinstance(model.fs.costing.LCOW_constraint, Constraint)
+        assert isinstance(model.fs.costing.LCOW, Expression)
 
         assert_units_consistent(model.fs)
         assert degrees_of_freedom(model.fs) == 0

--- a/watertap/costing/unit_models/anaerobic_digestor.py
+++ b/watertap/costing/unit_models/anaerobic_digestor.py
@@ -83,10 +83,10 @@ def cost_anaerobic_digestor_capital(
         flow_in / blk.reference_flow, to_units=pyo.units.dimensionless
     )
 
-    print(f"base_currency: {blk.costing_package.base_currency}")
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.capital_a_parameter * sizing_term**blk.capital_b_parameter,
             to_units=blk.costing_package.base_currency,

--- a/watertap/costing/unit_models/anaerobic_digestor.py
+++ b/watertap/costing/unit_models/anaerobic_digestor.py
@@ -86,7 +86,8 @@ def cost_anaerobic_digestor_capital(
     print(f"base_currency: {blk.costing_package.base_currency}")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.capital_a_parameter * sizing_term**blk.capital_b_parameter,
             to_units=blk.costing_package.base_currency,
         )

--- a/watertap/costing/unit_models/clarifier.py
+++ b/watertap/costing/unit_models/clarifier.py
@@ -84,6 +84,7 @@ def cost_circular_clarifier(blk, cost_electricity_flow=True):
     Circular clarifier costing method [1]
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
 
     surface_area = pyo.units.convert(
         blk.unit_model.surface_area, to_units=pyo.units.ft**2
@@ -91,7 +92,8 @@ def cost_circular_clarifier(blk, cost_electricity_flow=True):
 
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             blk.costing_package.circular.construction_a_parameter * surface_area**2
             + blk.costing_package.circular.construction_b_parameter * surface_area
             + blk.costing_package.circular.construction_c_parameter,
@@ -140,6 +142,7 @@ def cost_rectangular_clarifier(blk, cost_electricity_flow=True):
     Rectangular clarifier costing method [1]
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
 
     surface_area = pyo.units.convert(
         blk.unit_model.surface_area, to_units=pyo.units.ft**2
@@ -147,7 +150,8 @@ def cost_rectangular_clarifier(blk, cost_electricity_flow=True):
 
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             blk.costing_package.rectangular.construction_a_parameter * surface_area**2
             + blk.costing_package.rectangular.construction_b_parameter * surface_area
             + blk.costing_package.rectangular.construction_c_parameter,
@@ -190,6 +194,7 @@ def cost_primary_clarifier(blk, cost_electricity_flow=True):
     Primary clarifier costing method [2]
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
 
     t0 = blk.flowsheet().time.first()
     flow_in = pyo.units.convert(
@@ -197,7 +202,8 @@ def cost_primary_clarifier(blk, cost_electricity_flow=True):
     )
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             blk.costing_package.primary.capital_a_parameter
             * pyo.units.convert(
                 flow_in / (1e6 * pyo.units.gallon / pyo.units.day),

--- a/watertap/costing/unit_models/compressor.py
+++ b/watertap/costing/unit_models/compressor.py
@@ -34,9 +34,10 @@ def build_compressor_cost_param_block(blk):
 )
 def cost_compressor(blk, cost_electricity_flow=True):
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.costing_package.compressor.unit_cost
             * blk.unit_model.control_volume.properties_in[0].flow_mass_phase_comp[

--- a/watertap/costing/unit_models/compressor.py
+++ b/watertap/costing/unit_models/compressor.py
@@ -36,7 +36,8 @@ def cost_compressor(blk, cost_electricity_flow=True):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.costing_package.compressor.unit_cost
             * blk.unit_model.control_volume.properties_in[0].flow_mass_phase_comp[
                 "Vap", "H2O"

--- a/watertap/costing/unit_models/crystallizer.py
+++ b/watertap/costing/unit_models/crystallizer.py
@@ -157,9 +157,10 @@ def cost_crystallizer_by_crystal_mass(blk):
     Mass-based capital cost for FC crystallizer
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             (
                 blk.costing_package.crystallizer.iec_percent
@@ -188,9 +189,10 @@ def cost_crystallizer_by_volume(blk):
     Volume-based capital cost for FC crystallizer
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             (
                 blk.costing_package.crystallizer.volume_cost

--- a/watertap/costing/unit_models/crystallizer.py
+++ b/watertap/costing/unit_models/crystallizer.py
@@ -159,7 +159,8 @@ def cost_crystallizer_by_crystal_mass(blk):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             (
                 blk.costing_package.crystallizer.iec_percent
                 * blk.costing_package.crystallizer.fob_unit_cost
@@ -189,7 +190,8 @@ def cost_crystallizer_by_volume(blk):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             (
                 blk.costing_package.crystallizer.volume_cost
                 * (

--- a/watertap/costing/unit_models/cstr_injection.py
+++ b/watertap/costing/unit_models/cstr_injection.py
@@ -61,6 +61,7 @@ def cost_cstr_injection_capital(blk, capital_a_parameter, capital_b_parameter):
     Generic function for costing an CSTR injection system.
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
 
     blk.capital_a_parameter = pyo.Expression(expr=capital_a_parameter)
     blk.capital_b_parameter = pyo.Expression(expr=capital_b_parameter)
@@ -68,7 +69,8 @@ def cost_cstr_injection_capital(blk, capital_a_parameter, capital_b_parameter):
     print(f"base_currency: {blk.costing_package.base_currency}")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             blk.capital_a_parameter
             * (blk.unit_model.control_volume.volume[0] / pyo.units.m**3)
             ** blk.capital_b_parameter,

--- a/watertap/costing/unit_models/dewatering.py
+++ b/watertap/costing/unit_models/dewatering.py
@@ -101,6 +101,7 @@ def cost_centrifuge(
     Centrifuge costing method
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     cost_blk = blk.costing_package.centrifuge
     t0 = blk.flowsheet().time.first()
     x = flow_in = pyo.units.convert(
@@ -108,7 +109,8 @@ def cost_centrifuge(
     )
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             cost_blk.capital_a_parameter * x + cost_blk.capital_b_parameter,
             to_units=blk.costing_package.base_currency,
         )
@@ -134,6 +136,7 @@ def cost_filter_belt_press(
     Belt Press Filter costing method
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     cost_blk = blk.costing_package.filter_belt_press
     t0 = blk.flowsheet().time.first()
     x = flow_in = pyo.units.convert(
@@ -142,7 +145,8 @@ def cost_filter_belt_press(
 
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             cost_blk.capital_a_parameter * x + cost_blk.capital_b_parameter,
             to_units=blk.costing_package.base_currency,
         )
@@ -168,6 +172,7 @@ def cost_filter_plate_press(
     Plate Press Filter costing method
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
 
     cost_blk = blk.costing_package.filter_plate_press
     t0 = blk.flowsheet().time.first()
@@ -176,7 +181,8 @@ def cost_filter_plate_press(
 
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             cost_blk.capital_a_parameter
             * x_units
             * (x / x_units) ** cost_blk.capital_b_parameter,

--- a/watertap/costing/unit_models/electroNP.py
+++ b/watertap/costing/unit_models/electroNP.py
@@ -107,10 +107,10 @@ def cost_electroNP_capital(blk, HRT, sizing_cost):
         to_units=pyo.units.m**3 / pyo.units.hr,
     )
 
-    print(f"base_currency: {blk.costing_package.base_currency}")
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.HRT * flow_in * blk.sizing_cost,
             to_units=blk.costing_package.base_currency,

--- a/watertap/costing/unit_models/electroNP.py
+++ b/watertap/costing/unit_models/electroNP.py
@@ -110,7 +110,8 @@ def cost_electroNP_capital(blk, HRT, sizing_cost):
     print(f"base_currency: {blk.costing_package.base_currency}")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.HRT * flow_in * blk.sizing_cost,
             to_units=blk.costing_package.base_currency,
         )

--- a/watertap/costing/unit_models/electrodialysis.py
+++ b/watertap/costing/unit_models/electrodialysis.py
@@ -88,10 +88,11 @@ def cost_electrodialysis_stack(blk):
     """
     make_capital_cost_var(blk)
     make_fixed_operating_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     if blk.find_component("capital_cost_rectifier") is not None:
         blk.capital_cost_constraint = pyo.Constraint(
             expr=blk.capital_cost
-            == blk.costing_package.TIC
+            == blk.cost_factor
             * (
                 pyo.units.convert(
                     blk.costing_package.electrodialysis.membrane_capital_cost
@@ -111,7 +112,7 @@ def cost_electrodialysis_stack(blk):
     else:
         blk.capital_cost_constraint = pyo.Constraint(
             expr=blk.capital_cost
-            == blk.costing_package.TIC
+            == blk.cost_factor
             * pyo.units.convert(
                 blk.costing_package.electrodialysis.membrane_capital_cost
                 * (

--- a/watertap/costing/unit_models/electrodialysis.py
+++ b/watertap/costing/unit_models/electrodialysis.py
@@ -91,24 +91,28 @@ def cost_electrodialysis_stack(blk):
     if blk.find_component("capital_cost_rectifier") is not None:
         blk.capital_cost_constraint = pyo.Constraint(
             expr=blk.capital_cost
-            == pyo.units.convert(
-                blk.costing_package.electrodialysis.membrane_capital_cost
-                * (
-                    2
-                    * blk.unit_model.cell_pair_num
-                    * blk.unit_model.cell_width
-                    * blk.unit_model.cell_length
+            == blk.costing_package.TIC
+            * (
+                pyo.units.convert(
+                    blk.costing_package.electrodialysis.membrane_capital_cost
+                    * (
+                        2
+                        * blk.unit_model.cell_pair_num
+                        * blk.unit_model.cell_width
+                        * blk.unit_model.cell_length
+                    )
+                    + blk.costing_package.electrodialysis.stack_electrode_captical_cost
+                    * (2 * blk.unit_model.cell_width * blk.unit_model.cell_length),
+                    to_units=blk.costing_package.base_currency,
                 )
-                + blk.costing_package.electrodialysis.stack_electrode_captical_cost
-                * (2 * blk.unit_model.cell_width * blk.unit_model.cell_length),
-                to_units=blk.costing_package.base_currency,
+                + blk.capital_cost_rectifier
             )
-            + blk.capital_cost_rectifier
         )
     else:
         blk.capital_cost_constraint = pyo.Constraint(
             expr=blk.capital_cost
-            == pyo.units.convert(
+            == blk.costing_package.TIC
+            * pyo.units.convert(
                 blk.costing_package.electrodialysis.membrane_capital_cost
                 * (
                     2

--- a/watertap/costing/unit_models/electrolyzer.py
+++ b/watertap/costing/unit_models/electrolyzer.py
@@ -112,7 +112,8 @@ def cost_electrolyzer(blk):
     )
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == (blk.membrane_cost + blk.anode_cost + blk.cathode_cost)
+        == blk.costing_package.TIC
+        * (blk.membrane_cost + blk.anode_cost + blk.cathode_cost)
         / blk.costing_package.electrolyzer.fraction_material_cost
     )
 

--- a/watertap/costing/unit_models/electrolyzer.py
+++ b/watertap/costing/unit_models/electrolyzer.py
@@ -110,9 +110,10 @@ def cost_electrolyzer(blk):
             to_units=blk.costing_package.base_currency,
         )
     )
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * (blk.membrane_cost + blk.anode_cost + blk.cathode_cost)
         / blk.costing_package.electrolyzer.fraction_material_cost
     )

--- a/watertap/costing/unit_models/evaporator.py
+++ b/watertap/costing/unit_models/evaporator.py
@@ -35,9 +35,10 @@ def build_evaporator_cost_param_block(blk):
 )
 def cost_evaporator(blk):
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.costing_package.evaporator.unit_cost
             * blk.costing_package.evaporator.material_factor_cost

--- a/watertap/costing/unit_models/evaporator.py
+++ b/watertap/costing/unit_models/evaporator.py
@@ -37,7 +37,8 @@ def cost_evaporator(blk):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.costing_package.evaporator.unit_cost
             * blk.costing_package.evaporator.material_factor_cost
             * (

--- a/watertap/costing/unit_models/gac.py
+++ b/watertap/costing/unit_models/gac.py
@@ -304,9 +304,10 @@ def _cost_gac(blk, parameter_blk):
         )
     )
 
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * (blk.contactor_cost + blk.adsorbent_cost + blk.other_process_cost)
     )
 

--- a/watertap/costing/unit_models/gac.py
+++ b/watertap/costing/unit_models/gac.py
@@ -306,7 +306,8 @@ def _cost_gac(blk, parameter_blk):
 
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.contactor_cost + blk.adsorbent_cost + blk.other_process_cost
+        == blk.costing_package.TIC
+        * (blk.contactor_cost + blk.adsorbent_cost + blk.other_process_cost)
     )
 
     make_fixed_operating_cost_var(blk)

--- a/watertap/costing/unit_models/heat_exchanger.py
+++ b/watertap/costing/unit_models/heat_exchanger.py
@@ -40,9 +40,10 @@ def cost_heat_exchanger(blk):
     TODO: describe equations
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.costing_package.heat_exchanger.unit_cost
             * blk.costing_package.heat_exchanger.material_factor_cost

--- a/watertap/costing/unit_models/heat_exchanger.py
+++ b/watertap/costing/unit_models/heat_exchanger.py
@@ -42,7 +42,8 @@ def cost_heat_exchanger(blk):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.costing_package.heat_exchanger.unit_cost
             * blk.costing_package.heat_exchanger.material_factor_cost
             * (

--- a/watertap/costing/unit_models/ion_exchange.py
+++ b/watertap/costing/unit_models/ion_exchange.py
@@ -336,9 +336,10 @@ def cost_ion_exchange(blk):
             to_units=blk.costing_package.base_currency,
         )
     )
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             (
                 ((blk.capital_cost_vessel + blk.capital_cost_resin) * tot_num_col)

--- a/watertap/costing/unit_models/ion_exchange.py
+++ b/watertap/costing/unit_models/ion_exchange.py
@@ -197,11 +197,6 @@ def build_ion_exhange_cost_param_block(blk):
         units=pyo.units.dimensionless,
         doc="Number of cycles the regenerant can be reused before disposal",
     )
-    blk.total_installed_cost_factor = pyo.Var(
-        initialize=1.65,
-        units=pyo.units.dimensionless,
-        doc="Costing factor to account for total installed cost of equipment",
-    )
 
 
 @register_costing_parameter_block(
@@ -345,8 +340,7 @@ def cost_ion_exchange(blk):
                 ((blk.capital_cost_vessel + blk.capital_cost_resin) * tot_num_col)
                 + blk.capital_cost_backwash_tank
                 + blk.capital_cost_regen_tank
-            )
-            * ion_exchange_params.total_installed_cost_factor,
+            ),
             to_units=blk.costing_package.base_currency,
         )
     )

--- a/watertap/costing/unit_models/ion_exchange.py
+++ b/watertap/costing/unit_models/ion_exchange.py
@@ -338,7 +338,8 @@ def cost_ion_exchange(blk):
     )
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             (
                 ((blk.capital_cost_vessel + blk.capital_cost_resin) * tot_num_col)
                 + blk.capital_cost_backwash_tank

--- a/watertap/costing/unit_models/mixer.py
+++ b/watertap/costing/unit_models/mixer.py
@@ -153,7 +153,7 @@ def build_caoh2_cost_param_block(blk):
 def build_caoh2_mixer_cost_param_block(blk):
 
     blk.unit_cost = pyo.Var(
-        initialize=792.8 * 2.20462,
+        initialize=792.8 * 2.20462 / 2.0,
         doc="Ca(OH)2 mixer cost",
         units=pyo.units.USD_2018 / (pyo.units.kg / pyo.units.day),
     )
@@ -184,8 +184,7 @@ def cost_caoh2_mixer(blk, dosing_rate):
     )
     cost_by_flow_volume(
         blk,
-        blk.costing_package.caoh2_mixer.unit_cost
-        / blk.costing_package.factor_total_investment,
+        blk.costing_package.caoh2_mixer.unit_cost,
         blk.lime_kg_per_day,
     )
     blk.costing_package.cost_flow(

--- a/watertap/costing/unit_models/pump.py
+++ b/watertap/costing/unit_models/pump.py
@@ -77,7 +77,8 @@ def cost_high_pressure_pump(blk, cost_electricity_flow=True):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.costing_package.high_pressure_pump.cost
             * pyo.units.convert(blk.unit_model.work_mechanical[t0], pyo.units.W),
             to_units=blk.costing_package.base_currency,

--- a/watertap/costing/unit_models/pump.py
+++ b/watertap/costing/unit_models/pump.py
@@ -75,9 +75,10 @@ def cost_high_pressure_pump(blk, cost_electricity_flow=True):
     """
     t0 = blk.flowsheet().time.first()
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.costing_package.high_pressure_pump.cost
             * pyo.units.convert(blk.unit_model.work_mechanical[t0], pyo.units.W),

--- a/watertap/costing/unit_models/thickener.py
+++ b/watertap/costing/unit_models/thickener.py
@@ -44,12 +44,14 @@ def cost_thickener(blk, cost_electricity_flow=True):
     Gravity Sludge Thickener costing method
     """
     make_capital_cost_var(blk)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     cost_blk = blk.costing_package.thickener
     t0 = blk.flowsheet().time.first()
     x = diameter = pyo.units.convert(blk.unit_model.diameter, to_units=pyo.units.feet)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.cost_factor
+        * pyo.units.convert(
             cost_blk.capital_a_parameter * x + cost_blk.capital_b_parameter,
             to_units=blk.costing_package.base_currency,
         )

--- a/watertap/costing/unit_models/uv_aop.py
+++ b/watertap/costing/unit_models/uv_aop.py
@@ -86,10 +86,10 @@ def cost_uv_aop_bundle(blk, reactor_cost, lamp_cost, factor_lamp_replacement):
         blk.unit_model.electricity_demand[0], to_units=pyo.units.kW
     )
 
-    print(f"base_currency: {blk.costing_package.base_currency}")
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.reactor_cost * flow_in + blk.lamp_cost * electricity_demand,
             to_units=blk.costing_package.base_currency,

--- a/watertap/costing/unit_models/uv_aop.py
+++ b/watertap/costing/unit_models/uv_aop.py
@@ -89,7 +89,8 @@ def cost_uv_aop_bundle(blk, reactor_cost, lamp_cost, factor_lamp_replacement):
     print(f"base_currency: {blk.costing_package.base_currency}")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.reactor_cost * flow_in + blk.lamp_cost * electricity_demand,
             to_units=blk.costing_package.base_currency,
         )

--- a/watertap/costing/util.py
+++ b/watertap/costing/util.py
@@ -140,7 +140,8 @@ def cost_membrane(blk, membrane_cost, factor_membrane_replacement):
 
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.membrane_cost * blk.unit_model.area,
             to_units=blk.costing_package.base_currency,
         )
@@ -231,7 +232,8 @@ def cost_by_flow_volume(blk, flow_cost, flow_to_cost):
     blk.flow_cost = pyo.Expression(expr=flow_cost)
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == pyo.units.convert(
+        == blk.costing_package.TIC
+        * pyo.units.convert(
             blk.flow_cost * flow_to_cost, to_units=blk.costing_package.base_currency
         )
     )

--- a/watertap/costing/util.py
+++ b/watertap/costing/util.py
@@ -138,9 +138,10 @@ def cost_membrane(blk, membrane_cost, factor_membrane_replacement):
     blk.membrane_cost = pyo.Expression(expr=membrane_cost)
     blk.factor_membrane_replacement = pyo.Expression(expr=factor_membrane_replacement)
 
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.membrane_cost * blk.unit_model.area,
             to_units=blk.costing_package.base_currency,
@@ -230,9 +231,10 @@ def cost_by_flow_volume(blk, flow_cost, flow_to_cost):
     """
     make_capital_cost_var(blk)
     blk.flow_cost = pyo.Expression(expr=flow_cost)
+    blk.costing_package.add_cost_factor(blk, "TIC")
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.TIC
+        == blk.cost_factor
         * pyo.units.convert(
             blk.flow_cost * flow_to_cost, to_units=blk.costing_package.base_currency
         )

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -36,7 +36,7 @@ class WaterTAPCostingData(WaterTAPCostingBlockData):
         # Build flowsheet level costing components
         # These are the global parameters
         self.factor_total_investment = pyo.Var(
-            initialize=2,
+            initialize=1.0,
             doc="Total investment factor [investment cost/equipment cost]",
             units=pyo.units.dimensionless,
         )

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -115,6 +115,3 @@ class WaterTAPCostingData(WaterTAPCostingBlockData):
         calculate_variable_from_constraint(
             self.total_operating_cost, self.total_operating_cost_constraint
         )
-
-        for var, con in self._registered_LCOWs.values():
-            calculate_variable_from_constraint(var, con)

--- a/watertap/costing/zero_order_costing.py
+++ b/watertap/costing/zero_order_costing.py
@@ -281,9 +281,6 @@ class ZeroOrderCostingData(WaterTAPCostingBlockData):
             self.total_fixed_operating_cost, self.total_fixed_operating_cost_constraint
         )
 
-        for var, con in self._registered_LCOWs.values():
-            calculate_variable_from_constraint(var, con)
-
 
 def _load_case_study_definition(self):
     """

--- a/watertap/examples/flowsheets/full_treatment_train/analysis/flowsheet_softening_two_stage.py
+++ b/watertap/examples/flowsheets/full_treatment_train/analysis/flowsheet_softening_two_stage.py
@@ -17,6 +17,7 @@ mutable parameters for optimization:
 from pyomo.environ import ConcreteModel, TransformationFactory
 
 from idaes.core import FlowsheetBlock
+from idaes.core.solvers import get_solver
 from idaes.core.util.scaling import calculate_scaling_factors
 
 from watertap.examples.flowsheets.full_treatment_train.util import (
@@ -75,7 +76,10 @@ def set_up_optimization(m, system_recovery=0.50, **kwargs):
 
 
 def optimize(m, check_termination=True):
-    return solve_block(m, tee=False, fail_flag=check_termination)
+    s = get_solver()
+    s.options["bound_relax_factor"] = 1e-20
+    s.options["bound_push"] = 1e-20
+    return solve_block(m, solver=s, tee=True, fail_flag=check_termination)
 
 
 def solve_flowsheet(**desal_kwargs):
@@ -95,7 +99,9 @@ def solve_flowsheet(**desal_kwargs):
     initialize(m, **desal_kwargs)
 
     check_dof(m)
-    solve_block(m, tee=False, fail_flag=True)
+    s = get_solver()
+    s.options["bound_relax_factor"] = 1e-20
+    solve_block(m, solver=s, tee=True, fail_flag=True)
 
     # report
     print("===================================" "\n          Simulation          ")

--- a/watertap/examples/flowsheets/ion_exchange/tests/test_ion_exchange_demo.py
+++ b/watertap/examples/flowsheets/ion_exchange/tests/test_ion_exchange_demo.py
@@ -151,7 +151,7 @@ class TestIXDemo:
         assert value(m.fs.costing.specific_energy_consumption) == pytest.approx(
             0.057245, rel=1e-3
         )
-        assert value(m.fs.costing.LCOW) == pytest.approx(0.222437, rel=1e-3)
+        assert value(m.fs.costing.LCOW) == pytest.approx(0.191008, rel=1e-3)
 
     @pytest.mark.component
     def test_optimization(self, ix_0D):
@@ -189,33 +189,33 @@ class TestIXDemo:
         results = solver.solve(m)
         assert_optimal_termination(results)
         assert degrees_of_freedom(m) == 0
-        assert value(m.fs.ion_exchange.number_columns) == 6
-        assert value(m.fs.ion_exchange.bed_depth) == pytest.approx(1.61147, rel=1e-3)
+        assert value(m.fs.ion_exchange.number_columns) == 7
+        assert value(m.fs.ion_exchange.bed_depth) == pytest.approx(1.38976, rel=1e-3)
         assert value(m.fs.ion_exchange.t_breakthru) == pytest.approx(
-            133404.2583, rel=1e-3
+            133134.2829, rel=1e-3
         )
         assert value(m.fs.ion_exchange.dimensionless_time) == pytest.approx(
             1.33210077, rel=1e-3
         )
         assert value(m.fs.costing.specific_energy_consumption) == pytest.approx(
-            0.051706, rel=1e-3
+            0.039173, rel=1e-3
         )
-        assert value(m.fs.costing.LCOW) == pytest.approx(0.145645, rel=1e-3)
+        assert value(m.fs.costing.LCOW) == pytest.approx(0.112747, rel=1e-3)
 
     @pytest.mark.unit
     def test_main_fun(self):
         m = ixf.main()
 
         assert degrees_of_freedom(m) == 0
-        assert value(m.fs.ion_exchange.number_columns) == 6
-        assert value(m.fs.ion_exchange.bed_depth) == pytest.approx(1.61147, rel=1e-3)
+        assert value(m.fs.ion_exchange.number_columns) == 7
+        assert value(m.fs.ion_exchange.bed_depth) == pytest.approx(1.38976, rel=1e-3)
         assert value(m.fs.ion_exchange.t_breakthru) == pytest.approx(
-            133404.2583, rel=1e-3
+            133134.2829, rel=1e-3
         )
         assert value(m.fs.ion_exchange.dimensionless_time) == pytest.approx(
             1.33210077, rel=1e-3
         )
         assert value(m.fs.costing.specific_energy_consumption) == pytest.approx(
-            0.051706, rel=1e-3
+            0.039173, rel=1e-3
         )
-        assert value(m.fs.costing.LCOW) == pytest.approx(0.145645, rel=1e-3)
+        assert value(m.fs.costing.LCOW) == pytest.approx(0.112747, rel=1e-3)

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -291,7 +291,7 @@ def build(
 
     # explicitly set the costing parameters used
     m.fs.costing.utilization_factor.fix(0.9)
-    m.fs.costing.factor_total_investment.fix(2)
+    m.fs.costing.TIC.fix(2)
     m.fs.costing.factor_maintenance_labor_chemical.fix(0.03)
     m.fs.costing.factor_capital_annualization.fix(0.1)
     m.fs.costing.electricity_cost.set_value(0.07)
@@ -401,6 +401,7 @@ def build(
 
     m.fs.costing.pumping_energy_aggregate_lcow = Expression(
         expr=m.fs.costing.factor_total_investment
+        * m.fs.costing.TIC
         * (
             m.fs.costing.primary_pump_capex_lcow
             + (
@@ -442,6 +443,7 @@ def build(
 
     m.fs.costing.membrane_aggregate_lcow = Expression(
         expr=m.fs.costing.factor_total_investment
+        * m.fs.costing.TIC
         * m.fs.costing.membrane_capex_lcow
         * (
             1
@@ -566,11 +568,14 @@ def cost_high_pressure_pump_lsrro(blk, cost_electricity_flow=True):
     make_capital_cost_var(blk)
     blk.capital_cost_constraint = Constraint(
         expr=blk.capital_cost
-        == blk.costing_package.high_pressure_pump.cost
-        * pyunits.watt
-        / (pyunits.m**3 * pyunits.pascal / pyunits.s)
-        * blk.unit_model.outlet.pressure[t0]
-        * blk.unit_model.control_volume.properties_out[t0].flow_vol
+        == blk.costing_package.TIC
+        * (
+            blk.costing_package.high_pressure_pump.cost
+            * pyunits.watt
+            / (pyunits.m**3 * pyunits.pascal / pyunits.s)
+            * blk.unit_model.outlet.pressure[t0]
+            * blk.unit_model.control_volume.properties_out[t0].flow_vol
+        )
     )
 
     if cost_electricity_flow:

--- a/watertap/examples/flowsheets/lsrro/tests/test_lssro_paper_analysis.py
+++ b/watertap/examples/flowsheets/lsrro/tests/test_lssro_paper_analysis.py
@@ -86,18 +86,21 @@ def test_against_paper_analysis(csv_file, row_index):
         for property_name, (converter, argument) in _input_headers.items()
     }
     number_of_stages = input_arguments["number_of_stages"]
-    model, results = run_lsrro_case(
-        **input_arguments,
-        has_NaCl_solubility_limit=True,
-        permeate_quality_limit=1000e-6,
-        has_calculated_concentration_polarization=True,
-        has_calculated_ro_pressure_drop=True,
-        A_value=5 / 3.6e11,
-        B_max=None,
-        number_of_RO_finite_elements=10
-    )
+    try:
+        model, results = run_lsrro_case(
+            **input_arguments,
+            has_NaCl_solubility_limit=True,
+            permeate_quality_limit=1000e-6,
+            has_calculated_concentration_polarization=True,
+            has_calculated_ro_pressure_drop=True,
+            A_value=5 / 3.6e11,
+            B_max=None,
+            number_of_RO_finite_elements=10
+        )
+    except ValueError:
+        results = None
 
-    if check_optimal_termination(results):
+    if results is not None and check_optimal_termination(results):
         for property_name, flowsheet_attribute in _results_headers.items():
             assert value(model.find_component(flowsheet_attribute)) == pytest.approx(
                 float(row[property_name]),

--- a/watertap/examples/flowsheets/mvc/mvc_single_stage.py
+++ b/watertap/examples/flowsheets/mvc/mvc_single_stage.py
@@ -407,7 +407,7 @@ def set_operating_conditions(m):
     m.fs.tb_distillate.properties_out[0].flow_mass_phase_comp["Liq", "TDS"].fix(1e-5)
 
     # Costing
-    m.fs.costing.factor_total_investment.fix(2)
+    m.fs.costing.TIC.fix(2)
     m.fs.costing.electricity_cost = 0.1  # 0.15
     m.fs.costing.heat_exchanger.material_factor_cost.fix(5)
     m.fs.costing.evaporator.material_factor_cost.fix(5)

--- a/watertap/examples/flowsheets/mvc/tests/test_mvc_single_stage.py
+++ b/watertap/examples/flowsheets/mvc/tests/test_mvc_single_stage.py
@@ -229,8 +229,8 @@ class TestMVC:
         )
 
         # Costing
-        assert m.fs.costing.factor_total_investment.is_fixed()
-        assert value(m.fs.costing.factor_total_investment) == 2
+        assert m.fs.costing.TIC.is_fixed()
+        assert value(m.fs.costing.TIC) == 2
         assert m.fs.costing.heat_exchanger.material_factor_cost.is_fixed()
         assert value(m.fs.costing.heat_exchanger.material_factor_cost) == 5
         assert m.fs.costing.evaporator.material_factor_cost.is_fixed()

--- a/watertap/examples/flowsheets/nf_dspmde/nf.py
+++ b/watertap/examples/flowsheets/nf_dspmde/nf.py
@@ -17,6 +17,7 @@ from pyomo.environ import (
     Constraint,
     NonNegativeReals,
     assert_optimal_termination,
+    value,
 )
 
 
@@ -65,7 +66,7 @@ def main():
     unfix_opt_vars(m)
     results = optimize(m, solver)
     assert_optimal_termination(results)
-    print("Optimal cost", m.fs.costing.LCOW.value)
+    print("Optimal cost", value(m.fs.costing.LCOW))
     print("Optimal NF pressure (Bar)", m.fs.NF.pump.outlet.pressure[0].value / 1e5)
     print("Optimal area (m2)", m.fs.NF.nfUnit.area.value)
     print(

--- a/watertap/examples/flowsheets/nf_dspmde/nf_with_bypass.py
+++ b/watertap/examples/flowsheets/nf_dspmde/nf_with_bypass.py
@@ -19,6 +19,7 @@ from pyomo.environ import (
     units as pyunits,
     Var,
     assert_optimal_termination,
+    value,
 )
 
 import idaes.core.util.scaling as iscale
@@ -53,7 +54,7 @@ def main():
     nf.add_objective(m)
     results = optimize(m, solver)
     assert_optimal_termination(results)
-    print("Optimal cost", m.fs.costing.LCOW.value)
+    print("Optimal cost", value(m.fs.costing.LCOW))
     print("Optimal NF pressure (Bar)", m.fs.NF.pump.outlet.pressure[0].value / 1e5)
     print("Optimal area (m2)", m.fs.NF.nfUnit.area.value)
     print(

--- a/watertap/examples/flowsheets/nf_dspmde/tests/test_nf.py
+++ b/watertap/examples/flowsheets/nf_dspmde/tests/test_nf.py
@@ -15,7 +15,6 @@ from pyomo.environ import value
 from watertap.examples.flowsheets.nf_dspmde.nf import main
 
 
-@pytest.mark.requires_idaes_solver
 @pytest.mark.component
 def test_main():
     m = main()

--- a/watertap/examples/flowsheets/nf_dspmde/tests/test_nf_with_bypass.py
+++ b/watertap/examples/flowsheets/nf_dspmde/tests/test_nf_with_bypass.py
@@ -14,7 +14,6 @@ from pyomo.environ import value
 from watertap.examples.flowsheets.nf_dspmde.nf_with_bypass import main
 
 
-@pytest.mark.requires_idaes_solver
 @pytest.mark.component
 def test_main():
     m = main()

--- a/watertap/examples/flowsheets/oaro/oaro_multi.py
+++ b/watertap/examples/flowsheets/oaro/oaro_multi.py
@@ -243,7 +243,7 @@ def build(number_of_stages, erd_type=ERDtype.pump_as_turbine):
 
     # process costing and add system level metrics
     m.fs.costing.utilization_factor.fix(0.9)
-    m.fs.costing.factor_total_investment.fix(2)
+    m.fs.costing.TIC.fix(2)
     m.fs.costing.factor_maintenance_labor_chemical.fix(0.03)
     m.fs.costing.factor_capital_annualization.fix(0.1)
     m.fs.costing.electricity_cost.set_value(0.07)

--- a/watertap/examples/flowsheets/oaro/tests/test_oaro_multi.py
+++ b/watertap/examples/flowsheets/oaro/tests/test_oaro_multi.py
@@ -80,7 +80,7 @@ class TestOAROwithTurbine:
         m = system_frame
         solve(m, solver=solver)
         fs = m.fs
-        assert pytest.approx(3.98455e-3, rel=1e-5) == value(
+        assert pytest.approx(3.98306e-3, rel=1e-5) == value(
             fs.product.flow_mass_phase_comp[0, "Liq", "NaCl"]
         )
         assert pytest.approx(0.2888, rel=1e-5) == value(fs.water_recovery)

--- a/watertap/examples/flowsheets/oaro/tests/test_oaro_multi.py
+++ b/watertap/examples/flowsheets/oaro/tests/test_oaro_multi.py
@@ -26,6 +26,7 @@ from watertap.examples.flowsheets.oaro.oaro_multi import (
     build,
     set_operating_conditions,
     initialize_system,
+    optimize_set_up,
     solve,
     ERDtype,
 )
@@ -78,12 +79,12 @@ class TestOAROwithTurbine:
     @pytest.mark.component
     def test_solution(self, system_frame):
         m = system_frame
+        optimize_set_up(m, number_of_stages=3, water_recovery=0.5)
         solve(m, solver=solver)
-        fs = m.fs
-        assert pytest.approx(3.98306e-3, rel=1e-5) == value(
-            fs.product.flow_mass_phase_comp[0, "Liq", "NaCl"]
+        assert pytest.approx(1.318023e-3, rel=1e-5) == value(
+            m.fs.product.flow_mass_phase_comp[0, "Liq", "NaCl"]
         )
-        assert pytest.approx(0.2888, rel=1e-5) == value(fs.water_recovery)
+        assert pytest.approx(0.5, rel=1e-5) == value(m.fs.mass_water_recovery)
 
     @pytest.mark.component
     def test_config_error(self, system_frame):

--- a/watertap/unit_models/tests/test_anaerobic_digestor.py
+++ b/watertap/unit_models/tests/test_anaerobic_digestor.py
@@ -410,7 +410,7 @@ class TestAdm(object):
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(1083290.8, rel=1e-5) == value(
+        assert pytest.approx(2.0 * 1083290.8, rel=1e-5) == value(
             m.fs.unit.costing.capital_cost
         )
         assert pytest.approx(5.2754, rel=1e-5) == value(m.fs.costing.LCOW)

--- a/watertap/unit_models/tests/test_clarifier.py
+++ b/watertap/unit_models/tests/test_clarifier.py
@@ -137,7 +137,9 @@ class TestClarifierCosting:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(1681573, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(1681573 * 2, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -158,7 +160,9 @@ class TestClarifierCosting:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(2131584, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(2131584 * 2, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -178,4 +182,6 @@ class TestClarifierCosting:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(1390570, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(1390570 * 2, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )

--- a/watertap/unit_models/tests/test_crystallizer.py
+++ b/watertap/unit_models/tests/test_crystallizer.py
@@ -454,7 +454,7 @@ class TestCrystallization:
         # Residence time
         assert pytest.approx(1.0228, rel=1e-3) == value(b.t_res)
         # Mass-basis costing
-        assert pytest.approx(300000, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 300000, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
 
@@ -485,7 +485,7 @@ class TestCrystallization:
         # Minimum active volume
         assert pytest.approx(0.959, rel=1e-3) == value(b.volume_suspension)
         # Mass-basis costing
-        assert pytest.approx(300000, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 300000, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
 
@@ -543,7 +543,7 @@ class TestCrystallization:
         # Minimum active volume
         assert pytest.approx(0.959, rel=1e-3) == value(b.volume_suspension)
         # Volume-basis costing
-        assert pytest.approx(199000, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 199000, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
 

--- a/watertap/unit_models/tests/test_cstr.py
+++ b/watertap/unit_models/tests/test_cstr.py
@@ -22,6 +22,7 @@ from pyomo.environ import (
     ConcreteModel,
     units,
     value,
+    Objective,
 )
 from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 
@@ -456,8 +457,10 @@ class TestInitializers:
         m.fs.unit.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         m.fs.costing.cost_process()
         m.fs.costing.add_LCOW(m.fs.unit.control_volume.properties_out[0].flow_vol)
+        m.fs.costing.initialize()
+        m.objective = Objective(expr=m.fs.costing.LCOW)
         assert_units_consistent(m)
-        results = solver.solve(m)
+        results = solver.solve(m, tee=True)
 
         assert_optimal_termination(results)
 
@@ -465,7 +468,7 @@ class TestInitializers:
         assert pytest.approx(526.45 * 2, rel=1e-5) == value(
             m.fs.unit.costing.capital_cost
         )
-        assert pytest.approx(1.07948e-5, rel=1e-5) == value(m.fs.costing.LCOW)
+        assert pytest.approx(8.94365e-07, rel=1e-5) == value(m.fs.costing.LCOW)
 
     @pytest.mark.unit
     def test_report(self, model):

--- a/watertap/unit_models/tests/test_cstr.py
+++ b/watertap/unit_models/tests/test_cstr.py
@@ -462,7 +462,9 @@ class TestInitializers:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(526.45, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(526.45 * 2, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
         assert pytest.approx(1.07948e-5, rel=1e-5) == value(m.fs.costing.LCOW)
 
     @pytest.mark.unit

--- a/watertap/unit_models/tests/test_cstr_injection.py
+++ b/watertap/unit_models/tests/test_cstr_injection.py
@@ -281,7 +281,9 @@ class TestSaponification(object):
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(7.75429, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(7.75429 * 2, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
         assert pytest.approx(0.00082698, rel=1e-5) == value(m.fs.costing.LCOW)
 
     @pytest.mark.unit

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -492,7 +492,9 @@ def test_du_default_costing():
     assert pytest.approx(1964.42, rel=1e-5) == value(
         pyunits.convert(m.fs.unit.inlet.flow_vol[0], to_units=pyunits.gal / pyunits.hr)
     )
-    assert pytest.approx(1602087.9, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+    assert pytest.approx(1602087.9 * 2, rel=1e-5) == value(
+        m.fs.unit.costing.capital_cost
+    )
     assert pytest.approx(1602087.9, rel=1e-5) == value(
         pyunits.convert(
             (328.03 * 1964.42 + 751295) * pyunits.USD_2007,
@@ -553,7 +555,9 @@ def test_du_centrifuge_costing():
     assert value(m.fs.costing.centrifuge.capital_b_parameter) == 751295
 
     # Check solutions
-    assert pytest.approx(1602087.9, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+    assert pytest.approx(1602087.9 * 2, rel=1e-5) == value(
+        m.fs.unit.costing.capital_cost
+    )
     assert pytest.approx(1602087.9, rel=1e-5) == value(
         pyunits.convert(
             (328.03 * 1964.42 + 751295) * pyunits.USD_2007,
@@ -621,7 +625,9 @@ def test_du_centrifuge_costing2():
     assert "electricity" not in m.fs.costing.aggregate_flow_costs.keys()
 
     # Check solutions
-    assert pytest.approx(1602087.9, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+    assert pytest.approx(1602087.9 * 2, rel=1e-5) == value(
+        m.fs.unit.costing.capital_cost
+    )
     assert pytest.approx(1602087.9, rel=1e-5) == value(
         pyunits.convert(
             (328.03 * 1964.42 + 751295) * pyunits.USD_2007,
@@ -686,7 +692,9 @@ def test_du_filter_plate_press_costing():
     assert value(m.fs.costing.filter_plate_press.capital_b_parameter) == 0.4216
 
     # Check solutions
-    assert pytest.approx(2885989.2, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+    assert pytest.approx(2885989.2 * 2, rel=1e-5) == value(
+        m.fs.unit.costing.capital_cost
+    )
     assert pytest.approx(2885989.2, rel=1e-5) == value(
         pyunits.convert(
             (102794 * 1964.42**0.4216) * pyunits.USD_2007,
@@ -754,7 +762,9 @@ def test_du_filter_belt_press_costing():
     assert value(m.fs.costing.filter_belt_press.capital_b_parameter) == 433972
 
     # Check solutions
-    assert pytest.approx(828025.2, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+    assert pytest.approx(828025.2 * 2, rel=1e-5) == value(
+        m.fs.unit.costing.capital_cost
+    )
     assert pytest.approx(828025.2, rel=1e-5) == value(
         pyunits.convert(
             (146.29 * 1964.42 + 433972) * pyunits.USD_2007,

--- a/watertap/unit_models/tests/test_electroNP_ZO.py
+++ b/watertap/unit_models/tests/test_electroNP_ZO.py
@@ -280,7 +280,7 @@ class TestElectroNP:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(1036611.9, rel=1e-5) == value(
+        assert pytest.approx(2.0 * 1036611.9, rel=1e-5) == value(
             m.fs.unit.costing.capital_cost
         )
         assert pytest.approx(0.04431857, rel=1e-5) == value(m.fs.costing.LCOW)

--- a/watertap/unit_models/tests/test_electrodialysis_0D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_0D.py
@@ -281,7 +281,7 @@ class TestElectrodialysisVoltageConst:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(584.6, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 584.6, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(153.6471, rel=1e-3) == value(

--- a/watertap/unit_models/tests/test_electrodialysis_1D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_1D.py
@@ -292,7 +292,7 @@ class TestElectrodialysisVoltageConst:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(584.6, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 584.6, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(153.6471, rel=1e-3) == value(
@@ -323,7 +323,7 @@ class TestElectrodialysisVoltageConst:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(2979.6988, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 2979.6988, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(297.5365, rel=1e-3) == value(

--- a/watertap/unit_models/tests/test_electrolyzer.py
+++ b/watertap/unit_models/tests/test_electrolyzer.py
@@ -317,7 +317,7 @@ class TestElectrolyzer:
         assert pyo.check_optimal_termination(results)
 
         # check solution values
-        assert pytest.approx(17930, rel=1e-3) == pyo.value(
+        assert pytest.approx(2.0 * 17930, rel=1e-3) == pyo.value(
             m.fs.unit.costing.capital_cost
         )
         assert pytest.approx(82.50, rel=1e-3) == pyo.value(

--- a/watertap/unit_models/tests/test_gac.py
+++ b/watertap/unit_models/tests/test_gac.py
@@ -407,7 +407,7 @@ class TestGACRobust:
         assert pytest.approx(4.359, rel=1e-3) == pyo.value(cost.adsorbent_unit_cost)
         assert pytest.approx(17450, rel=1e-3) == pyo.value(cost.adsorbent_cost)
         assert pytest.approx(81690, rel=1e-3) == pyo.value(cost.other_process_cost)
-        assert pytest.approx(156000, rel=1e-3) == pyo.value(cost.capital_cost)
+        assert pytest.approx(2.0 * 156000, rel=1e-3) == pyo.value(cost.capital_cost)
         assert pytest.approx(12680, rel=1e-3) == pyo.value(cost.gac_makeup_cost)
         assert pytest.approx(27660, rel=1e-3) == pyo.value(cost.gac_regen_cost)
         assert pytest.approx(0.01631, rel=1e-3) == pyo.value(cost.energy_consumption)
@@ -445,7 +445,7 @@ class TestGACRobust:
         assert pytest.approx(4.359, rel=1e-3) == pyo.value(cost.adsorbent_unit_cost)
         assert pytest.approx(17450, rel=1e-3) == pyo.value(cost.adsorbent_cost)
         assert pytest.approx(159500, rel=1e-3) == pyo.value(cost.other_process_cost)
-        assert pytest.approx(340200, rel=1e-3) == pyo.value(cost.capital_cost)
+        assert pytest.approx(2.0 * 340200, rel=1e-3) == pyo.value(cost.capital_cost)
         assert pytest.approx(12680, rel=1e-3) == pyo.value(cost.gac_makeup_cost)
         assert pytest.approx(27660, rel=1e-3) == pyo.value(cost.gac_regen_cost)
         assert pytest.approx(2.476, rel=1e-3) == pyo.value(cost.energy_consumption)
@@ -474,7 +474,7 @@ class TestGACRobust:
         assert pyo.value(mr.fs.costing.gac_pressure.num_contactors_redundant) == 2
         assert pytest.approx(89040, rel=1e-3) == pyo.value(cost.contactor_cost)
         assert pytest.approx(69690, rel=1e-3) == pyo.value(cost.other_process_cost)
-        assert pytest.approx(176200, rel=1e-3) == pyo.value(cost.capital_cost)
+        assert pytest.approx(2.0 * 176200, rel=1e-3) == pyo.value(cost.capital_cost)
 
     @pytest.mark.component
     def test_robust_costing_max_gac_ref(self, gac_frame_robust):

--- a/watertap/unit_models/tests/test_ion_exchange_0D.py
+++ b/watertap/unit_models/tests/test_ion_exchange_0D.py
@@ -307,16 +307,16 @@ class TestIonExchangeLangmuir:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(2.0 * 8894349.86900, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 8894349.86900 / 1.65, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
-        assert pytest.approx(2498819.7327, rel=1e-3) == value(
+        assert pytest.approx(2288575.0472, rel=1e-3) == value(
             m.fs.costing.total_operating_cost
         )
-        assert pytest.approx(17788699.7380, rel=1e-3) == value(
+        assert pytest.approx(17788699.7380 / 1.65, rel=1e-3) == value(
             m.fs.costing.total_capital_cost
         )
-        assert pytest.approx(0.30125629, rel=1e-3) == value(m.fs.costing.LCOW)
+        assert pytest.approx(0.2370983, rel=1e-3) == value(m.fs.costing.LCOW)
         assert pytest.approx(0.0572452, rel=1e-3) == value(
             m.fs.costing.specific_energy_consumption
         )
@@ -611,16 +611,16 @@ class TestIonExchangeFreundlich:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(2.0 * 9701947.4187, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 9701947.4187 / 1.65, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
-        assert pytest.approx(1448862.0602, rel=1e-3) == value(
+        assert pytest.approx(1219532.1263, rel=1e-3) == value(
             m.fs.costing.total_operating_cost
         )
-        assert pytest.approx(19403894.837, rel=1e-3) == value(
+        assert pytest.approx(19403894.837 / 1.65, rel=1e-3) == value(
             m.fs.costing.total_capital_cost
         )
-        assert pytest.approx(0.238664, rel=1e-3) == value(m.fs.costing.LCOW)
+        assert pytest.approx(0.168688, rel=1e-3) == value(m.fs.costing.LCOW)
         assert pytest.approx(0.04382530, rel=1e-3) == value(
             m.fs.costing.specific_energy_consumption
         )
@@ -910,16 +910,16 @@ class TestIonExchangeInert:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(2.0 * 9701947.4187, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 9701947.4187 / 1.65, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
-        assert pytest.approx(695243.5958, rel=1e-3) == value(
+        assert pytest.approx(465913.6619, rel=1e-3) == value(
             m.fs.costing.total_operating_cost
         )
-        assert pytest.approx(19403894.837, rel=1e-3) == value(
+        assert pytest.approx(19403894.837 / 1.65, rel=1e-3) == value(
             m.fs.costing.total_capital_cost
         )
-        assert pytest.approx(0.18559, rel=1e-3) == value(m.fs.costing.LCOW)
+        assert pytest.approx(0.115619, rel=1e-3) == value(m.fs.costing.LCOW)
         assert pytest.approx(0.04382530, rel=1e-3) == value(
             m.fs.costing.specific_energy_consumption
         )

--- a/watertap/unit_models/tests/test_ion_exchange_0D.py
+++ b/watertap/unit_models/tests/test_ion_exchange_0D.py
@@ -307,7 +307,7 @@ class TestIonExchangeLangmuir:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(8894349.86900, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 8894349.86900, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(2498819.7327, rel=1e-3) == value(
@@ -611,7 +611,7 @@ class TestIonExchangeFreundlich:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(9701947.4187, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 9701947.4187, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(1448862.0602, rel=1e-3) == value(
@@ -910,7 +910,7 @@ class TestIonExchangeInert:
         results = solver.solve(m, tee=True)
         assert_optimal_termination(results)
 
-        assert pytest.approx(9701947.4187, rel=1e-3) == value(
+        assert pytest.approx(2.0 * 9701947.4187, rel=1e-3) == value(
             m.fs.costing.aggregate_capital_cost
         )
         assert pytest.approx(695243.5958, rel=1e-3) == value(

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -773,7 +773,9 @@ def test_costing():
     assert value(m.fs.costing.thickener.capital_b_parameter) == 37068
 
     # Check solutions
-    assert pytest.approx(220675.79, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+    assert pytest.approx(220675.79 * 2, rel=1e-5) == value(
+        m.fs.unit.costing.capital_cost
+    )
     assert pytest.approx(220675.79, rel=1e-5) == value(
         units.convert(
             (4729.8 * value(units.convert(10 * units.m, to_units=units.feet)) + 37068)

--- a/watertap/unit_models/tests/test_uv_aop.py
+++ b/watertap/unit_models/tests/test_uv_aop.py
@@ -252,7 +252,9 @@ class TestUV:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(1041639, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(2.0 * 1041639, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
         assert pytest.approx(53286.2, rel=1e-5) == value(
             m.fs.unit.costing.fixed_operating_cost
         )
@@ -468,7 +470,9 @@ class TestUV_standard:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(820692, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(2.0 * 820692, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
         assert pytest.approx(23525, rel=1e-5) == value(
             m.fs.unit.costing.fixed_operating_cost
         )
@@ -709,7 +713,9 @@ class TestUV_with_multiple_comps:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(1767152, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(2.0 * 1767152, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
         assert pytest.approx(90400.7, rel=1e-5) == value(
             m.fs.unit.costing.fixed_operating_cost
         )
@@ -936,7 +942,9 @@ class TestUV_detailed:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(865726, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(2.0 * 865726, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
         assert pytest.approx(38511.4, rel=1e-5) == value(
             m.fs.unit.costing.fixed_operating_cost
         )
@@ -1158,7 +1166,9 @@ class TestUVAOP:
         assert_optimal_termination(results)
 
         # Check solutions
-        assert pytest.approx(1076448, rel=1e-5) == value(m.fs.unit.costing.capital_cost)
+        assert pytest.approx(2.0 * 1076448, rel=1e-5) == value(
+            m.fs.unit.costing.capital_cost
+        )
         assert pytest.approx(64870.2, rel=1e-5) == value(
             m.fs.unit.costing.fixed_operating_cost
         )

--- a/watertap/unit_models/zero_order/CANDOP_zo.py
+++ b/watertap/unit_models/zero_order/CANDOP_zo.py
@@ -139,7 +139,7 @@ class CANDOPData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/anaerobic_mbr_mec_zo.py
+++ b/watertap/unit_models/zero_order/anaerobic_mbr_mec_zo.py
@@ -85,7 +85,7 @@ class AnaerobicMBRMECZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/autothermal_hydrothermal_liquefaction_zo.py
+++ b/watertap/unit_models/zero_order/autothermal_hydrothermal_liquefaction_zo.py
@@ -244,7 +244,7 @@ class ATHTLZOData(ZeroOrderBaseData):
 
         expr = reactor_cost + pump_cost + other_cost + solid_filter_cost + heat_cost
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/brine_concentrator_zo.py
+++ b/watertap/unit_models/zero_order/brine_concentrator_zo.py
@@ -181,7 +181,7 @@ class BrineConcentratorZOData(ZeroOrderBaseData):
             )
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/centrifuge_zo.py
+++ b/watertap/unit_models/zero_order/centrifuge_zo.py
@@ -101,7 +101,7 @@ class CentrifugeZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/chlorination_zo.py
+++ b/watertap/unit_models/zero_order/chlorination_zo.py
@@ -147,7 +147,7 @@ class ChlorinationZOData(ZeroOrderBaseData):
             to_units=blk.config.flowsheet_costing_block.base_currency,
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/clarifier_zo.py
+++ b/watertap/unit_models/zero_order/clarifier_zo.py
@@ -131,7 +131,7 @@ class ClarifierZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/cloth_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/cloth_media_filtration_zo.py
@@ -79,7 +79,7 @@ class ClothMediaFiltrationData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/coag_and_floc_zo.py
+++ b/watertap/unit_models/zero_order/coag_and_floc_zo.py
@@ -363,7 +363,7 @@ class CoagulationFlocculationZOData(ZeroOrderBaseData):
             )
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/cofermentation_zo.py
+++ b/watertap/unit_models/zero_order/cofermentation_zo.py
@@ -87,7 +87,7 @@ class CofermentationZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/constructed_wetlands_zo.py
+++ b/watertap/unit_models/zero_order/constructed_wetlands_zo.py
@@ -71,7 +71,7 @@ class ConstructedWetlandsZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/dmbr_zo.py
+++ b/watertap/unit_models/zero_order/dmbr_zo.py
@@ -78,7 +78,7 @@ class DMBRZOOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/electrochemical_nutrient_removal_zo.py
+++ b/watertap/unit_models/zero_order/electrochemical_nutrient_removal_zo.py
@@ -147,7 +147,7 @@ class ElectroNPZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/electrocoagulation_zo.py
+++ b/watertap/unit_models/zero_order/electrocoagulation_zo.py
@@ -598,7 +598,9 @@ class ElectrocoagulationZOData(ZeroOrderBaseData):
             )
         )
 
-        ec._add_cost_factor(blk, parameter_dict["capital_cost"]["cost_factor"])
+        blk.costing_package.add_cost_factor(
+            blk, parameter_dict["capital_cost"]["cost_factor"]
+        )
 
         blk.capital_cost_constraint = Constraint(
             expr=blk.capital_cost

--- a/watertap/unit_models/zero_order/gac_zo.py
+++ b/watertap/unit_models/zero_order/gac_zo.py
@@ -237,7 +237,7 @@ class GACZOData(ZeroOrderBaseData):
 
         expr = contactor_cost + adsorbent_cost + other_process_cost
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/hrcs_zo.py
+++ b/watertap/unit_models/zero_order/hrcs_zo.py
@@ -75,7 +75,7 @@ class HRCSZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/hydrothermal_gasification_zo.py
+++ b/watertap/unit_models/zero_order/hydrothermal_gasification_zo.py
@@ -293,7 +293,7 @@ class HTGZOData(ZeroOrderBaseData):
             + heater_cost
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
         blk.capital_cost_constraint = pyo.Constraint(

--- a/watertap/unit_models/zero_order/ion_exchange_zo.py
+++ b/watertap/unit_models/zero_order/ion_exchange_zo.py
@@ -196,7 +196,7 @@ class IonExchangeZOData(ZeroOrderBaseData):
                 to_units=blk.config.flowsheet_costing_block.base_currency,
             )
 
-            blk.unit_model._add_cost_factor(
+            blk.costing_package.add_cost_factor(
                 blk, parameter_dict["capital_cost"]["cost_factor"]
             )
 
@@ -244,7 +244,7 @@ class IonExchangeZOData(ZeroOrderBaseData):
             )
 
             # Determine if a costing factor is required
-            blk.unit_model._add_cost_factor(
+            blk.costing_package.add_cost_factor(
                 blk, parameter_dict["capital_cost"]["cost_factor"]
             )
 

--- a/watertap/unit_models/zero_order/mabr_zo.py
+++ b/watertap/unit_models/zero_order/mabr_zo.py
@@ -171,7 +171,7 @@ class MABRZOData(ZeroOrderBaseData):
 
         expr = DCC_reactor + DCC_blower
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/magprex_zo.py
+++ b/watertap/unit_models/zero_order/magprex_zo.py
@@ -111,7 +111,7 @@ class MagprexZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/membrane_evaporator_zo.py
+++ b/watertap/unit_models/zero_order/membrane_evaporator_zo.py
@@ -101,7 +101,7 @@ class MembraneEvaporatorData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/metab_zo.py
+++ b/watertap/unit_models/zero_order/metab_zo.py
@@ -264,7 +264,7 @@ class MetabZOData(ZeroOrderBaseData):
             + blk.DCC_vacuum
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/microbial_battery_zo.py
+++ b/watertap/unit_models/zero_order/microbial_battery_zo.py
@@ -104,7 +104,7 @@ class MicrobialBatteryData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/nanofiltration_zo.py
@@ -170,7 +170,7 @@ class NanofiltrationZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/ozone_zo.py
+++ b/watertap/unit_models/zero_order/ozone_zo.py
@@ -173,7 +173,7 @@ class OzoneZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/peracetic_acid_disinfection_zo.py
+++ b/watertap/unit_models/zero_order/peracetic_acid_disinfection_zo.py
@@ -211,7 +211,7 @@ class PeraceticAcidDisinfectionData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/photothermal_membrane_zo.py
+++ b/watertap/unit_models/zero_order/photothermal_membrane_zo.py
@@ -100,7 +100,7 @@ class PhotothermalMembraneData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/pump_electricity_zo.py
+++ b/watertap/unit_models/zero_order/pump_electricity_zo.py
@@ -127,7 +127,7 @@ class PumpElectricityZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/sedimentation_zo.py
+++ b/watertap/unit_models/zero_order/sedimentation_zo.py
@@ -216,7 +216,7 @@ class SedimentationZOData(ZeroOrderBaseData):
             )
 
             # Determine if a costing factor is required
-            blk.unit_model._add_cost_factor(
+            blk.costing_package.add_cost_factor(
                 blk, parameter_dict["capital_cost"]["cost_factor"]
             )
 

--- a/watertap/unit_models/zero_order/struvite_classifier_zo.py
+++ b/watertap/unit_models/zero_order/struvite_classifier_zo.py
@@ -75,7 +75,7 @@ class StruviteClassifierZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/suboxic_activated_sludge_process_zo.py
+++ b/watertap/unit_models/zero_order/suboxic_activated_sludge_process_zo.py
@@ -95,7 +95,7 @@ class SuboxicASMZOData(ZeroOrderBaseData):
 
         expr = aeration_basin_cost + other_equipment_cost + control_system_cost
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/supercritical_salt_precipitation_zo.py
+++ b/watertap/unit_models/zero_order/supercritical_salt_precipitation_zo.py
@@ -132,7 +132,7 @@ class SaltPrecipitationZOData(ZeroOrderBaseData):
             to_units=blk.config.flowsheet_costing_block.base_currency,
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/surface_discharge_zo.py
+++ b/watertap/unit_models/zero_order/surface_discharge_zo.py
@@ -109,7 +109,7 @@ class SurfaceDischargeData(ZeroOrderBaseData):
             to_units=blk.config.flowsheet_costing_block.base_currency,
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/uv_aop_zo.py
+++ b/watertap/unit_models/zero_order/uv_aop_zo.py
@@ -97,7 +97,7 @@ class UVAOPZOData(UVZOData, AOPAdditionMixin):
         expr += blk.unit_model._get_aop_capital_cost(blk, C, D)
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/uv_zo.py
+++ b/watertap/unit_models/zero_order/uv_zo.py
@@ -98,7 +98,7 @@ class UVZOData(ZeroOrderBaseData):
         expr = blk.unit_model._get_uv_capital_cost(blk, A, B)
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/vfa_recovery_zo.py
+++ b/watertap/unit_models/zero_order/vfa_recovery_zo.py
@@ -110,7 +110,7 @@ class VFARecoveryZOData(ZeroOrderBaseData):
         )
 
         # Determine if a costing factor is required
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 

--- a/watertap/unit_models/zero_order/well_field_zo.py
+++ b/watertap/unit_models/zero_order/well_field_zo.py
@@ -104,7 +104,7 @@ class WellFieldZOData(ZeroOrderBaseData):
             to_units=blk.config.flowsheet_costing_block.base_currency,
         )
 
-        blk.unit_model._add_cost_factor(
+        blk.costing_package.add_cost_factor(
             blk, parameter_dict["capital_cost"]["cost_factor"]
         )
 


### PR DESCRIPTION
## Fixes/Resolves: Part 1 of 3 for #1134 

## Summary/Motivation:
The two costing packages have different ways of accounting for indirect capital costs. The ZO Costing Package allows the indirect capital cost to be specified per unit model. The WT Costing Package has a global-level indirect capital cost.

This PR would resolve the conflict in favor of the ZO costing package. This requires modifying WaterTAP's existing detailed model's costing methods, and a few related changes to our detailed flowsheets.

## Changes proposed in this PR:
- Move `TIC` / `TPEC` factor calculation to the costing base class
- Add `TIC` factor to all unit models which do not already have a factor
- Specify a default o `2` for `TIC` when used in the WT Costing Package
- Make `factor_total_investment` have a default value of `1` in the WT Costing Package
- Various changes to detailed flowsheets to reproduce existing results.
- Set automatic scaling factors on unit model costing aggregates to resolve some resulting detailed flowsheet instability (in particular, NF and LSRRO).

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
