### PR TITLE
Add influent/effluent quality metrics for ASM1

### DIFF
--- a/watertap/property_models/activated_sludge/asm1_properties.py
+++ b/watertap/property_models/activated_sludge/asm1_properties.py
@@ -148,14 +148,14 @@ class ASM1ParameterData(PhysicalParameterBlock):
             units=pyo.units.dimensionless,
             domain=pyo.PositiveReals,
             doc="Conversion factor applied for TSS calculation",
-        ) 
+        )
         self.BOD5_factor = pyo.Var(
             ["raw", "effluent"],
             initialize={"raw": 0.65, "effluent": 0.25},
             units=pyo.units.dimensionless,
             domain=pyo.PositiveReals,
             doc="Conversion factor for BOD5",
-        ) 
+        )
         # Fix Vars that are treated as Params
         for v in self.component_objects(pyo.Var):
             v.fix()
@@ -396,7 +396,13 @@ class ASM1StateBlockData(StateBlockData):
         )
 
         def _TSS(self):
-            tss = self.conc_mass_comp["X_S"] + self.conc_mass_comp["X_I"] + self.conc_mass_comp["X_BH"] + self.conc_mass_comp["X_BA"] + self.conc_mass_comp["X_P"]
+            tss = (
+                self.conc_mass_comp["X_S"]
+                + self.conc_mass_comp["X_I"]
+                + self.conc_mass_comp["X_BH"]
+                + self.conc_mass_comp["X_BA"]
+                + self.conc_mass_comp["X_P"]
+            )
             return self.params.COD_to_SS * tss
 
         self.TSS = pyo.Expression(
@@ -405,9 +411,14 @@ class ASM1StateBlockData(StateBlockData):
         )
 
         def _BOD5(self, i):
-            bod5 = self.conc_mass_comp["X_S"] + self.conc_mass_comp["X_S"] + (1-self.params.f_p)*(self.conc_mass_comp["X_BH"] + self.conc_mass_comp["X_BA"])
-            #TODO: 0.25 should be a parameter instead as it changes by influent/effluent
-            return self.params.BOD5_factor[i]*bod5
+            bod5 = (
+                self.conc_mass_comp["X_S"]
+                + self.conc_mass_comp["X_S"]
+                + (1 - self.params.f_p)
+                * (self.conc_mass_comp["X_BH"] + self.conc_mass_comp["X_BA"])
+            )
+            # TODO: 0.25 should be a parameter instead as it changes by influent/effluent
+            return self.params.BOD5_factor[i] * bod5
 
         self.BOD5 = pyo.Expression(
             ["raw", "effluent"],
@@ -416,16 +427,33 @@ class ASM1StateBlockData(StateBlockData):
         )
 
         def _COD(self):
-            cod = self.conc_mass_comp["S_S"] + self.conc_mass_comp["S_I"] +  self.conc_mass_comp["X_S"] + self.conc_mass_comp["X_S"] + self.conc_mass_comp["X_I"] + self.conc_mass_comp["X_BH"] + self.conc_mass_comp["X_BA"]+ self.conc_mass_comp["X_P"]
+            cod = (
+                self.conc_mass_comp["S_S"]
+                + self.conc_mass_comp["S_I"]
+                + self.conc_mass_comp["X_S"]
+                + self.conc_mass_comp["X_S"]
+                + self.conc_mass_comp["X_I"]
+                + self.conc_mass_comp["X_BH"]
+                + self.conc_mass_comp["X_BA"]
+                + self.conc_mass_comp["X_P"]
+            )
             return cod
 
         self.COD = pyo.Expression(
             rule=_COD,
             doc="Chemical Oxygen Demand",
         )
-        
+
         def _TKN(self):
-            tkn = self.conc_mass_comp["S_NH"] + self.conc_mass_comp["S_ND"] +  self.conc_mass_comp["X_ND"] + self.params.i_xb * (self.conc_mass_comp["X_BH"] + self.conc_mass_comp["X_BA"]) + self.params.i_xp * (self.conc_mass_comp["X_P"] + self.conc_mass_comp["X_I"])
+            tkn = (
+                self.conc_mass_comp["S_NH"]
+                + self.conc_mass_comp["S_ND"]
+                + self.conc_mass_comp["X_ND"]
+                + self.params.i_xb
+                * (self.conc_mass_comp["X_BH"] + self.conc_mass_comp["X_BA"])
+                + self.params.i_xp
+                * (self.conc_mass_comp["X_P"] + self.conc_mass_comp["X_I"])
+            )
             return tkn
 
         self.TKN = pyo.Expression(
@@ -441,7 +469,6 @@ class ASM1StateBlockData(StateBlockData):
             rule=_Total_N,
             doc="Total Nitrogen",
         )
