### PR TITLE
Fixes for Pyomo 6.7

### DIFF
--- a/docs/how_to_guides/how_to_use_a_property_model.rst
+++ b/docs/how_to_guides/how_to_use_a_property_model.rst
@@ -70,6 +70,12 @@ A portion of the displayed output is shown below.
 
 .. testoutput::
 
+   WARNING: model contains export suffix 'fs.state_block[0].scaling_factor' that
+   contains 4 component keys that are not exported as part of the NL file.
+   Skipping.
+   WARNING: model contains export suffix 'fs.state_block[0].scaling_factor' that
+   contains 4 component keys that are not exported as part of the NL file.
+   Skipping.
    Block fs.state_block[0]
 
      Variables:

--- a/docs/how_to_guides/how_to_use_a_property_model.rst
+++ b/docs/how_to_guides/how_to_use_a_property_model.rst
@@ -70,12 +70,6 @@ A portion of the displayed output is shown below.
 
 .. testoutput::
 
-   WARNING: model contains export suffix 'fs.state_block[0].scaling_factor' that
-   contains 4 component keys that are not exported as part of the NL file.
-   Skipping.
-   WARNING: model contains export suffix 'fs.state_block[0].scaling_factor' that
-   contains 4 component keys that are not exported as part of the NL file.
-   Skipping.
    Block fs.state_block[0]
 
      Variables:

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         # primary requirements for unit and property models
         # maintainers: switch to SPECIAL_DEPENDENCIES_FOR_RELEASE when cutting a release of watertap
         *SPECIAL_DEPENDENCIES_FOR_PRERELEASE,
-        "pyomo>=6.6.1,<6.7",  # (also needed for units in electrolyte database (edb))
+        "pyomo>=6.6.1",  # (also needed for units in electrolyte database (edb))
         "pyyaml",  # watertap.core.wt_database
         # the following requirements are for the electrolyte database (edb)
         "pymongo>3",  # database interface

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -21,7 +21,7 @@ from idaes.core.util.scaling import (
     constraints_with_scale_factor_generator,
 )
 from idaes.core.solvers import get_solver
-from watertap.core.plugins.solvers import IpoptWaterTAP
+from watertap.core.plugins.solvers import IpoptWaterTAP, _pyomo_nl_writer_log
 
 
 class TestIpoptWaterTAP:
@@ -119,6 +119,7 @@ class TestIpoptWaterTAP:
         pyo.assert_optimal_termination(results)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
         del s.options["ignore_variable_scaling"]
 
     @pytest.mark.unit
@@ -135,6 +136,7 @@ class TestIpoptWaterTAP:
         s._presolve(m, tee=True)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
         s.options["nlp_scaling_method"] = "user-scaling"
 
     @pytest.mark.unit
@@ -144,6 +146,7 @@ class TestIpoptWaterTAP:
         del s.options["nlp_scaling_method"]
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
 
     @pytest.mark.unit
     def test_passthrough_negative(self, m, s):
@@ -155,6 +158,7 @@ class TestIpoptWaterTAP:
         del s.options["ignore_variable_scaling"]
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
 
     @pytest.mark.unit
     def test_presolve_incorrect_number_of_arguments(self, m, s):
@@ -175,6 +179,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
         m.a.value = 1
 
     @pytest.mark.unit
@@ -192,6 +197,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
         m.a.value = 1
 
     @pytest.mark.unit
@@ -209,6 +215,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
         IPOPT._presolve = IPOPT_presolve
 
     @pytest.mark.unit
@@ -226,6 +233,7 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
+        assert _pyomo_nl_writer_log.filters == []
         iscale.constraint_autoscale_large_jac = constraint_autoscale_large_jac
 
     @pytest.fixture(scope="class")

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -16,13 +16,12 @@ import idaes.core.util.scaling as iscale
 
 from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
 from pyomo.common.errors import ApplicationError
-import pyomo.repn.plugins.nl_writer as _nl_writer
 from idaes.core.util.scaling import (
     set_scaling_factor,
     constraints_with_scale_factor_generator,
 )
 from idaes.core.solvers import get_solver
