### PR TITLE
Allow the parameter sweep to accept pre-sampled values

### DIFF
--- a/docs/how_to_guides/how_to_use_parameter_sweep_monte_carlo.rst
+++ b/docs/how_to_guides/how_to_use_parameter_sweep_monte_carlo.rst
@@ -42,9 +42,11 @@ The parameter sweep tool currently offers 6 classes that can be broadly categori
     * ``LinearSample``: Draw samples that are evenly spaced within a specified interval.
     * ``GeomSample``: Draw samples that are evenly spaced within a specified interval on a negative log scale.
     * ``ReverseGeomSample``: Draw samples that are evenly spaced within a specified interval on a log scale
+    * ``PredeterminedFixedSample``: Samples are predetermined by an external tool. This class wrangles data into a format compatible with parameter sweep that uses fixed sampling.
 #. ``RANDOM``: Final result is an array that combines individual variable vectors into a matrix. **The individual sweep variable vectors must be of the same length**.
     * ``UniformSample``: Draw samples uniformly from a given upper and lower range.
     * ``NormalSample``: Draw samples from a normal distribution given a mean and standard deviation.
+    * ``PredeterminedRandomSample``: Samples are predetermined by an external tool. This class wrangles data into a format compatible with parameter sweep that uses random sampling.
 #. ``RANDOM_LHS``: Final result is similar to the ``RANDOM`` category.
     * ``LatinHypercubeSample``: Draw samples using a Latin Hypercube algorithm which may yield a more complete exploration of high-dimensional parameter spaces. Note that currently this sample type may not be combined with other sampling types.
 

--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -455,7 +455,7 @@ class _ParameterSweepBase(ABC):
         sampling_type = None
 
         # Check the list of parameters to make sure they are valid
-        for k in sweep_params:
+        for k in sweep_params.keys():
             # Convert to using Sample class
             if isinstance(sweep_params[k], (list, tuple)):
                 sweep_params[k] = LinearSample(*sweep_params[k])

--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -348,38 +348,6 @@ class _ParameterSweepBase(ABC):
         return global_combo_array
 
     """
-    Create an empty buffer of the right size to hold the global array of combinations.
-    """
-
-    def _create_empty_global_combo_array(self, d, sampling_type, num_samples):
-        num_var_params = len(d)
-
-        if sampling_type == SamplingType.FIXED:
-            nx = 1
-            for k, v in d.items():
-                nx *= v.num_samples
-        elif (
-            sampling_type == SamplingType.RANDOM
-            or sampling_type == SamplingType.RANDOM_LHS
-        ):
-            # Make sure num_samples are the same here and across the SamplingTypes
-            for k, v in d.items():
-                if v.num_samples != num_samples:
-                    raise RuntimeError(
-                        "The number of samples should be the same across all sweep parameters."
-                    )
-            nx = num_samples
-        else:
-            raise ValueError(f"Unknown sampling type: {sampling_type}")
-
-        if not float(nx).is_integer():
-            raise RuntimeError(f"Total number of samples must be integer valued")
-        nx = int(nx)
-
-        # allocate the right amount of memory
-        return np.zeros((nx, num_var_params), dtype=float)
-
-    """
     Put together all of the parameter combinations that the sweep will be run for.
     """
 
@@ -387,14 +355,8 @@ class _ParameterSweepBase(ABC):
         # only build the full array of combinations on the root process. on the non-root
         # processes, initialize an empty array of the right size that will be synced
         # over from the root process.
-        if self.parallel_manager.is_root_process():
-            global_combo_array = self._create_global_combo_array(d, sampling_type)
-        else:
-            global_combo_array = self._create_empty_global_combo_array(
-                d, sampling_type, num_samples
-            )
 
-        # make sure all processes running in parallel have an identical copy of the data
+        global_combo_array = self._create_global_combo_array(d, sampling_type)
         self.parallel_manager.sync_array_with_peers(global_combo_array)
 
         return global_combo_array

--- a/watertap/tools/parameter_sweep/sampling_types.py
+++ b/watertap/tools/parameter_sweep/sampling_types.py
@@ -98,6 +98,13 @@ class ReverseGeomSample(FixedSample):
 
 
 class PredeterminedFixedSample(FixedSample):