-
 
         iscale.set_scaling_factor(self.flow_vol, 1e1)
         iscale.set_scaling_factor(self.temperature, 1e-1)

--- a/watertap/property_models/activated_sludge/asm1_reactions.py
+++ b/watertap/property_models/activated_sludge/asm1_reactions.py
@@ -87,25 +87,11 @@ class ASM1ReactionParameterData(ReactionParameterBlock):
             domain=pyo.PositiveReals,
             doc="Yield of cell COD formed per g COD oxidized, Y_H",
         )
-        self.f_p = pyo.Var(
-            initialize=0.08,
-            units=pyo.units.dimensionless,
-            domain=pyo.PositiveReals,
-            doc="Fraction of biomass yielding particulate products, f_p",
-        )
-        self.i_xb = pyo.Var(
-            initialize=0.08,
-            units=pyo.units.dimensionless,
-            domain=pyo.PositiveReals,
-            doc="Mass fraction of N per COD in biomass, i_xb",
-        )
-        self.i_xp = pyo.Var(
-            initialize=0.06,
-            units=pyo.units.dimensionless,
-            domain=pyo.PositiveReals,
-            doc="Mass fraction of N per COD in particulates, i_xp",
-        )
 
+        add_object_reference(self, "f_p", self.config.property_package.f_p)
+        add_object_reference(self, "i_xb", self.config.property_package.i_xb)
+        add_object_reference(self, "i_xp", self.config.property_package.i_xp)
+        
         # Kinetic Parameters
         self.mu_A = pyo.Var(
             initialize=0.5,

--- a/watertap/property_models/activated_sludge/asm1_reactions.py
+++ b/watertap/property_models/activated_sludge/asm1_reactions.py
@@ -91,7 +91,7 @@ class ASM1ReactionParameterData(ReactionParameterBlock):
         add_object_reference(self, "f_p", self.config.property_package.f_p)
         add_object_reference(self, "i_xb", self.config.property_package.i_xb)
         add_object_reference(self, "i_xp", self.config.property_package.i_xp)
-        
+
         # Kinetic Parameters
         self.mu_A = pyo.Var(
             initialize=0.5,

--- a/watertap/property_models/activated_sludge/asm1_reactions.py
+++ b/watertap/property_models/activated_sludge/asm1_reactions.py
@@ -38,7 +38,7 @@ import idaes.logger as idaeslog
 
 
 # Some more information about this module
-__author__ = "Andrew Lee, Xinhong Liu"
+__author__ = "Andrew Lee, Xinhong Liu, Adam Atia"
 
 
 # Set up logger

--- a/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
@@ -161,7 +161,7 @@ class TestStateBlock(object):
                 "X_ND",
             ]
             assert value(model.props[1].conc_mass_comp[i]) == 0.1
-        
+
         assert isinstance(model.props[1].params.f_p, Var)
         assert value(model.props[1].params.f_p) == 0.08
         assert isinstance(model.props[1].params.i_xb, Var)
@@ -336,8 +336,8 @@ class TestStateBlock(object):
     @pytest.mark.unit
     def test_expressions(self, model):
         assert value(model.props[1].TSS) == 0.375
-        assert value(model.props[1].COD) == pytest.approx(0.7999, rel=1e-3)     
+        assert value(model.props[1].COD) == pytest.approx(0.7999, rel=1e-3)
         assert value(model.props[1].BOD5["effluent"]) == 0.096
-        assert value(model.props[1].BOD5["raw"]) == 0.096 *0.65/0.25
+        assert value(model.props[1].BOD5["raw"]) == 0.096 * 0.65 / 0.25
         assert value(model.props[1].TKN) == pytest.approx(0.328, rel=1e-3)
         assert value(model.props[1].Total_N) == pytest.approx(0.428, rel=1e-3)

--- a/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
@@ -11,7 +11,7 @@
 #################################################################################
 """
 Tests for ASM1 thermo property package.
-Authors: Andrew Lee
+Authors: Andrew Lee, Adam Atia
 """
 
 import pytest
@@ -320,3 +320,11 @@ class TestStateBlock(object):
     @pytest.mark.unit
     def check_units(self, model):
         assert_units_consistent(model)
+
+    @pytest.mark.unit
+    def test_expressions(self, model):
+        assert value(model.props[1].TSS) == 0.375
+        assert value(model.props[1].COD) == pytest.approx(0.7999, rel=1e-3)     
+        assert value(model.props[1].BOD5) == 0.096
+        assert value(model.props[1].TKN) == pytest.approx(0.328, rel=1e-3)
+        assert value(model.props[1].Total_N) == pytest.approx(0.428, rel=1e-3)

--- a/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
@@ -161,6 +161,18 @@ class TestStateBlock(object):
                 "X_ND",
             ]
             assert value(model.props[1].conc_mass_comp[i]) == 0.1
