### PR TITLE
Making sure the MultiprocessingParallelManager cleans up when done

### DIFF
--- a/watertap/tools/parallel/concurrent_futures_parallel_manager.py
+++ b/watertap/tools/parallel/concurrent_futures_parallel_manager.py
@@ -102,7 +102,7 @@ class ConcurrentFuturesParallelManager(ParallelManager):
     def gather(self):
         results = []
         try:
-            execution_results = futures.wait(self.running_futures.keys())
+            execution_results = futures.wait(self.running_futures.keys(), timeout=30)
             for future in execution_results.done:
                 process_number, values = self.running_futures[future]
                 results.append(LocalResults(process_number, values, future.result()))

--- a/watertap/tools/parallel/concurrent_futures_parallel_manager.py
+++ b/watertap/tools/parallel/concurrent_futures_parallel_manager.py
@@ -102,7 +102,7 @@ class ConcurrentFuturesParallelManager(ParallelManager):
     def gather(self):
         results = []
         try:
-            execution_results = futures.wait(self.running_futures.keys(), timeout=30)
+            execution_results = futures.wait(self.running_futures.keys())
             for future in execution_results.done:
                 process_number, values = self.running_futures[future]
                 results.append(LocalResults(process_number, values, future.result()))

--- a/watertap/tools/parallel/multiprocessing_parallel_manager.py
+++ b/watertap/tools/parallel/multiprocessing_parallel_manager.py
@@ -113,7 +113,7 @@ class MultiprocessingParallelManager(ParallelManager):
         # collect result from the actors
         while len(results) < self.expected_samples:
             if self.return_queue.empty() == False:
-                i, values, result = self.return_queue.get()
+                i, values, result = self.return_queue.get(timeout=30)
 
                 results.append(LocalResults(i, values, result))
         # sort the results by the process number to keep a deterministic ordering

