### PR TITLE
Enable solver logs in Unit Test Harness

### DIFF
--- a/watertap/unit_models/tests/unit_test_harness.py
+++ b/watertap/unit_models/tests/unit_test_harness.py
@@ -21,6 +21,7 @@ from idaes.core.util.model_statistics import (
 from idaes.core.solvers import get_solver
 from idaes.core.util.testing import initialization_tester
 import idaes.core.util.scaling as iscale
+import idaes.logger as idaeslog
 
 
 # -----------------------------------------------------------------------------
@@ -123,6 +124,7 @@ class UnitTestHarness(abc.ABC):
             unit=blk,
             solver=blk._test_objs.solver,
             optarg=blk._test_objs.optarg,
+            outlvl=idaeslog.DEBUG,
         )
 
     @pytest.mark.component
@@ -138,7 +140,7 @@ class UnitTestHarness(abc.ABC):
             opt = get_solver(
                 solver=blk._test_objs.solver, options=blk._test_objs.optarg
             )
-        results = opt.solve(blk)
+        results = opt.solve(blk, tee=True)
 
         # check solve
         badly_scaled_vars = list(


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
Enables logging the solver output to the screen in the unit model test harness. Note you only see the solver logs if you run `pytest -s`.

This is good for both debugging and testing the unit model tests, as well as things which affect the unit model tests.

## Changes proposed in this PR:
- Add `tee=True` to `solve` call
- Add `outlvl=idaes.logger.DEBUG` to `initialization_tester` call.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