+    """
+    Similar to other fixed ssampling types except the setup function arguments.
+    In this case a user needs to specify a numpy array (or a list) of 
+    predetermined values. For example:
+
+    sample_obj = PredeterminedFixedSample(np.array([1,2,3,4]))
+    """
     def sample(self):
         return self.values
 
@@ -127,6 +134,13 @@ class NormalSample(RandomSample):
 
 
 class PredeterminedRandomSample(RandomSample):
+    """
+    Similar to other fixed ssampling types except the setup function arguments.
+    In this case a user needs to specify a numpy array (or a list) of 
+    predetermined values. For example:
+
+    sample_obj = PredeterminedFixedSample(np.array([1,2,3,4]))
+    """
     def sample(self):
         return self.values
 

--- a/watertap/tools/parameter_sweep/sampling_types.py
+++ b/watertap/tools/parameter_sweep/sampling_types.py
@@ -22,7 +22,6 @@ class SamplingType(Enum):
     FIXED = auto()
     RANDOM = auto()
     RANDOM_LHS = auto()
-    PREDETERMINED = auto()
 
 
 class _Sample(ABC):

--- a/watertap/tools/parameter_sweep/sampling_types.py
+++ b/watertap/tools/parameter_sweep/sampling_types.py
@@ -22,6 +22,7 @@ class SamplingType(Enum):
     FIXED = auto()
     RANDOM = auto()
     RANDOM_LHS = auto()
+    PREDETERMINED = auto()
 
 
 class _Sample(ABC):
@@ -96,6 +97,13 @@ class ReverseGeomSample(FixedSample):
         self.upper_limit = upper_limit
         self.num_samples = num_samples
 
+class PredeterminedFixedSample(FixedSample):
+    def sample(self):
+        return self.values
+
+    def setup(self, values, num_samples):
+        self.values = values
+        self.num_samples = num_samples
 
 class UniformSample(RandomSample):
     def sample(self):
@@ -114,6 +122,14 @@ class NormalSample(RandomSample):
     def setup(self, mean, sd, num_samples):
         self.mean = mean
         self.sd = sd
+        self.num_samples = num_samples
+
+class PredeterminedRandomSample(RandomSample):
+    def sample(self):
+        return self.values
+
+    def setup(self, values, num_samples):
+        self.values = values
         self.num_samples = num_samples
 
 

--- a/watertap/tools/parameter_sweep/sampling_types.py
+++ b/watertap/tools/parameter_sweep/sampling_types.py
@@ -101,9 +101,9 @@ class PredeterminedFixedSample(FixedSample):
     def sample(self):
         return self.values
 
-    def setup(self, values, num_samples):
+    def setup(self, values):
         self.values = values
-        self.num_samples = num_samples
+        self.num_samples = len(values)
 
 
 class UniformSample(RandomSample):
@@ -130,9 +130,9 @@ class PredeterminedRandomSample(RandomSample):
     def sample(self):
         return self.values
 
-    def setup(self, values, num_samples):
+    def setup(self, values):
         self.values = values
-        self.num_samples = num_samples
+        self.num_samples = len(values)
 
 
 class LatinHypercubeSample(_Sample):

--- a/watertap/tools/parameter_sweep/sampling_types.py
+++ b/watertap/tools/parameter_sweep/sampling_types.py
@@ -96,6 +96,7 @@ class ReverseGeomSample(FixedSample):
         self.upper_limit = upper_limit
         self.num_samples = num_samples
 
+
 class PredeterminedFixedSample(FixedSample):
     def sample(self):
         return self.values
@@ -103,6 +104,7 @@ class PredeterminedFixedSample(FixedSample):
     def setup(self, values, num_samples):
         self.values = values
         self.num_samples = num_samples
+
 
 class UniformSample(RandomSample):
     def sample(self):
@@ -122,6 +124,7 @@ class NormalSample(RandomSample):
         self.mean = mean
         self.sd = sd
         self.num_samples = num_samples
+
 
 class PredeterminedRandomSample(RandomSample):
     def sample(self):

--- a/watertap/tools/parameter_sweep/sampling_types.py
+++ b/watertap/tools/parameter_sweep/sampling_types.py
@@ -100,11 +100,12 @@ class ReverseGeomSample(FixedSample):
 class PredeterminedFixedSample(FixedSample):
     """
     Similar to other fixed ssampling types except the setup function arguments.
-    In this case a user needs to specify a numpy array (or a list) of 
+    In this case a user needs to specify a numpy array (or a list) of
     predetermined values. For example:
 
     sample_obj = PredeterminedFixedSample(np.array([1,2,3,4]))
     """
