### PR TITLE
In the UI export, allow output variables (which may not exist pre-solve) to be marked as 'deferred'

### DIFF
--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -87,11 +87,7 @@ class ModelExport(BaseModel):
     Note that it makes no sense to use both attributes at the same time.
     """
 
-    _SupportedObjType = Union[
-        pyo.Var,
-        pyo.Expression,
-        pyo.Param
-    ]
+    _SupportedObjType = Union[pyo.Var, pyo.Expression, pyo.Param]
     "Used for type hints and as a shorthand in error messages (i.e. not for runtime checks)"
 
     # TODO: if Optional[_SupportedObjType] is used for the `obj` type hint,
@@ -146,7 +142,7 @@ class ModelExport(BaseModel):
 
     @staticmethod
     def _get_obj(values):
-        return values.get('obj', None)
+        return values.get("obj", None)
 
     # NOTE: IMPORTANT: all validators used to set a dynamic default value
     # should have the `always=True` option, or the validator won't be called
@@ -207,7 +203,7 @@ class ModelExport(BaseModel):
         if v is None:
             obj = cls._get_obj(values)
             if obj is None:
-                v = values.get('deferred_obj')  # must be one or the other
+                v = values.get("deferred_obj")  # must be one or the other
             else:
                 v = str(obj)
         return v
@@ -390,7 +386,7 @@ class FlowsheetExport(BaseModel):
         """Handle potentially 'deferred' objects.
         These are stored in a different attribute, and the actual object is populated later.
         """
-        if d.get('deferred_obj', None) is not None:
+        if d.get("deferred_obj", None) is not None:
             self._deferred += 1
 
     def _has_deferred(self):
@@ -510,7 +506,7 @@ class FlowsheetExport(BaseModel):
         return obj
 
     @staticmethod
-    def _parse_units_text(text:str) -> Any:
+    def _parse_units_text(text: str) -> Any:
         """Parse Pyomo units provided as text.
 
         Whitespace is stripped before processing.
@@ -559,9 +555,9 @@ class FlowsheetExport(BaseModel):
         if v == "false":
             return False
         raise ValueError(
-                f"Bad boolean value '{value}' for '{name} ({v})': "
-                f"must be 'true' or 'false' (case-insensitive)"
-            )
+            f"Bad boolean value '{value}' for '{name} ({v})': "
+            f"must be 'true' or 'false' (case-insensitive)"
+        )
 
     def to_csv(self, output: Union[TextIOBase, Path, str] = None) -> int:
         """Write wrapped objects as CSV.
@@ -1042,7 +1038,9 @@ class FlowsheetInterface:
             mo.value = pyo.value(u.convert(mo.obj, to_units=mo.ui_units))
             if hasattr(mo.obj, "bounds"):
                 if _log.isEnabledFor(logging.DEBUG):
-                    _log.debug(f"export.bounds key={key} value={mo.value} obj.value={mo.obj.value}")
+                    _log.debug(
+                        f"export.bounds key={key} value={mo.value} obj.value={mo.obj.value}"
+                    )
                 if mo.obj.ub is None:
                     mo.ub = mo.obj.ub
                 else:

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -29,7 +29,6 @@ import inspect
 import logging
 from pathlib import Path
 import re
-from traceback import print_last
 from typing import Any, Callable, List, Optional, Dict, Union, TypeVar
 from types import ModuleType
 

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -93,7 +93,9 @@ class ModelExport(BaseModel):
     # TODO: if Optional[_SupportedObjType] is used for the `obj` type hint,
     # pydantic will run the runtime instance check which is not what we want
     # (as we want/need to use the pyomo is_xxx_type() methods instead)
-    # so we're using Optional[object] unless we find a way to tell pydantic to skip this check
+    # so we're using Optional[object] unless we find a way to tell pydantic to
+    # skip this check.
+
     # inputs
     obj: Optional[object] = Field(default=None, exclude=True)
     deferred_obj: Optional[str] = Field(default=None, exclude=True)

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -789,7 +789,6 @@ class FlowsheetInterface:
             result = self.run_action(Actions.solve, **kwargs)
         except Exception as err:
             raise RuntimeError(f"Solving flowsheet: {err}") from err
-        self.fs_exp.undefer(self.fs_exp.m.fs)
         return result
 
     def get_diagram(self, **kwargs):
@@ -976,6 +975,7 @@ class FlowsheetInterface:
                         raise RuntimeError(f"Solve failed: {result}")
             # Sync model with exported values
             if action_name in (Actions.build, Actions.solve):
+                self.fs_exp.undefer(self.fs_exp.m.fs)  # ensure all vars exported
                 self.export_values()
             return result
 

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -66,7 +66,26 @@ class UnsupportedObjType(TypeError):
 
 
 class ModelExport(BaseModel):
-    """A variable, expression, or parameter."""
+    """A variable, expression, or parameter.
+
+    The object may be passed as a valid Pyomo model component with the 'obj' attribute
+    or, if it may not exist yet in the flowsheet until after solving the model, as a
+    string with the 'deferred_obj'. An example of using deferred_obj is shown below::
+
+        exports.add(
+            deferred_obj="fs.leach.solid_outlet.flow_mass[0]",
+            name="solid flow mass",
+            rounding=4,
+            ui_units=pyo.units.kg/pyo.units.hour,
+            display_units="kg/hr",
+            description="solid flow mass",
+            is_input=False,
+            is_output=True,
+            output_category="solids"
+        )
+
+    Note that it makes no sense to use both attributes at the same time.
+    """
 
     _SupportedObjType = Union[
         pyo.Var,

--- a/watertap/ui/fsapi.py
+++ b/watertap/ui/fsapi.py
@@ -482,6 +482,7 @@ class FlowsheetExport(BaseModel):
         Raises:
             ValueError, if the object named by 'text' could not be found
         """