+        
+        assert isinstance(model.props[1].params.f_p, Var)
+        assert value(model.props[1].params.f_p) == 0.08
+        assert isinstance(model.props[1].params.i_xb, Var)
+        assert value(model.props[1].params.i_xb) == 0.08
+        assert isinstance(model.props[1].params.i_xp, Var)
+        assert value(model.props[1].params.i_xp) == 0.06
+        assert isinstance(model.props[1].params.COD_to_SS, Var)
+        assert value(model.props[1].params.COD_to_SS) == 0.75
+        assert isinstance(model.props[1].params.BOD5_factor, Var)
+        assert value(model.props[1].params.BOD5_factor["raw"]) == 0.65
+        assert value(model.props[1].params.BOD5_factor["effluent"]) == 0.25
 
         assert isinstance(model.props[1].material_flow_expression, Expression)
         for j in model.params.component_list:
@@ -325,6 +337,7 @@ class TestStateBlock(object):
     def test_expressions(self, model):
         assert value(model.props[1].TSS) == 0.375
         assert value(model.props[1].COD) == pytest.approx(0.7999, rel=1e-3)     
-        assert value(model.props[1].BOD5) == 0.096
+        assert value(model.props[1].BOD5["effluent"]) == 0.096
+        assert value(model.props[1].BOD5["raw"]) == 0.096 *0.65/0.25
         assert value(model.props[1].TKN) == pytest.approx(0.328, rel=1e-3)
         assert value(model.props[1].Total_N) == pytest.approx(0.428, rel=1e-3)

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -39,7 +39,6 @@ from idaes.core.util.model_statistics import (
     number_variables,
     number_total_constraints,
     number_unused_variables,
-    unused_variables_set,
 )
 import idaes.core.util.scaling as iscale
 from idaes.core.util.testing import (

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -39,6 +39,7 @@ from idaes.core.util.model_statistics import (
     number_variables,
     number_total_constraints,
     number_unused_variables,
+    unused_variables_set,
 )
 import idaes.core.util.scaling as iscale
 from idaes.core.util.testing import (
@@ -187,9 +188,9 @@ class TestDu(object):
         assert hasattr(du.fs.unit.overflow, "pressure")
         assert hasattr(du.fs.unit.overflow, "alkalinity")
 
-        assert number_variables(du) == 79
+        assert number_variables(du) == 85
         assert number_total_constraints(du) == 62
-        assert number_unused_variables(du) == 0
+        assert number_unused_variables(du) == 6
 
     @pytest.mark.unit
     def test_dof(self, du):

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -176,9 +176,9 @@ class TestThickASM1(object):
         assert hasattr(tu.fs.unit.overflow, "pressure")
         assert hasattr(tu.fs.unit.overflow, "alkalinity")
 
-        assert number_variables(tu) == 81
+        assert number_variables(tu) == 87
         assert number_total_constraints(tu) == 63
-        assert number_unused_variables(tu) == 0
+        assert number_unused_variables(tu) == 6
 
     @pytest.mark.unit
     def test_dof(self, tu):

--- a/watertap/unit_models/translators/tests/test_translator_adm1_asm1.py
+++ b/watertap/unit_models/translators/tests/test_translator_adm1_asm1.py
@@ -91,9 +91,9 @@ def test_config():
 
 
 # -----------------------------------------------------------------------------
-class TestAsm1Adm1(object):
+class TestAdm1Asm1(object):
     @pytest.fixture(scope="class")
-    def asmadm(self):
+    def admasm(self):
         m = ConcreteModel()
 
         m.fs = FlowsheetBlock(dynamic=False)
@@ -153,111 +153,110 @@ class TestAsm1Adm1(object):
 
     @pytest.mark.build
     @pytest.mark.unit
-    def test_build(self, asmadm):
+    def test_build(self, admasm):
 
-        assert hasattr(asmadm.fs.unit, "inlet")
-        assert len(asmadm.fs.unit.inlet.vars) == 6
-        assert hasattr(asmadm.fs.unit.inlet, "flow_vol")
-        assert hasattr(asmadm.fs.unit.inlet, "conc_mass_comp")
-        assert hasattr(asmadm.fs.unit.inlet, "temperature")
-        assert hasattr(asmadm.fs.unit.inlet, "pressure")
-        assert hasattr(asmadm.fs.unit.inlet, "anions")
-        assert hasattr(asmadm.fs.unit.inlet, "cations")
+        assert hasattr(admasm.fs.unit, "inlet")
+        assert len(admasm.fs.unit.inlet.vars) == 6
+        assert hasattr(admasm.fs.unit.inlet, "flow_vol")
+        assert hasattr(admasm.fs.unit.inlet, "conc_mass_comp")
+        assert hasattr(admasm.fs.unit.inlet, "temperature")
+        assert hasattr(admasm.fs.unit.inlet, "pressure")
+        assert hasattr(admasm.fs.unit.inlet, "anions")
+        assert hasattr(admasm.fs.unit.inlet, "cations")
 
-        assert hasattr(asmadm.fs.unit, "outlet")
-        assert len(asmadm.fs.unit.outlet.vars) == 5
-        assert hasattr(asmadm.fs.unit.outlet, "flow_vol")
-        assert hasattr(asmadm.fs.unit.outlet, "conc_mass_comp")
-        assert hasattr(asmadm.fs.unit.outlet, "temperature")
-        assert hasattr(asmadm.fs.unit.outlet, "pressure")
-        assert hasattr(asmadm.fs.unit.outlet, "alkalinity")
+        assert hasattr(admasm.fs.unit, "outlet")
+        assert len(admasm.fs.unit.outlet.vars) == 5
+        assert hasattr(admasm.fs.unit.outlet, "flow_vol")
+        assert hasattr(admasm.fs.unit.outlet, "conc_mass_comp")
+        assert hasattr(admasm.fs.unit.outlet, "temperature")
+        assert hasattr(admasm.fs.unit.outlet, "pressure")
+        assert hasattr(admasm.fs.unit.outlet, "alkalinity")
 
-        assert number_variables(asmadm) == 132
-        assert number_total_constraints(asmadm) == 16
-
-        assert number_unused_variables(asmadm.fs.unit) == 4
+        assert number_variables(admasm) == 138
+        assert number_total_constraints(admasm) == 16
+        assert number_unused_variables(admasm.fs.unit) == 4
 
     @pytest.mark.component
-    def test_units(self, asmadm):
-        assert_units_consistent(asmadm)
+    def test_units(self, admasm):
+        assert_units_consistent(admasm)
 
     @pytest.mark.unit
-    def test_dof(self, asmadm):
-        assert degrees_of_freedom(asmadm) == 0
+    def test_dof(self, admasm):
+        assert degrees_of_freedom(admasm) == 0
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
-    def test_initialize(self, asmadm):
-        initialization_tester(asmadm)
+    def test_initialize(self, admasm):
+        initialization_tester(admasm)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
-    def test_solve(self, asmadm):
+    def test_solve(self, admasm):
         solver = get_solver()
-        results = solver.solve(asmadm)
+        results = solver.solve(admasm)
         assert_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
-    def test_solution(self, asmadm):
+    def test_solution(self, admasm):
         assert pytest.approx(101325.0, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.pressure[0]
+            admasm.fs.unit.outlet.pressure[0]
         )
         assert pytest.approx(308.15, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.temperature[0]
+            admasm.fs.unit.outlet.temperature[0]
         )
         assert pytest.approx(0.1308, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "S_I"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "S_I"]
         )
         assert pytest.approx(0.2585, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "S_S"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "S_S"]
         )
         assert pytest.approx(17.216, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "X_I"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "X_I"]
         )
         assert pytest.approx(3.2375, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "X_S"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "X_S"]
         )
         assert pytest.approx(1e-10, abs=1e-6) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "X_BH"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "X_BH"]
         )
         assert pytest.approx(1e-10, abs=1e-6) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "X_BA"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "X_BA"]
         )
         assert pytest.approx(1e-10, abs=1e-6) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "X_P"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "X_P"]
         )
         assert pytest.approx(1e-10, abs=1e-6) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "S_O"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "S_O"]
         )
         assert pytest.approx(1e-10, abs=1e-6) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "S_NO"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "S_NO"]
         )
         assert pytest.approx(1.322, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "S_NH"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "S_NH"]
         )
         assert pytest.approx(0.00839, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "S_ND"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "S_ND"]
         )
         assert pytest.approx(0.251, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.conc_mass_comp[0, "X_ND"]
+            admasm.fs.unit.outlet.conc_mass_comp[0, "X_ND"]
         )
         assert pytest.approx(0.095061, rel=1e-3) == value(
-            asmadm.fs.unit.outlet.alkalinity[0]
+            admasm.fs.unit.outlet.alkalinity[0]
         )
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
-    def test_conservation(self, asmadm):
+    def test_conservation(self, admasm):
         assert (
             abs(
                 value(
-                    asmadm.fs.unit.inlet.flow_vol[0] * asmadm.fs.props_ADM1.dens_mass
-                    - asmadm.fs.unit.outlet.flow_vol[0] * asmadm.fs.props_ASM1.dens_mass
+                    admasm.fs.unit.inlet.flow_vol[0] * admasm.fs.props_ADM1.dens_mass
+                    - admasm.fs.unit.outlet.flow_vol[0] * admasm.fs.props_ASM1.dens_mass
                 )
             )
             <= 1e-6
@@ -267,21 +266,21 @@ class TestAsm1Adm1(object):
             abs(
                 value(
                     (
-                        asmadm.fs.unit.inlet.flow_vol[0]
-                        * asmadm.fs.props_ADM1.dens_mass
-                        * asmadm.fs.props_ADM1.cp_mass
+                        admasm.fs.unit.inlet.flow_vol[0]
+                        * admasm.fs.props_ADM1.dens_mass
+                        * admasm.fs.props_ADM1.cp_mass
                         * (
-                            asmadm.fs.unit.inlet.temperature[0]
-                            - asmadm.fs.props_ADM1.temperature_ref
+                            admasm.fs.unit.inlet.temperature[0]
+                            - admasm.fs.props_ADM1.temperature_ref
                         )
                     )
                     - (
-                        asmadm.fs.unit.outlet.flow_vol[0]
-                        * asmadm.fs.props_ASM1.dens_mass
-                        * asmadm.fs.props_ASM1.cp_mass
+                        admasm.fs.unit.outlet.flow_vol[0]
+                        * admasm.fs.props_ASM1.dens_mass
+                        * admasm.fs.props_ASM1.cp_mass
                         * (
-                            asmadm.fs.unit.outlet.temperature[0]
-                            - asmadm.fs.props_ASM1.temperature_ref
+                            admasm.fs.unit.outlet.temperature[0]
+                            - admasm.fs.props_ASM1.temperature_ref
                         )
                     )
                 )

--- a/watertap/unit_models/translators/tests/test_translator_asm1_adm1.py
+++ b/watertap/unit_models/translators/tests/test_translator_asm1_adm1.py
@@ -164,7 +164,7 @@ class TestAsm1Adm1(object):
         assert hasattr(asmadm.fs.unit.outlet, "anions")
         assert hasattr(asmadm.fs.unit.outlet, "cations")
 
-        assert number_variables(asmadm) == 137
+        assert number_variables(asmadm) == 143
         assert number_total_constraints(asmadm) == 34
 
         assert number_unused_variables(asmadm.fs.unit) == 0


### PR DESCRIPTION
## Fixes/Resolves:
## Summary/Motivation:
This PR adds quality metrics to ASM1 which can be used to evaluate WWTP performance and should be useful for optimization cases. Said metrics/properties can now be calculated for any ASM1 stateblock.

## Changes proposed in this PR:
- add TSS
- add BOD5- note- this is the only one indexed by "raw" or "effluent", each of which incorporate a different conversion factor
- add COD
- add Kjeldahl nitrogen
- add total nitrogen
- add associated params as needed and move a couple params from ASM1 rxn to prop model

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.