-from watertap.core.plugins.solvers import IpoptWaterTAP, _SuffixData
+from watertap.core.plugins.solvers import IpoptWaterTAP
 
 
 class TestIpoptWaterTAP:
@@ -112,7 +111,6 @@ class TestIpoptWaterTAP:
         assert cons_with_sf == [(m.b.d, 1e6)]
 
         assert not hasattr(s, "_model")
-        assert _nl_writer._SuffixData is _SuffixData
 
     @pytest.mark.unit
     def test_option_absorption(self, m, s):
@@ -121,7 +119,6 @@ class TestIpoptWaterTAP:
         pyo.assert_optimal_termination(results)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
         del s.options["ignore_variable_scaling"]
 
     @pytest.mark.unit
@@ -138,7 +135,6 @@ class TestIpoptWaterTAP:
         s._presolve(m, tee=True)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
         s.options["nlp_scaling_method"] = "user-scaling"
 
     @pytest.mark.unit
@@ -148,7 +144,6 @@ class TestIpoptWaterTAP:
         del s.options["nlp_scaling_method"]
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
 
     @pytest.mark.unit
     def test_passthrough_negative(self, m, s):
@@ -160,7 +155,6 @@ class TestIpoptWaterTAP:
         del s.options["ignore_variable_scaling"]
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
 
     @pytest.mark.unit
     def test_presolve_incorrect_number_of_arguments(self, m, s):
@@ -181,7 +175,6 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
         m.a.value = 1
 
     @pytest.mark.unit
@@ -199,7 +192,6 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
         m.a.value = 1
 
     @pytest.mark.unit
@@ -217,7 +209,6 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
         IPOPT._presolve = IPOPT_presolve
 
     @pytest.mark.unit
@@ -235,7 +226,6 @@ class TestIpoptWaterTAP:
             s.solve(m)
         self._test_bounds(m)
         assert not hasattr(s, "_scaling_cache")
-        assert _nl_writer._SuffixData is _SuffixData
         iscale.constraint_autoscale_large_jac = constraint_autoscale_large_jac
 
     @pytest.fixture(scope="class")

--- a/watertap/examples/custom_model_demo/simple_prop_pack.py
+++ b/watertap/examples/custom_model_demo/simple_prop_pack.py
@@ -77,9 +77,7 @@ class PropParameterData(PhysicalParameterBlock):
         self.NaCl = Component()
 
         # parameters
-        self.cp = Param(
-            mutable=False, initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K)
-        )
+        self.cp = Param(initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K))
 
         dens_mass_param_dict = {"0": 995, "1": 756}
         self.dens_mass_param = Param(

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet_noPHA.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet_noPHA.py
@@ -347,7 +347,7 @@ def build_flowsheet():
 
     seq.run(m, function)
 
-    solver = get_solver(options={"bound_push": 1e-4})
+    solver = get_solver()
     results = solver.solve(m, tee=False)
     check_solve(results, logger=_log, fail_flag=True)
 

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/tests/test_asm2_noPHA_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/tests/test_asm2_noPHA_flowsheet.py
@@ -43,7 +43,6 @@ class TestASM2DFlowsheet:
         assert degrees_of_freedom(model) == 0
         assert_optimal_termination(model.results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.integration
     def test_results(self, model):
         # Treated water
@@ -144,10 +143,10 @@ class TestASM2DFlowsheet:
             0.101, rel=1e-2
         )
         assert value(model.fs.Sludge.conc_mass_comp[0, "X_MeOH"]) == pytest.approx(
-            1.36e-9, rel=1e2
+            1.81e-7, rel=1e2
         )
         assert value(model.fs.Sludge.conc_mass_comp[0, "X_MeP"]) == pytest.approx(
-            1.2e-8, rel=1e2
+            1.44e-6, rel=1e2
         )
         assert value(model.fs.Sludge.conc_mass_comp[0, "X_PAO"]) == pytest.approx(
             1.95e-6, rel=1e2

--- a/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/chemistry/tests/test_posttreatment.py
+++ b/watertap/examples/flowsheets/full_treatment_train/flowsheet_components/chemistry/tests/test_posttreatment.py
@@ -53,7 +53,6 @@ def test_ideal_naocl_mixer():
     ].value == pytest.approx(5.373448801531194e-07, rel=1e-3)
 
 
-@pytest.mark.requires_idaes_solver
 @pytest.mark.component
 def test_ideal_naocl_chlorination():
     model = run_ideal_naocl_chlorination_example()
@@ -65,10 +64,9 @@ def test_ideal_naocl_chlorination():
     ].value == pytest.approx(4.254858076511e-07, rel=1e-3)
     assert model.fs.ideal_naocl_chlorination_unit.outlet.mole_frac_comp[
         0, "H_+"
-    ].value == pytest.approx(5.75022333462775e-11, rel=1e-3)
+    ].value == pytest.approx(5.64e-11, rel=1e-1)
 
 
-@pytest.mark.requires_idaes_solver
 @pytest.mark.component
 def test_ideal_naocl_chlorination_full_block():
     model = run_chlorination_block_example(fix_free_chlorine=True)