+        _log.debug(f"eval text={text}")
         try:
             obj = eval(text, {"fs": flowsheet})
         except Exception as err:
@@ -1014,11 +1015,15 @@ class FlowsheetInterface:
         u = pyo.units
         self.fs_exp.dof = degrees_of_freedom(self.fs_exp.obj)
         for key, mo in self.fs_exp.model_objects.items():
-            _log.debug(f"convert units for export: obj={mo.obj} to_units={mo.ui_units}")
+            _log.debug(f"export values obj key={key}")
+            if mo.obj is None:
+                _log.debug(f"export values skip (obj is None)")
+                continue
+            _log.debug(f"export.units obj={mo.obj} to_units={mo.ui_units}")
             mo.value = pyo.value(u.convert(mo.obj, to_units=mo.ui_units))
-            # print(f'{key} is being set to: {mo.value}')
             if hasattr(mo.obj, "bounds"):
-                # print(f'{key} is being set to: {mo.value} from {mo.obj.value}')
+                if _log.isEnabledFor(logging.DEBUG):
+                    _log.debug(f"export.bounds key={key} value={mo.value} obj.value={mo.obj.value}")
                 if mo.obj.ub is None:
                     mo.ub = mo.obj.ub
                 else:

--- a/watertap/ui/tests/test_flowsheet_interfaces.py
+++ b/watertap/ui/tests/test_flowsheet_interfaces.py
@@ -106,14 +106,14 @@ def test_roundtrip_with_garbage_collection(fs_interface, n_times):
         fs_interface.load(data)
         gc.collect()
 
+
 # -----------------------------------------------------------------
 #  Tests to cover various UI export features
 # -----------------------------------------------------------------
 
 
 def flash_flowsheet():
-    """Very simple flowsheet for testing.
-    """
+    """Very simple flowsheet for testing."""
     m = ConcreteModel()
     m.fs = FlowsheetBlock(dynamic=False)
     # Flash properties
@@ -141,7 +141,7 @@ def flash_flowsheet_interface():
         do_build=_build_flash,
         do_solve=_solve_flash,
         get_diagram=_get_diagram,
-        requires_idaes_solver=True
+        requires_idaes_solver=True,
     )
     return fi
 
@@ -169,7 +169,7 @@ def _export_flash(flowsheet=None, exports=None, **kwargs):
         description="Flash inlet",
         is_output=False,
         is_input=True,
-        input_category="Flash"
+        input_category="Flash",
     )
     # export a 'deferred' output
     exports.add(
@@ -180,7 +180,7 @@ def _export_flash(flowsheet=None, exports=None, **kwargs):
         description="Flash vapor outlet temperature",
         is_output=True,
         is_input=False,
-        output_category="Flash"
+        output_category="Flash",
     )
 
 