--- a/watertap/tools/parallel/multiprocessing_parallel_manager.py
+++ b/watertap/tools/parallel/multiprocessing_parallel_manager.py
@@ -138,6 +138,6 @@ def multiProcessingActor(
         if queue.empty():
             break
         else:
-            i, local_parameters = queue.get()
+            i, local_parameters = queue.get(timeout=30)
             result = actor.execute(local_parameters)
             return_queue.put([i, local_parameters, result])

--- a/watertap/tools/parallel/multiprocessing_parallel_manager.py
+++ b/watertap/tools/parallel/multiprocessing_parallel_manager.py
@@ -22,7 +22,10 @@ import multiprocessing
 from queue import Empty as EmptyQueue
 from numbers import Number
 from typing import Optional
+import logging
 
+
+_logger = logging.getLogger(__name__)
 
 TimeoutSpec = Optional[Number]
 
@@ -140,10 +143,12 @@ class MultiprocessingParallelManager(ParallelManager):
         return results
 
     def _shut_down(self):
-        for worker in self.actors:
-            print(f"Attempting to shut down {worker}")
-            worker.join(timeout=self.timeout)
-        print(f"Shut down {len(self.actors)} workers")
+        n_shut_down = 0
+        for process in self.actors:
+            _logger.debug("Attempting to shut down %s", process)
+            process.join(timeout=self.timeout)
+            n_shut_down += 1
+        _logger.debug("Shut down %d processes", n_shut_down)
 
     def results_from_local_tree(self, results):
         return results

--- a/watertap/tools/parallel/multiprocessing_parallel_manager.py
+++ b/watertap/tools/parallel/multiprocessing_parallel_manager.py
@@ -12,9 +12,7 @@
 
 import logging
 import multiprocessing
-from numbers import Number
 from queue import Empty as EmptyQueue
-from typing import Optional
 
 import numpy
 

--- a/watertap/tools/parallel/multiprocessing_parallel_manager.py
+++ b/watertap/tools/parallel/multiprocessing_parallel_manager.py
@@ -116,9 +116,16 @@ class MultiprocessingParallelManager(ParallelManager):
                 i, values, result = self.return_queue.get(timeout=30)
 
                 results.append(LocalResults(i, values, result))
+        self._shut_down()
         # sort the results by the process number to keep a deterministic ordering
         results.sort(key=lambda result: result.process_number)
         return results
+
+    def _shut_down(self, timeout=5):
+        for worker in self.actors:
+            print(f"Attempting to shut down {worker}")
+            worker.join(timeout=5)
+        print(f"Shut down {len(self.actors)} workers")
 
     def results_from_local_tree(self, results):
         return results

--- a/watertap/tools/parallel/multiprocessing_parallel_manager.py
+++ b/watertap/tools/parallel/multiprocessing_parallel_manager.py
@@ -10,32 +10,44 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
-import functools
 import logging
 import multiprocessing
+from numbers import Number
+from queue import Empty as EmptyQueue
+from typing import Optional
 
 import numpy
 
 from watertap.tools.parallel.results import LocalResults
 from watertap.tools.parallel.parallel_manager import (
-    build_and_execute,
+    parallelActor,
     ParallelManager,
 )
 
 
 _logger = logging.getLogger(__name__)
 
+TimeoutSpec = Optional[Number]
+
+_DEFAULT_TIMEOUT_SECONDS = 1
+
 
 class MultiprocessingParallelManager(ParallelManager):
     def __init__(
         self,
         number_of_subprocesses=1,
+        timeout: TimeoutSpec = _DEFAULT_TIMEOUT_SECONDS,
         **kwargs,
     ):
         self.max_number_of_subprocesses = number_of_subprocesses
 
         # this will be updated when child processes are kicked off
         self.actual_number_of_subprocesses = None
+
+        # Future -> (process number, parameters). Used to keep track of the process number and parameters for
+        # all in-progress futures
+        self.running_futures = dict()
+        self.timeout = timeout
 
     def is_root_process(self):
         return True
@@ -87,32 +99,77 @@ class MultiprocessingParallelManager(ParallelManager):
         # split the parameters prameters for async run
         self.expected_samples = len(all_parameters)
         divided_parameters = numpy.array_split(all_parameters, self.expected_samples)
+        # create queues, run queue will be used to store paramters we want to run
+        # and return_queue is used to store results
+        self.run_queue = multiprocessing.Queue()
+        self.return_queue = multiprocessing.Queue()
+        for i, param in enumerate(divided_parameters):
+            # print(param)
+            self.run_queue.put([i, param])
+        # setup multiprocessing actors
+        self.actors = []
 
-        build_and_execute_this_run = functools.partial(
-            build_and_execute, do_build, do_build_kwargs, do_execute
-        )
-
-        actor = functools.partial(multiProcessingActor, build_and_execute_this_run)
-
-        self._pool = multiprocessing.Pool(self.actual_number_of_subprocesses)
-        self._results = self._pool.map_async(actor, enumerate(divided_parameters))
-        self._pool.close()
+        for cpu in range(self.actual_number_of_subprocesses):
+            self.actors.append(
+                multiprocessing.Process(
+                    target=multiProcessingActor,
+                    args=(
+                        self.run_queue,
+                        self.return_queue,
+                        do_build,
+                        do_build_kwargs,
+                        do_execute,
+                        divided_parameters[0],
+                    ),
+                    kwargs={
+                        "timeout": self.timeout,
+                    },
+                )
+            )
+            self.actors[-1].start()
 
     def gather(self):
-        results = self._results.get()
+        results = []
+        # collect result from the actors
+        while len(results) < self.expected_samples:
+            try:
+                i, values, result = self.return_queue.get(timeout=self.timeout)
+                results.append(LocalResults(i, values, result))
+            except EmptyQueue:
+                break
+        self._shut_down()
         # sort the results by the process number to keep a deterministic ordering
         results.sort(key=lambda result: result.process_number)
         return results
+
+    def _shut_down(self):
+        n_shut_down = 0
+        for process in self.actors:
+            _logger.debug("Attempting to shut down %s", process)
+            process.join(timeout=self.timeout)
+            n_shut_down += 1
+        _logger.debug("Shut down %d processes", n_shut_down)
 
     def results_from_local_tree(self, results):
         return results
 
 
+# This function is used for running the actors in multprocessing
 def multiProcessingActor(
-    build_and_execute_this_run,
-    i_local_parameters,
+    queue,
+    return_queue,
+    do_build,
+    do_build_kwargs,
+    do_execute,
+    local_parameters,
+    timeout: TimeoutSpec = _DEFAULT_TIMEOUT_SECONDS,
 ):
-    i, local_parameters = i_local_parameters
-    return LocalResults(
-        i, local_parameters, build_and_execute_this_run(local_parameters)
-    )
+    actor = parallelActor(do_build, do_build_kwargs, do_execute, local_parameters)
+    while True:
+        try:
+            msg = queue.get(timeout=timeout)
+        except EmptyQueue:
+            return
+        i, local_parameters = msg
+        result = actor.execute(local_parameters)
+        return_queue.put([i, local_parameters, result])

--- a/watertap/tools/parallel/multiprocessing_parallel_manager.py
+++ b/watertap/tools/parallel/multiprocessing_parallel_manager.py
@@ -10,19 +10,19 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
-import numpy
+import logging
+import multiprocessing
+from numbers import Number
+from queue import Empty as EmptyQueue
+from typing import Optional
 
+import numpy
 
 from watertap.tools.parallel.results import LocalResults
 from watertap.tools.parallel.parallel_manager import (
     parallelActor,
     ParallelManager,
 )
-import multiprocessing
-from queue import Empty as EmptyQueue
-from numbers import Number
-from typing import Optional
-import logging
 
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Fixes/Resolves: #1158

## Summary/Motivation:
See #1158. This will call `kill` to clean up any hanging `Process`es at the end of the run using the `MultiprocessingParallelManager`.

## Changes proposed in this PR:
- See above.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
