### PR TITLE
Fix Binder IDAES solver configuration and Jupyter documentation

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,2 +1,3 @@
 set -e
 idaes get-extensions --verbose --distro ubuntu2204
+python -c "import idaes; from pyomo.environ import SolverFactory as S; print(S('ipopt').executable())"

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,2 +1,2 @@
 set -e
-idaes get-extensions --verbose --distro ubuntu1804
+idaes get-extensions --verbose --distro ubuntu2204

--- a/docs/how_to_guides/notebooks.rst
+++ b/docs/how_to_guides/notebooks.rst
@@ -22,7 +22,7 @@ Local (developer) installation
 
    .. code-block:: shell
 
-      python -m ipykernel --user --name "watertap-dev"
+      python -m ipykernel install --user --name "watertap-dev"
 
 #. Then, start the Jupyter server from the current directory, navigate to the desired notebook using the file browser, and launch it
 


### PR DESCRIPTION
## Summary/Motivation

- `idaes get-extensions` command in `.binder/postBuild` was outdated after Binder updated their base image to Ubuntu 22.04. This caused solvers not to be available when running in a Binder container
- The `ipykernel` command in the Jupyter how-to guide in the Sphinx docs was found to be incorrect (it was `python -m ipykernel --user ...` while it should have been `python -m ipykernel install --user ...`)

## Changes proposed in this PR:
- Fix `ipykernel` command in Jupyter how-to guide in the Sphinx docs
- Change `--distro` from `ubuntu1804` to `ubuntu2204`
- Add command to verify that `ipopt` is available during Binder image build

These fixes can be tested interactively by using this Binder link: https://mybinder.org/v2/gh/lbianchi-lbl/watertap/nb-fixes.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