@@ -197,4 +197,3 @@ def _solve_flash(flowsheet=None):
 
 def _get_diagram():
     return "NULL"
-

--- a/watertap/ui/tests/test_flowsheet_interfaces.py
+++ b/watertap/ui/tests/test_flowsheet_interfaces.py
@@ -23,7 +23,7 @@ from idaes.core import FlowsheetBlock
 from idaes.models.properties.activity_coeff_models.BTX_activity_coeff_VLE import (
     BTXParameterBlock,
 )
-from idaes.models.unit_models import Flash, Mixer
+from idaes.models.unit_models import Flash
 
 from ..fsapi import FlowsheetInterface
 

--- a/watertap/ui/tests/test_flowsheet_interfaces.py
+++ b/watertap/ui/tests/test_flowsheet_interfaces.py
@@ -17,6 +17,13 @@ import gc
 
 import pytest
 from pyomo.environ import assert_optimal_termination
+import numpy as np
+from pyomo.environ import ConcreteModel, SolverFactory, units
+from idaes.core import FlowsheetBlock
+from idaes.models.properties.activity_coeff_models.BTX_activity_coeff_VLE import (
+    BTXParameterBlock,
+)
+from idaes.models.unit_models import Flash, Mixer
 
 from ..fsapi import FlowsheetInterface
 
@@ -27,10 +34,10 @@ def fs_interface(request) -> FlowsheetInterface:
     fs_exp = fs_interface.fs_exp
 
     markers_to_apply = []
-    # with this parametrization setup, ``request`` will be a SubRequest
-    # if we use request.applymarker(), the marker will be applied to the entire class
-    # using _parent_request (unfortunately private API) lets us target more precisely
-    # a single (test_function, param_value) combination
+    # With this parametrization setup, ``request`` will be a SubRequest.
+    # If we use request.applymarker(), the marker will be applied to the entire class.
+    # Using _parent_request (unfortunately private API) lets us target more precisely
+    # a single (test_function, param_value) combination.
     request_where_marker_should_be_applied = request._parent_request
 
     if fs_exp.requires_idaes_solver:
@@ -45,10 +52,12 @@ def fs_interface(request) -> FlowsheetInterface:
 def pytest_generate_tests(metafunc):
     if "fs_interface" in metafunc.fixturenames:
         by_name = dict(FlowsheetInterface.from_installed_packages())
-        # NOTE: with ``scope="class"``, a fresh, separate fixture instance will be created:
+        # NOTE: with ``scope="class"``, a fresh, separate fixture
+        # instance will be created:
         # - for each standalone (i.e. module-level) test function,
