### PR TITLE
Work around for issue #1312

### DIFF
--- a/tutorials/parameter_sweep_demo.ipynb
+++ b/tutorials/parameter_sweep_demo.ipynb
@@ -221,7 +221,7 @@
     "        \"optimize_kwargs\": {\"solver\": solver, \"check_termination\": False},\n",
     "        \"initialize_function\": None,\n",
     "        \"initialize_kwargs\": {},\n",
-    "        \"parallel_back_end\": \"MultiProcessing\", # Multiprocessing, MPI, Ray available\n",
+    "        \"parallel_back_end\": \"MultiProcessing\", # ConcurrentFutures, MPI, Ray available\n",
     "        \"number_of_subprocesses\": num_procs,\n",
     "        \n",
     "        # Additional useful keyword arguments\n",

--- a/tutorials/parameter_sweep_demo.ipynb
+++ b/tutorials/parameter_sweep_demo.ipynb
@@ -221,7 +221,7 @@
     "        \"optimize_kwargs\": {\"solver\": solver, \"check_termination\": False},\n",
     "        \"initialize_function\": None,\n",
     "        \"initialize_kwargs\": {},\n",
-    "        \"parallel_back_end\": \"ConcurrentFutures\", # Multiprocessing, MPI, Ray available\n",
+    "        \"parallel_back_end\": \"MultiProcessing\", # Multiprocessing, MPI, Ray available\n",
     "        \"number_of_subprocesses\": num_procs,\n",
     "        \n",
     "        # Additional useful keyword arguments\n",

--- a/watertap/tools/parallel/parallel_manager_factory.py
+++ b/watertap/tools/parallel/parallel_manager_factory.py
@@ -47,12 +47,12 @@ def create_parallel_manager(parallel_manager_class=None, **kwargs):
 
     number_of_subprocesses = kwargs.get("number_of_subprocesses", 1)
     if should_fan_out(number_of_subprocesses):
-        parallel_backend = kwargs.get("parallel_back_end", "ConcurrentFutures")
-        if parallel_backend == "ConcurrentFutures":
+        parallel_backend = kwargs.get("parallel_back_end", "multiprocessing")
+        if parallel_backend.lower() in ("concurrentfutures", "concurrent.futures"):
             return ConcurrentFuturesParallelManager(number_of_subprocesses)
-        elif parallel_backend == "MultiProcessing":
+        elif parallel_backend.lower() in ("multiprocessing",):
             return MultiprocessingParallelManager(number_of_subprocesses)
-        elif parallel_backend == "RayIo":
+        elif parallel_backend.lower() in ("rayio", "ray"):
             if ray_avaialble:
                 return RayIoParallelManager(number_of_subprocesses)
             else:


### PR DESCRIPTION
## Fixes #1312

## Summary/Motivation:
We observed in #1314 that the notebook only seems to be failing on Python 3.8, but not Python 3.9+. We suspect the issue is with Python 3.8 itself. However, we don't see this issue when using the `multiprocessing` parallel back end for Python 3.8.

Since we still support Python 3.8, this PR would change the notebook to use the multiprocessing parallel back end and makes that the default for parameter sweep.

## Changes proposed in this PR:
- Use `multiprocessing` parallel manager in example notebook
- Change default back end from `concurrent.futures` to `multiprocessing`
- Drive by: make the parallel factory more user friendly by not caring about case and catch a few other potential spellings, etc.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