@@ -87,10 +85,10 @@ def test_ideal_naocl_chlorination_full_block():
     )
     assert model.fs.ideal_naocl_chlorination_unit.outlet.mole_frac_comp[
         0, "OCl_-"
-    ].value == pytest.approx(4.5088044031726496e-07, rel=1e-3)
+    ].value == pytest.approx(4.48e-07, rel=1e-2)
     assert model.fs.ideal_naocl_chlorination_unit.outlet.mole_frac_comp[
         0, "H_+"
-    ].value == pytest.approx(5.4260427865375997e-11, rel=1e-3)
+    ].value == pytest.approx(5.43e-11, rel=1e-1)
 
 
 @pytest.mark.component

--- a/watertap/examples/flowsheets/full_treatment_train/model_components/seawater_salt_prop_pack.py
+++ b/watertap/examples/flowsheets/full_treatment_train/model_components/seawater_salt_prop_pack.py
@@ -88,22 +88,18 @@ class PropParameterData(PhysicalParameterBlock):
 
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=extract_data(mw_comp_data),
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight",
         )
 
         self.dens_mass = Param(
-            mutable=False,
             initialize=1000,
             units=pyunits.kg / pyunits.m**3,
             doc="Density",
         )
 
-        self.cp = Param(
-            mutable=False, initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K)
-        )
+        self.cp = Param(initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K))
 
         # ---default scaling---
         self.set_default_scaling("temperature", 1e-2)

--- a/watertap/property_models/NDMA_prop_pack.py
+++ b/watertap/property_models/NDMA_prop_pack.py
@@ -86,15 +86,12 @@ class NDMAParameterData(PhysicalParameterBlock):
         self.Liq = LiquidPhase()
 
         # heat capacity
-        self.cp = Param(
-            mutable=False, initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K)
-        )
+        self.cp = Param(initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K))
 
         # molecular weight
         mw_comp_data = {"H2O": 18.01528e-3, "NDMA": 74.0819e-3}
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=extract_data(mw_comp_data),
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight kg/mol",

--- a/watertap/property_models/NaCl_T_dep_prop_pack.py
+++ b/watertap/property_models/NaCl_T_dep_prop_pack.py
@@ -91,7 +91,6 @@ class NaClParameterData(PhysicalParameterBlock):
         mw_comp_data = {"H2O": 18.01528e-3, "NaCl": 58.44e-3}
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=extract_data(mw_comp_data),
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight kg/mol",

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -94,7 +94,6 @@ class NaClParameterData(PhysicalParameterBlock):
         mw_comp_data = {"H2O": 18.01528e-3, "NaCl": 58.44e-3}
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=extract_data(mw_comp_data),
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight kg/mol",