-        # - for each test class, once by the first test method in the class that requests it
-        # as a consequence, this means that all test methods within a test class operate on the same object
+        # - for each test class, once by the first test method in
+        #   the class that requests it
+        # thus, all test methods within a test class operate on the same object
         metafunc.parametrize(
             "fs_interface",
             list(by_name.values()),
@@ -96,3 +105,96 @@ def test_roundtrip_with_garbage_collection(fs_interface, n_times):
         data = fs_interface.dict()
         fs_interface.load(data)
         gc.collect()
+
+# -----------------------------------------------------------------
+#  Tests to cover various UI export features
+# -----------------------------------------------------------------
+
+
+def flash_flowsheet():
+    """Very simple flowsheet for testing.
+    """
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+    # Flash properties
+    m.fs.properties = BTXParameterBlock(
+        valid_phase=("Liq", "Vap"), activity_coeff_model="Ideal", state_vars="FTPz"
+    )
+    # Flash unit
+    m.fs.flash = Flash(property_package=m.fs.properties)
+    m.fs.flash.inlet.flow_mol.fix(1)
+    m.fs.flash.inlet.temperature.fix(0)
+    m.fs.flash.inlet.pressure[:].set_value(np.nan, True)
+    m.fs.flash.inlet.pressure.fix(100)
+    m.fs.flash.inlet.mole_frac_comp[0, "benzene"].fix(0.5)
+    m.fs.flash.inlet.mole_frac_comp[0, "toluene"].fix(0.5)
+    m.fs.flash.heat_duty.fix(0)
+    m.fs.flash.deltaP.fix(0)
+    return m
+
+
+@pytest.fixture(scope="module")
+def flash_flowsheet_interface():
+    fi = FlowsheetInterface(
+        name="test_flash",
+        do_export=_export_flash,
+        do_build=_build_flash,
+        do_solve=_solve_flash,
+        get_diagram=_get_diagram,
+        requires_idaes_solver=True
+    )
+    return fi
+
+
+def test_flash_flowsheet_interface(flash_flowsheet_interface):
+    fi = flash_flowsheet_interface
+    print("build flash flowsheet")
+    fi.build()
+    print("solve flash flowsheet")
+    fi.solve()
+    print("get flash flowsheet contents")
+    data = fi.fs_exp.json()
+    assert data
+    print(f"flash flowsheet contents:\n{data}")
+
+
+def _export_flash(flowsheet=None, exports=None, **kwargs):
+    flash = flowsheet.flash
+    # export an input
+    exports.add(
+        obj=flash.inlet.pressure[0],
+        ui_units=units.Pa,
+        display_units="Pascals",
+        rounding=2,
+        description="Flash inlet",
+        is_output=False,
+        is_input=True,
+        input_category="Flash"
+    )
+    # export a 'deferred' output
+    exports.add(
+        deferred_obj="fs.flash.vap_outlet.temperature[0]",
+        ui_units=units.K,
+        display_units="Kelvin",
+        rounding=2,
+        description="Flash vapor outlet temperature",
+        is_output=True,
+        is_input=False,
+        output_category="Flash"
+    )
+
+
+def _build_flash(**kwargs):
+    m = flash_flowsheet()
+    m.fs.flash.initialize()
+    return m
+
+
+def _solve_flash(flowsheet=None):
+    solver = SolverFactory("ipopt")
+    return solver.solve(flowsheet)
+
+
+def _get_diagram():
+    return "NULL"
+

--- a/watertap/ui/tests/test_flowsheet_interfaces.py
+++ b/watertap/ui/tests/test_flowsheet_interfaces.py
@@ -173,7 +173,7 @@ def _export_flash(flowsheet=None, exports=None, **kwargs):
     )
     # export a 'deferred' output
     exports.add(
-        deferred_obj="fs.flash.vap_outlet.temperature[0]",
+        obj="flash.vap_outlet.temperature[0]",
         ui_units=units.K,
         display_units="Kelvin",
         rounding=2,

--- a/watertap/ui/tests/test_fsapi.py
+++ b/watertap/ui/tests/test_fsapi.py
@@ -251,8 +251,8 @@ def csv_from_localfile(exports=None, flowsheet=None, **kwargs):
 
 
 def populate_csv_exports(f):
-    units = "units.foobar" if CSVTestSettings.bad_units else "units.m**3/units.s"
-    obj = "dirt" if CSVTestSettings.bad_obj else "fs.feed.flow_vol[0]"
+    units = "foobar" if CSVTestSettings.bad_units else "m**3/s"
+    obj = "dirt" if CSVTestSettings.bad_obj else "feed.flow_vol[0]"
     rows = [
         "name,obj,description,ui_units,display_units,rounding,is_input,input_category,is_output,output_category",
         f"feed,{obj},feed flow volume,{units},m^3/s,3,TRUE,something,FALSE,",
@@ -325,7 +325,7 @@ def test_export_values():
     key = list(fsi.fs_exp.model_objects.keys())[0]
     orig_value = value(fsi.fs_exp.model_objects[key].obj)
     new_value = orig_value + 1
-    print(f"@@ orig_value = {orig_value}, new value = {new_value}")
+    print(f"export_values: orig_value = {orig_value}, new value = {new_value}")
     fsi.fs_exp.model_objects[key].obj.value = new_value
 
     # re-export


### PR DESCRIPTION
## Summary/Motivation:

Without this, the attempt to export variables that don't exist yet will prevent some flowsheets from being used with the UI.

## Changes proposed in this PR:
In the `watertap.ui.fsapi` module:
- Add a `deferred_obj` attr to the ModelExport class that holds the (string) description of the object
- Add an `undefer()` method to the FlowsheetExport class
- Call `undefer()` automatically once the flowsheet has been solved to resolve the deferred values

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
