### PR TITLE
Resolve nbmake 1.5.1 errors on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ setup(
             "json-schema-for-humans",
             "mongomock",
             "pandas",
-            "nbmake",
+            # treebeardtech/nbmake#121
+            "nbmake != 1.5.1",
             "nbconvert",
         ],
         "notebooks": [

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,8 @@ setup(
             "pytest",  # test framework
             "pytest-cov",  # code coverage
             "mongomock",  # mongodb mocking for testing
-            "nbmake",
+            # treebeardtech/nbmake#121
+            "nbmake != 1.5.1",
         ],
     },
     package_data={  # Optional


### PR DESCRIPTION
## Summary/Motivation:

- Workaround for treebeardtech/nbmake#121

## Changes proposed in this PR:
- Add exclusion for 1.5.1 to nbmake requirement


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
