### PR TITLE
Use MultiChoiceCostingBlock in dye_desalination_withRO

### DIFF
--- a/watertap/costing/multiple_choice_costing_block.py
+++ b/watertap/costing/multiple_choice_costing_block.py
@@ -14,6 +14,7 @@ import pyomo.environ as pyo
 from pyomo.common.config import ConfigBlock, ConfigValue
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from idaes.core import declare_process_block_class, ProcessBlockData, UnitModelBlockData
+from idaes.core.base.process_base import ProcessBaseBlock
 from idaes.core.util.misc import add_object_reference
 from idaes.core.base.costing_base import (
     UnitModelCostingBlockData,
@@ -100,7 +101,7 @@ class MultiUnitModelCostingBlockData(UnitModelCostingBlockData, UnitModelCosting
         add_object_reference(self, "costing_package", fcb)
         add_object_reference(self, "unit_model", unit_model)
 
-        self.costing_blocks = pyo.Block(self.config.costing_blocks)
+        self.costing_blocks = ProcessBaseBlock(self.config.costing_blocks)
         self.costing_block_selector = pyo.Param(
             self.config.costing_blocks, domain=pyo.Boolean, default=0, mutable=True
         )

--- a/watertap/costing/multiple_choice_costing_block.py
+++ b/watertap/costing/multiple_choice_costing_block.py
@@ -14,7 +14,6 @@ import pyomo.environ as pyo
 from pyomo.common.config import ConfigBlock, ConfigValue
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from idaes.core import declare_process_block_class, ProcessBlockData, UnitModelBlockData
-from idaes.core.base.process_base import ProcessBaseBlock
 from idaes.core.util.misc import add_object_reference
 from idaes.core.base.costing_base import (
     UnitModelCostingBlockData,
@@ -101,7 +100,7 @@ class MultiUnitModelCostingBlockData(UnitModelCostingBlockData, UnitModelCosting
         add_object_reference(self, "costing_package", fcb)
         add_object_reference(self, "unit_model", unit_model)
 
-        self.costing_blocks = ProcessBaseBlock(self.config.costing_blocks)
+        self.costing_blocks = pyo.Block(self.config.costing_blocks)
         self.costing_block_selector = pyo.Param(
             self.config.costing_blocks, domain=pyo.Boolean, default=0, mutable=True
         )

--- a/watertap/costing/tests/test_multiple_choice_costing_block.py
+++ b/watertap/costing/tests/test_multiple_choice_costing_block.py
@@ -173,6 +173,7 @@ def setup_flowsheet():
     )
 
     def my_own_reverse_osmosis_costing(blk):
+        flowsheet = blk.flowsheet()
         blk.variable_operating_cost = pyo.Var(
             initialize=42,
             units=blk.costing_package.base_currency / blk.costing_package.base_period,

--- a/watertap/costing/tests/test_multiple_choice_costing_block.py
+++ b/watertap/costing/tests/test_multiple_choice_costing_block.py
@@ -12,7 +12,6 @@
 
 import pytest
 
-import os
 import re
 
 import pyomo.environ as pyo
@@ -26,10 +25,9 @@ from watertap.unit_models.reverse_osmosis_0D import (
     MassTransferCoefficient,
     PressureChangeType,
 )
-from watertap.costing import WaterTAPCosting, ROType
+from watertap.costing import WaterTAPCosting
 from watertap.costing.unit_models.reverse_osmosis import (
     cost_reverse_osmosis,
-    cost_high_pressure_reverse_osmosis,
 )
 
 

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
@@ -56,6 +56,7 @@ from watertap.unit_models.reverse_osmosis_0D import (
 from watertap.costing.unit_models.dewatering import (
     cost_centrifuge,
 )
+from watertap.costing import MultiUnitModelCostingBlock
 
 from watertap.core.wt_database import Database
 import watertap.core.zero_order_properties as prop_ZO
@@ -476,30 +477,24 @@ def add_costing(m):
         flowsheet_costing_block=m.fs.zo_costing
     )
 
-    # TODO: Use MultiUnitModelCostingBlock
     if hasattr(m.fs, "dewaterer"):
-        # m.fs.dewaterer.costing = MultiUnitModelCostingBlock(
-        #     flowsheet_costing_block=m.fs.ro_costing,
-        #     costing_blocks={
-        #         "centrifuge": {
-        #             "costing_method": cost_centrifuge,
-        #             "costing_method_arguments": {"cost_electricity_flow": False},
-        #         },
-        #         "filter_belt_press": {
-        #             "costing_method": cost_filter_belt_press,
-        #             "costing_method_arguments": {"cost_electricity_flow": False},
-        #         },
-        #         "filter_plate_press": {
-        #             "costing_method": cost_filter_plate_press,
-        #             "costing_method_arguments": {"cost_electricity_flow": False},
-        #         },
-        #     },
-        #     initial_costing_block="centrifuge",
-        # )
-        m.fs.dewaterer.costing = UnitModelCostingBlock(
+        m.fs.dewaterer.costing = MultiUnitModelCostingBlock(
             flowsheet_costing_block=m.fs.ro_costing,
-            costing_method=cost_centrifuge,
-            costing_method_arguments={"cost_electricity_flow": False},
+            costing_blocks={
+                "centrifuge": {
+                    "costing_method": cost_centrifuge,
+                    "costing_method_arguments": {"cost_electricity_flow": False},
+                },
+                "filter_belt_press": {
+                    "costing_method": cost_filter_belt_press,
+                    "costing_method_arguments": {"cost_electricity_flow": False},
+                },
+                "filter_plate_press": {
+                    "costing_method": cost_filter_plate_press,
+                    "costing_method_arguments": {"cost_electricity_flow": False},
+                },
+            },
+            initial_costing_block="centrifuge",
         )
     else:
         pass

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
@@ -55,6 +55,8 @@ from watertap.unit_models.reverse_osmosis_0D import (
 )
 from watertap.costing.unit_models.dewatering import (
     cost_centrifuge,
+    cost_filter_belt_press,
+    cost_filter_plate_press,
 )
 from watertap.costing import MultiUnitModelCostingBlock
 
@@ -74,7 +76,7 @@ _log = idaeslog.getLogger(__name__)
 
 
 def main():
-    m = build(include_pretreatment=False, include_dewatering=False)
+    m = build(include_pretreatment=False, include_dewatering=True)
     set_operating_conditions(m)
 
     assert_degrees_of_freedom(m, 0)


### PR DESCRIPTION
## Fixes #1285 

## Summary/Motivation:
@MarcusHolly identified a bug in the `MultiUnitModelCostingBlock`. This PR addresses the bug, adds a unit test for the bug, and verifies that the code which identified the bug works correctly after the fix.

## Changes proposed in this PR:
- Fix bug in `MultiUnitModelCostingBlock` (3e3f0bc)
- Add unit test which fails with bug (3fb839c3f22282eabbef083e524167c3c23a0510)
- Uncomment commented code in dye desalination with RO (bf38c19, 61154cc)
- Add missing ```__init__.py``` in a test directory (was not picked up "user mode" tests) (f3893b2, b1d5a15)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