--- a/watertap/property_models/activated_sludge/asm1_properties.py
+++ b/watertap/property_models/activated_sludge/asm1_properties.py
@@ -99,14 +99,12 @@ class ASM1ParameterData(PhysicalParameterBlock):
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(
-            mutable=False,
             initialize=4182,
             doc="Specific heat capacity of water",
             units=pyo.units.J / pyo.units.kg / pyo.units.K,
         )
         # Density of water
         self.dens_mass = pyo.Param(
-            mutable=False,
             initialize=997,
             doc="Density of water",
             units=pyo.units.kg / pyo.units.m**3,

--- a/watertap/property_models/activated_sludge/asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/asm2d_properties.py
@@ -136,14 +136,12 @@ class ASM2dParameterData(PhysicalParameterBlock):
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(
-            mutable=False,
             initialize=4182,
             doc="Specific heat capacity of water",
             units=pyo.units.J / pyo.units.kg / pyo.units.K,
         )
         # Density of water
         self.dens_mass = pyo.Param(
-            mutable=False,
             initialize=997,
             doc="Density of water",
             units=pyo.units.kg / pyo.units.m**3,

--- a/watertap/property_models/activated_sludge/modified_asm2d_properties.py
+++ b/watertap/property_models/activated_sludge/modified_asm2d_properties.py
@@ -144,14 +144,12 @@ class ModifiedASM2dParameterData(PhysicalParameterBlock):
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(
-            mutable=False,
             initialize=4182,
             doc="Specific heat capacity of water",
             units=pyo.units.J / pyo.units.kg / pyo.units.K,
         )
         # Density of water
         self.dens_mass = pyo.Param(
-            mutable=False,
             initialize=997,
             doc="Density of water",
             units=pyo.units.kg / pyo.units.m**3,

--- a/watertap/property_models/anaerobic_digestion/adm1_properties.py
+++ b/watertap/property_models/anaerobic_digestion/adm1_properties.py
@@ -97,14 +97,12 @@ class ADM1ParameterData(PhysicalParameterBlock):
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(
-            mutable=False,
             initialize=4182,
             doc="Specific heat capacity of water",
             units=pyo.units.J / pyo.units.kg / pyo.units.K,
         )
         # Density of water
         self.dens_mass = pyo.Param(
-            mutable=False,
             initialize=997,
             doc="Density of water",
             units=pyo.units.kg / pyo.units.m**3,

--- a/watertap/property_models/anaerobic_digestion/adm1_properties_vapor.py
+++ b/watertap/property_models/anaerobic_digestion/adm1_properties_vapor.py
@@ -70,14 +70,12 @@ class ADM1_vaporParameterData(PhysicalParameterBlock):
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(
-            mutable=False,
             initialize=1.996,
             doc="Specific heat capacity of water",
             units=pyo.units.J / pyo.units.kg / pyo.units.K,
         )
         # Density of water
         self.dens_mass = pyo.Param(
-            mutable=False,
             # initialize=0.927613356,
             initialize=0.01,
             doc="Density of water",

--- a/watertap/property_models/anaerobic_digestion/modified_adm1_properties.py
+++ b/watertap/property_models/anaerobic_digestion/modified_adm1_properties.py
@@ -101,14 +101,12 @@ class ModifiedADM1ParameterData(PhysicalParameterBlock):
 
         # Heat capacity of water
         self.cp_mass = pyo.Param(
-            mutable=False,
             initialize=4182,
             doc="Specific heat capacity of water",
             units=pyo.units.J / pyo.units.kg / pyo.units.K,
         )
         # Density of water
         self.dens_mass = pyo.Param(
-            mutable=False,
             initialize=997,
             doc="Density of water",
             units=pyo.units.kg / pyo.units.m**3,

--- a/watertap/property_models/coagulation_prop_pack.py
+++ b/watertap/property_models/coagulation_prop_pack.py
@@ -88,9 +88,7 @@ class CoagulationParameterData(PhysicalParameterBlock):
         self.Sludge = Component()
 
         #   heat capacity of liquid
-        self.cp = Param(
-            mutable=False, initialize=4184, units=pyunits.J / (pyunits.kg * pyunits.K)
-        )
+        self.cp = Param(initialize=4184, units=pyunits.J / (pyunits.kg * pyunits.K))
 
         #   reference density of liquid
         self.ref_dens_liq = Param(

--- a/watertap/property_models/cryst_prop_pack.py
+++ b/watertap/property_models/cryst_prop_pack.py
@@ -165,7 +165,6 @@ class NaClParameterData(PhysicalParameterBlock):
         mw_comp_data = {"H2O": 18.01528e-3, "NaCl": 58.44e-3}
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=extract_data(mw_comp_data),
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight kg/mol",

--- a/watertap/property_models/cryst_prop_pack.py
+++ b/watertap/property_models/cryst_prop_pack.py
@@ -1959,11 +1959,6 @@ class NaClStateBlockData(StateBlockData):
                         ) / iscale.get_scaling_factor(self.dens_mass_solute[p])
                         iscale.set_scaling_factor(self.flow_vol_phase[p], sf)
 
-        # Scaling for flow volume
-        if self.is_property_constructed("flow_vol"):
-            sf = iscale.get_scaling_factor(self.flow_vol_phase)
-            iscale.set_scaling_factor(self.flow_vol, sf)
-
         # Scaling material heat capacities
         if self.is_property_constructed("cp_mass_solute"):
             for p in ["Sol", "Liq"]:

--- a/watertap/property_models/seawater_ion_prop_pack.py
+++ b/watertap/property_models/seawater_ion_prop_pack.py
@@ -90,22 +90,18 @@ class PropParameterData(PhysicalParameterBlock):
 
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=extract_data(mw_comp_data),
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight",
         )
 
         self.dens_mass = Param(
-            mutable=False,
             initialize=1000,
             units=pyunits.kg / pyunits.m**3,
             doc="Density",
         )
 
-        self.cp = Param(
-            mutable=False, initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K)
-        )
+        self.cp = Param(initialize=4.2e3, units=pyunits.J / (pyunits.kg * pyunits.K))
 
         # ---default scaling---
         self.set_default_scaling("temperature", 1e-2)

--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -112,7 +112,6 @@ class SeawaterParameterData(PhysicalParameterBlock):
 
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=mw_comp_data,
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight",

--- a/watertap/property_models/water_prop_pack.py
+++ b/watertap/property_models/water_prop_pack.py
@@ -101,7 +101,6 @@ class WaterParameterData(PhysicalParameterBlock):
         # molecular weight
         self.mw_comp = Param(
             self.component_list,
-            mutable=False,
             initialize=18.01528e-3,
             units=pyunits.kg / pyunits.mol,
             doc="Molecular weight",

--- a/watertap/unit_models/electrodialysis_0D.py
+++ b/watertap/unit_models/electrodialysis_0D.py
@@ -276,7 +276,6 @@ class Electrodialysis0DData(InitializationMixin, UnitModelBlockData):
         # Create unit model parameters and vars
         self.water_density = Param(
             initialize=1000,
-            mutable=False,
             units=pyunits.kg * pyunits.m**-3,
             doc="density of water",
         )

--- a/watertap/unit_models/nanofiltration_0D.py
+++ b/watertap/unit_models/nanofiltration_0D.py
@@ -230,7 +230,7 @@ class NanoFiltrationData(InitializationMixin, UnitModelBlockData):
             self.flowsheet().config.time,
             self.solute_list,
             initialize=1e-8,
-            bounds=(1e-11, 1e-5),
+            bounds=(1e-11, 1e-4),
             domain=NonNegativeReals,
             units=units_meta("length") * units_meta("time") ** -1,
             doc="Solute permeability coeff.",

--- a/watertap/unit_models/tests/test_osmotically_assisted_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_osmotically_assisted_reverse_osmosis_1D.py
@@ -329,7 +329,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
         for i in badly_scaled_var_generator(m):
             print(i[0].name, i[1])
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_initialize(self, RO_frame):
         initialization_tester(RO_frame)
@@ -341,7 +340,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
         [print(i[0], i[1]) for i in badly_scaled_var_lst]
         assert badly_scaled_var_lst == []
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, RO_frame):
         m = RO_frame
@@ -350,7 +348,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
         # Check for optimal solution
         assert_optimal_termination(results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_conservation(self, RO_frame):
         m = RO_frame
@@ -402,7 +399,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
             <= 1e-5
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solution(self, RO_frame):
         m = RO_frame
@@ -474,7 +470,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
             m.fs.unit.permeate_side.deltaP_stage[0]
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_CP_calculation_with_kf_fixed(self):
         """Testing 1D-OARO with ConcentrationPolarizationType.calculated option enabled.
@@ -575,7 +570,7 @@ class TestOsmoticallyAssistedReverseOsmosis:
         assert badly_scaled_var_lst == []
 
         # test solve
-        results = solver.solve(m)
+        results = solver.solve(m, tee=True)
 
         # Check for optimal solution
         assert_optimal_termination(results)
@@ -622,7 +617,7 @@ class TestOsmoticallyAssistedReverseOsmosis:
         assert pytest.approx(43.7056, rel=1e-3) == value(
             m.fs.unit.permeate_side.properties[0, 0].conc_mass_phase_comp["Liq", "NaCl"]
         )
-        assert pytest.approx(45.156, rel=1e-3) == value(
+        assert pytest.approx(45.111, rel=1e-3) == value(
             m.fs.unit.permeate_side.properties_interface[
                 0, x_interface_in
             ].conc_mass_phase_comp["Liq", "NaCl"]
@@ -645,7 +640,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
             m.fs.unit.permeate_side.cp_modulus[0, 1, "NaCl"]
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_CP_calculation_with_kf_calculation(self):
         """Testing 1D-OARO with ConcentrationPolarizationType.calculated option and MassTransferCoefficient.calculated
@@ -788,7 +782,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
             ].conc_mass_phase_comp["Liq", "NaCl"]
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_Pdrop_fixed_per_unit_length(self):
         """Testing 1D-OARO with PressureChangeType.fixed_per_unit_length option."""
@@ -951,7 +944,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
             ].conc_mass_phase_comp["Liq", "NaCl"]
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_Pdrop_calculation(self):
         """Testing 1D-OARO with PressureChangeType.calculated option."""
@@ -1119,7 +1111,6 @@ class TestOsmoticallyAssistedReverseOsmosis:
 
     water_recovery_list = [0.15, 0.2, 0.3, 0.4, 0.5, 0.55]
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.parametrize("water_recovery", water_recovery_list)
     @pytest.mark.component
     def test_water_recovery_sweep(self, water_recovery):


### PR DESCRIPTION
## Fixes/Resolves:
Make WaterTAP compatible with Pyomo 6.7.0.

## Summary/Motivation:
Keeping up with upstream dependencies.

## Changes proposed in this PR:
- Revert requirement `pyomo<6.7`. 832b2eb
- Revert #1146 (NL interface changed in Pyomo/pyomo#3037). 8e1084b
- Change bounds on B_comp for NF0D. This variable was sometimes fixed out-of-bounds which is not compatible with Pyomo 6.7. 14f38d8
- Remove scaling of Expression in cryst_prop_pack (not compatible with Pyomo 6.7). 9496411
- Update small regression values in full treatment train chemical post-treatment and loosen test requirement. Remove IDAES solver requirement from these tests. f04426d
- Update regression values in ASM2D_noPHA and remove custom `bound_push`. Remove IDAES solver requirement for this test. c9d4c98
- Update regression value in OARO1D; remove IDAES solver requirement for these tests. 7b66e15
- Remove `mutable=False` from Params with units. These were always mutable and now Pyomo raises a warning (Pyomo/pyomo#3004). 3d83b60
- New implementation of `scaling_factor` suffix warning suppression from Pyomo's NL writer. 2c73bfa


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
