### PR TITLE
Fixing doctests for Pyomo 6.7.1

### DIFF
--- a/docs/how_to_guides/how_to_use_MCAS_property_model.rst
+++ b/docs/how_to_guides/how_to_use_MCAS_property_model.rst
@@ -92,13 +92,13 @@ A portion of the displayed output is shown below.
            Key  : Lower    : Value     : Upper : Fixed : Stale : Domain
            None : 100000.0 : 5000000.0 :  None :  True :  True : NonNegativeReals
        flow_mol_phase_comp : Component molar flow rate
-           Size=3, Index=fs.state_block[0].flow_mol_phase_comp_index, Units=mol/s
+           Size=3, Index=fs.properties.phase_list*fs.properties.component_list, Units=mol/s
            Key             : Lower : Value : Upper : Fixed : Stale : Domain
            ('Liq', 'Cl_-') :     0 : 0.483 :  None :  True :  True : NonNegativeReals
             ('Liq', 'H2O') :     0 :  53.8 :  None :  True :  True : NonNegativeReals
            ('Liq', 'Na_+') :     0 : 0.483 :  None :  True :  True : NonNegativeReals
        flow_mass_phase_comp : Component Mass flowrate
-           Size=3, Index=fs.state_block[0].flow_mass_phase_comp_index, Units=kg/s
+           Size=3, Index=fs.properties.phase_list*fs.properties.component_list, Units=kg/s
            Key             : Lower : Value                : Upper : Fixed : Stale : Domain
            ('Liq', 'Cl_-') :     0 :             0.016905 :  None : False : False :  Reals
             ('Liq', 'H2O') :     0 :   0.9683999999999999 :  None : False : False :  Reals

--- a/docs/how_to_guides/how_to_use_a_property_model.rst
+++ b/docs/how_to_guides/how_to_use_a_property_model.rst
@@ -74,7 +74,7 @@ A portion of the displayed output is shown below.
 
      Variables:
        flow_mass_phase_comp : Mass flow rate
-           Size=2, Index=fs.state_block[0].flow_mass_phase_comp_index, Units=kg/s
+           Size=2, Index=fs.properties.phase_list*fs.properties.component_list, Units=kg/s
            Key             : Lower : Value : Upper : Fixed : Stale : Domain
             ('Liq', 'H2O') :   0.0 : 0.965 :  None :  True :  True : NonNegativeReals
            ('Liq', 'NaCl') :   0.0 : 0.035 :  None :  True :  True : NonNegativeReals


### PR DESCRIPTION
## Fixes: #1307, Supersedes #1308

## Summary/Motivation:
Pyomo/pyomo#3075 changed how implicit sets were constructed. This PR would update our doctests which rely on `Block.pprint` and are affected by this change.

## Changes proposed in this PR:
- Update how-to guides for property models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
