### PR TITLE
Fix binder launch and tweak BSM2 tutorial

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,4 +1,4 @@
-libgfortran4
+libgfortran5
 libgomp1
 liblapack3
 libblas3

--- a/tutorials/BSM2.ipynb
+++ b/tutorials/BSM2.ipynb
@@ -17,7 +17,8 @@
     "    - Anaerobic Digestion Model No. 1 (ADM1) documentation: https://watertap.readthedocs.io/en/stable/technical_reference/property_models/ADM1.html\n",
     "    - ASM1-ADM1 Translator documentation: https://watertap.readthedocs.io/en/stable/technical_reference/unit_models/translators/translator_asm1_adm1.html\n",
     "    - ADM1-ASM1 Translator documentation: https://watertap.readthedocs.io/en/stable/technical_reference/unit_models/translators/translator_adm1_asm1.html    \n",
-    "    - Unit Model documentation: https://watertap.readthedocs.io/en/stable/technical_reference/unit_models/index.html\n"
+    "    - Unit Model documentation: https://watertap.readthedocs.io/en/stable/technical_reference/unit_models/index.html\n",
+    "    - BSM2 flowsheet code: https://github.com/watertap-org/watertap/blob/main/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2.py\n"
    ]
   },
   {


### PR DESCRIPTION
## Fixes/Resolves:

## Summary/Motivation:
This PR is meant to address #1191 temporarily and add a link to the BSM2 tutorial notebook.

## Changes proposed in this PR:
- update libgfortran4 to libgfortran5 to bypass Binder launch error
- add link to full BSM2 flowsheet code in Jupyter notebook

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