+
     def sample(self):
         return self.values
 
@@ -136,11 +137,12 @@ class NormalSample(RandomSample):
 class PredeterminedRandomSample(RandomSample):
     """
     Similar to other fixed ssampling types except the setup function arguments.
-    In this case a user needs to specify a numpy array (or a list) of 
+    In this case a user needs to specify a numpy array (or a list) of
     predetermined values. For example:
 
     sample_obj = PredeterminedFixedSample(np.array([1,2,3,4]))
     """
+
     def sample(self):
         return self.values
 

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -260,9 +260,9 @@ class TestParameterSweep:
         C_values = nn_C + np.arange(nn_C)
 
         param_dict = dict()
-        param_dict["var_A"] = PredeterminedFixedSample(A_param, A_values, nn_A)
-        param_dict["var_B"] = PredeterminedFixedSample(B_param, B_values, nn_B)
-        param_dict["var_C"] = PredeterminedFixedSample(C_param, C_values, nn_C)
+        param_dict["var_A"] = PredeterminedFixedSample(A_param, A_values)
+        param_dict["var_B"] = PredeterminedFixedSample(B_param, B_values)
+        param_dict["var_C"] = PredeterminedFixedSample(C_param, C_values)
 
         global_combo_array = ps._build_combinations(
             param_dict, SamplingType.FIXED, None
@@ -354,9 +354,9 @@ class TestParameterSweep:
         C_values = 20.0 + A_values
 
         param_dict = dict()
-        param_dict["var_A"] = PredeterminedRandomSample(A_param, A_values, nn)
-        param_dict["var_B"] = PredeterminedRandomSample(B_param, B_values, nn)
-        param_dict["var_C"] = PredeterminedRandomSample(C_param, C_values, nn)
+        param_dict["var_A"] = PredeterminedRandomSample(A_param, A_values)
+        param_dict["var_B"] = PredeterminedRandomSample(B_param, B_values)
+        param_dict["var_C"] = PredeterminedRandomSample(C_param, C_values)
 
         global_combo_array = ps._build_combinations(param_dict, SamplingType.RANDOM, nn)
 

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -264,8 +264,8 @@ class TestParameterSweep:
         param_dict["var_B"] = PredeterminedFixedSample(B_param, B_values)
         param_dict["var_C"] = PredeterminedFixedSample(C_param, C_values)
 
-        global_combo_array = ps._create_global_combo_array(
-            param_dict, SamplingType.FIXED
+        global_combo_array = ps._build_combinations(
+            param_dict, SamplingType.FIXED, None
         )
 
         assert np.shape(global_combo_array)[0] == nn_A * nn_B * nn_C

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -271,7 +271,7 @@ class TestParameterSweep:
         assert np.shape(global_combo_array)[0] == nn_A * nn_B * nn_C
         assert np.shape(global_combo_array)[1] == len(param_dict)
         assert (global_combo_array[0] == np.array([nn_A, nn_B, nn_C])).all()
-        assert (global_combo_array[-1] == 2*np.array([nn_A, nn_B, nn_C])-1).all
+        assert (global_combo_array[-1] == 2 * np.array([nn_A, nn_B, nn_C]) - 1).all
 
     @pytest.mark.component
     def test_status_publishing(self):
@@ -348,7 +348,7 @@ class TestParameterSweep:
         A_param = pyo.Param(initialize=0.0, mutable=True)
         B_param = pyo.Param(initialize=0.0, mutable=True)
         C_param = pyo.Param(initialize=0.0, mutable=True)
-        
+
         A_values = np.arange(nn)
         B_values = 10.0 + A_values
         C_values = 20.0 + A_values
@@ -357,7 +357,7 @@ class TestParameterSweep:
         param_dict["var_A"] = PredeterminedRandomSample(A_param, A_values, nn)
         param_dict["var_B"] = PredeterminedRandomSample(B_param, B_values, nn)
         param_dict["var_C"] = PredeterminedRandomSample(C_param, C_values, nn)
-        
+
         global_combo_array = ps._build_combinations(param_dict, SamplingType.RANDOM, nn)
 
         assert np.shape(global_combo_array)[0] == nn

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -271,7 +271,7 @@ class TestParameterSweep:
         assert np.shape(global_combo_array)[0] == nn_A * nn_B * nn_C
         assert np.shape(global_combo_array)[1] == len(param_dict)
         assert (global_combo_array[0] == np.array([nn_A, nn_B, nn_C])).all()
-        assert (global_combo_array[-1] == 2 * np.array([nn_A, nn_B, nn_C]) - 1).all
+        assert (global_combo_array[-1] == 2 * np.array([nn_A, nn_B, nn_C]) - 1).all()
 
     @pytest.mark.component
     def test_status_publishing(self):

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -264,8 +264,8 @@ class TestParameterSweep:
         param_dict["var_B"] = PredeterminedFixedSample(B_param, B_values)
         param_dict["var_C"] = PredeterminedFixedSample(C_param, C_values)
 
-        global_combo_array = ps._build_combinations(
-            param_dict, SamplingType.FIXED, None
+        global_combo_array = ps._create_global_combo_array(
+            param_dict, SamplingType.FIXED
         )
 
         assert np.shape(global_combo_array)[0] == nn_A * nn_B * nn_C

--- a/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/tests/test_parameter_sweep.py
@@ -244,6 +244,36 @@ class TestParameterSweep:
         assert global_combo_array[-1, 2] == pytest.approx(range_C[1])
 
     @pytest.mark.component
+    def test_predetermined_fixed_build_combinations(self):
+        ps = ParameterSweep()
+
+        A_param = pyo.Param(initialize=0.0, mutable=True)
+        B_param = pyo.Param(initialize=1.0, mutable=True)
+        C_param = pyo.Param(initialize=2.0, mutable=True)
+
+        nn_A = 2
+        nn_B = 3
+        nn_C = 4
+
+        A_values = nn_A + np.arange(nn_A)
+        B_values = nn_B + np.arange(nn_B)
+        C_values = nn_C + np.arange(nn_C)
+
+        param_dict = dict()
+        param_dict["var_A"] = PredeterminedFixedSample(A_param, A_values, nn_A)
+        param_dict["var_B"] = PredeterminedFixedSample(B_param, B_values, nn_B)
+        param_dict["var_C"] = PredeterminedFixedSample(C_param, C_values, nn_C)
+
+        global_combo_array = ps._build_combinations(
+            param_dict, SamplingType.FIXED, None
+        )
+
+        assert np.shape(global_combo_array)[0] == nn_A * nn_B * nn_C
+        assert np.shape(global_combo_array)[1] == len(param_dict)
+        assert (global_combo_array[0] == np.array([nn_A, nn_B, nn_C])).all()
+        assert (global_combo_array[-1] == 2*np.array([nn_A, nn_B, nn_C])-1).all
+
+    @pytest.mark.component
     def test_status_publishing(self):
         requests = pytest.importorskip(
             "requests",
@@ -314,6 +344,24 @@ class TestParameterSweep:
         assert (range_B[0] - range_B[1]) < np.mean(global_combo_array[:, 1])
 
         assert np.all(global_combo_array[:, 2] == range_C[0])
+
+        A_param = pyo.Param(initialize=0.0, mutable=True)
+        B_param = pyo.Param(initialize=0.0, mutable=True)
+        C_param = pyo.Param(initialize=0.0, mutable=True)
+        
+        A_values = np.arange(nn)
+        B_values = 10.0 + A_values
+        C_values = 20.0 + A_values
+
+        param_dict = dict()
+        param_dict["var_A"] = PredeterminedRandomSample(A_param, A_values, nn)
+        param_dict["var_B"] = PredeterminedRandomSample(B_param, B_values, nn)
+        param_dict["var_C"] = PredeterminedRandomSample(C_param, C_values, nn)
+        
+        global_combo_array = ps._build_combinations(param_dict, SamplingType.RANDOM, nn)
+
+        assert np.shape(global_combo_array)[0] == nn
+        assert (global_combo_array == np.array([A_values, B_values, C_values]).T).all()
 
     @pytest.mark.component
     def test_divide_combinations(self):


### PR DESCRIPTION
## Fixes/Resolves:

Fixes the inability of the parameter sweep tool to accept pre-sampled values from a separate experiment.

## Summary/Motivation:

Enables better analysis and validation for existing flowsheet configurations

## Changes proposed in this PR:
- Creation of a predetermined random sampling type
- Creation of a predetermined fixed sampling type

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
