### PR TITLE
fix deprecation warnings in water and seawater prop packs

### DIFF
--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -749,9 +749,6 @@ class SeawaterParameterData(PhysicalParameterBlock):
                 "cp_mass_phase": {"method": "_cp_mass_phase"},
                 "therm_cond_phase": {"method": "_therm_cond_phase"},
                 "diffus_phase_comp": {"method": "_diffus_phase_comp"},
-                "boiling_point_elevation_phase": {
-                    "method": "_boiling_point_elevation_phase"
-                },
             }
         )
 
@@ -761,6 +758,9 @@ class SeawaterParameterData(PhysicalParameterBlock):
                 "osm_coeff": {"method": "_osm_coeff"},
                 "enth_flow": {"method": "_enth_flow"},
                 "dh_vap_mass": {"method": "_dh_vap_mass"},
+                "boiling_point_elevation_phase": {
+                    "method": "_boiling_point_elevation_phase"
+                },
             }
         )
 

--- a/watertap/property_models/water_prop_pack.py
+++ b/watertap/property_models/water_prop_pack.py
@@ -450,7 +450,6 @@ class WaterParameterData(PhysicalParameterBlock):
                 "mole_frac_phase_comp": {"method": "_mole_frac_phase_comp"},
                 "pressure_sat": {"method": "_pressure_sat"},
                 "enth_mass_phase": {"method": "_enth_mass_phase"},
-                "enth_flow_phase": {"method": "_enth_flow_phase"},
                 "cp_mass_phase": {"method": "_cp_mass_phase"},
                 "visc_d_phase": {"method": "_visc_d_phase"},
                 "therm_cond_phase": {"method": "_therm_cond_phase"},
@@ -460,6 +459,7 @@ class WaterParameterData(PhysicalParameterBlock):
         obj.define_custom_properties(
             {
                 "dh_vap_mass": {"method": "_dh_vap_mass"},
+                "enth_flow_phase": {"method": "_enth_flow_phase"},
             }
         )
 


### PR DESCRIPTION
## Fixes/Resolves:
Fixes #1274
## Summary/Motivation:
This fix addresses the deprecation warning for the boiling_point_elevation_phase in the seawater_prop_pack by removing it from add_properties() and adding it to define_custom_properties() when defining the metadata. (as stated in the warning)

EDIT: This also addresses the same warning in the water_prop_pack for `enth_flow_phase`.
## Changes proposed in this PR:
- change the method used to add the property to the metadata
### Legal Acknowledgement
By contributing to this software project, I agree to the following terms and conditions for my contribution:
1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.