### PR TITLE
Correcting error checks for MCAS properties config combinations

### DIFF
--- a/watertap/property_models/multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/multicomp_aq_sol_prop_pack.py
@@ -1523,7 +1523,10 @@ class MCASStateBlockData(StateBlockData):
                         * pyunits.second**-1
                     )
             else:
-                if (p, j) not in self.params.config.diffusivity_data.keys():
+                if (
+                    self.params.config.diffus_calculation == DiffusivityCalculation.none
+                    and (p, j) not in self.params.config.diffusivity_data.keys()
+                ):
                     raise ConfigurationError(
                         """
                         Missing a valid diffusivity_data configuration to use EinsteinRelation 


### PR DESCRIPTION
## Fixes/Resolves:
#1305

## Summary/Motivation:
Need to change the check in line 1526 from looking for `self.params.config.diffusivity_data.keys()` for `DiffusivityCalculation`s that are functions of other parameters and do not require `self.params.config.diffusivity_data.keys()`.

## Changes proposed in this PR:
- Adjust error check

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
