### PR TITLE
Implement `get_solver` for WaterTAP

### DIFF
--- a/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
+++ b/docs/how_to_guides/how_to_run_models_in_a_py_script.rst
@@ -69,7 +69,7 @@ Example: Python file with recommended structure
    # Import RO model
    from watertap.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
    # import the solver
-   from idaes.core.solvers import get_solver
+   from watertap.core.solvers import get_solver
 
 
    # Put all the model constructors, initialization, and solver in a separate function
@@ -128,7 +128,7 @@ Example: the same code without recommended structure (may cause errors on Window
    # Import RO model
    from watertap.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
    # import the solver
-   from idaes.core.solvers import get_solver
+   from watertap.core.solvers import get_solver
 
    # Create a concrete model, flowsheet, and NaCl property parameter block.
    m = ConcreteModel()

--- a/docs/how_to_guides/how_to_run_zero_order_model.rst
+++ b/docs/how_to_guides/how_to_run_zero_order_model.rst
@@ -8,7 +8,7 @@ The example script shown below is for the dual media filtration zero-order model
    from pyomo.environ import ConcreteModel
 
    from idaes.core import FlowsheetBlock
-   from idaes.core.solvers import get_solver
+   from watertap.core.solvers import get_solver
 
    from watertap.core.wt_database import Database
    from watertap.core.zero_order_properties import WaterParameterBlock

--- a/docs/how_to_guides/how_to_scale_a_model.rst
+++ b/docs/how_to_guides/how_to_scale_a_model.rst
@@ -165,7 +165,7 @@ The scaling factors are automatically passed-in when using the default WaterTAP 
 
 .. testcode:: [scaling_factor]
 
-    from idaes.core.solvers import get_solver
+    from watertap.core.solvers import get_solver
     # Create default WaterTAP solver object
     opt = get_solver()
     # Solve model m

--- a/docs/how_to_guides/how_to_use_MCAS_property_model.rst
+++ b/docs/how_to_guides/how_to_use_MCAS_property_model.rst
@@ -20,7 +20,7 @@ users to model the chemical and physical properties of simple systems without th
     # Import flowsheet block from IDAES core
     from idaes.core import FlowsheetBlock
     # Import solver from IDAES core
-    from idaes.core.solvers import get_solver
+    from watertap.core.solvers import get_solver
     # Import MCAS property model
     import watertap.property_models.multicomp_aq_sol_prop_pack as props
     # Import utility tool for calculating scaling factors

--- a/docs/how_to_guides/how_to_use_a_property_model.rst
+++ b/docs/how_to_guides/how_to_use_a_property_model.rst
@@ -18,7 +18,7 @@ users to model the chemical and physical properties of simple systems without th
     # Import flowsheet block from IDAES core
     from idaes.core import FlowsheetBlock
     # Import solver from IDAES core
-    from idaes.core.solvers import get_solver
+    from watertap.core.solvers import get_solver
     # Import NaCl property model
     import watertap.property_models.NaCl_prop_pack as props
     # Import utility tool for calculating scaling factors

--- a/docs/how_to_guides/how_to_use_unit_test_harness.rst
+++ b/docs/how_to_guides/how_to_use_unit_test_harness.rst
@@ -30,7 +30,7 @@ assumes a test file is being created for an anaerobic digester.
     from pyomo.environ import ConcreteModel
 
     from idaes.core import FlowsheetBlock, UnitModelCostingBlock
-    from idaes.core.solvers import get_solver
+    from watertap.core.solvers import get_solver
     import idaes.core.util.scaling as iscale
 
     from watertap.costing import WaterTAPCosting

--- a/tutorials/BSM2.ipynb
+++ b/tutorials/BSM2.ipynb
@@ -64,7 +64,7 @@
     "from pyomo.network import Arc, SequentialDecomposition\n",
     "from idaes.core import FlowsheetBlock\n",
     "import idaes.logger as idaeslog\n",
-    "from idaes.core.solvers import get_solver\n",
+    "from watertap.core.solvers import get_solver\n",
     "import idaes.core.util.scaling as iscale"
    ]
   },

--- a/tutorials/assets_parameter_sweep_demo/parameter_sweep_demo_script.py
+++ b/tutorials/assets_parameter_sweep_demo/parameter_sweep_demo_script.py
@@ -9,7 +9,7 @@
 # information, respectively. These files are also available online at the URL
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import (
     optimize,
 )

--- a/tutorials/introduction.ipynb
+++ b/tutorials/introduction.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "from pyomo.environ import ConcreteModel, Var, Reals, Objective, Constraint, value, units\n",
-    "from idaes.core.solvers import get_solver"
+    "from watertap.core.solvers import get_solver"
    ]
   },
   {

--- a/tutorials/nawi_spring_meeting2023.ipynb
+++ b/tutorials/nawi_spring_meeting2023.ipynb
@@ -79,7 +79,7 @@
     "from idaes.core.util.initialization import propagate_state\n",
     "\n",
     "# Import function to get default solver\n",
-    "from idaes.core.solvers import get_solver\n",
+    "from watertap.core.solvers import get_solver\n",
     "\n",
     "# Import function to check degrees of freedom\n",
     "from idaes.core.util.model_statistics import degrees_of_freedom\n",

--- a/tutorials/parameter_sweep_demo.ipynb
+++ b/tutorials/parameter_sweep_demo.ipynb
@@ -173,7 +173,7 @@
     "# Make the necessary imports\n",
     "from pprint import pprint\n",
     "from IPython import get_ipython\n",
-    "from idaes.core.solvers import get_solver\n",
+    "from watertap.core.solvers import get_solver\n",
     "from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import (\n",
     "    optimize,\n",
     ")\n",

--- a/tutorials/reverse_osmosis_0D.ipynb
+++ b/tutorials/reverse_osmosis_0D.ipynb
@@ -29,7 +29,7 @@
     "# Import flowsheet block from IDAES core\n",
     "from idaes.core import FlowsheetBlock\n",
     "# Import function to get default solver\n",
-    "from idaes.core.solvers import get_solver\n",
+    "from watertap.core.solvers import get_solver\n",
     "# Import function to check degrees of freedom\n",
     "from idaes.core.util.model_statistics import degrees_of_freedom\n",
     "# Import utility function for calculating scaling factors\n",

--- a/tutorials/unit_model_customization_example.ipynb
+++ b/tutorials/unit_model_customization_example.ipynb
@@ -56,7 +56,7 @@
     "from idaes.core import FlowsheetBlock\n",
     "from idaes.core.util.scaling import calculate_scaling_factors, set_scaling_factor\n",
     "from idaes.core.util.model_statistics import degrees_of_freedom\n",
-    "from idaes.core.solvers import get_solver\n",
+    "from watertap.core.solvers import get_solver\n",
     "from idaes.core.util.scaling import constraint_scaling_transform\n",
     "from idaes.core.util.initialization import propagate_state\n",
     "from idaes.models.unit_models import Feed, Product\n",

--- a/watertap/conftest.py
+++ b/watertap/conftest.py
@@ -46,7 +46,7 @@ class MarkerSpec(enum.Enum):
 def _handle_requires_idaes_solver(
     solver: Optional = None, action: Optional[Callable[[str], None]] = pytest.xfail
 ) -> None:
-    from idaes.core.solvers import get_solver
+    from watertap.core.solvers import get_solver
     from idaes.config import bin_directory
 
     solver = solver or get_solver()

--- a/watertap/core/plugins/solvers.py
+++ b/watertap/core/plugins/solvers.py
@@ -202,14 +202,3 @@ class IpoptWaterTAP(IPOPT):
                 )
             return False
         return True
-
-
-## reconfigure IDAES to use the ipopt-watertap solver
-import idaes
-
-_default_solver_config_value = idaes.cfg.get("default_solver")
-_idaes_default_solver = _default_solver_config_value._default
-
-_default_solver_config_value.set_default_value("ipopt-watertap")
-if not _default_solver_config_value._userSet:
-    _default_solver_config_value.reset()

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -20,7 +20,7 @@ from idaes.core.util.scaling import (
     set_scaling_factor,
     constraints_with_scale_factor_generator,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.core.plugins.solvers import IpoptWaterTAP, _pyomo_nl_writer_log
 
 

--- a/watertap/core/solvers.py
+++ b/watertap/core/solvers.py
@@ -1,0 +1,40 @@
+#################################################################################
+# WaterTAP Copyright (c) 2020-2024, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National Laboratory,
+# National Renewable Energy Laboratory, and National Energy Technology
+# Laboratory (subject to receipt of any required approvals from the U.S. Dept.
+# of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#################################################################################
+
+"""
+This module contains a get_solver function which is identical to the IDAES get_solver
+function except that it returns IpoptWaterTAP by default.
+"""
+
+from idaes.core.solvers import SolverWrapper as _SolverWrapper
+
+
+def get_solver(solver=None, options=None):
+    """
+    General method for getting a solver object which defaults to IpoptWaterTAP
+
+    Args:
+        solver: string name for desired solver. Default=None, use default solver
+        options: dict of solver options to use, overwrites any settings in
+                 IpoptWaterTAP. Default = None, use default solver options.
+
+    Returns:
+        A Pyomo solver object
+    """
+    if solver is None:
+        solver = "ipopt-watertap"
+    solver_obj = _SolverWrapper(solver, register=False)()
+
+    if options is not None:
+        solver_obj.options.update(options)
+
+    return solver_obj

--- a/watertap/core/tests/test_zero_order_diso.py
+++ b/watertap/core/tests/test_zero_order_diso.py
@@ -18,7 +18,7 @@ from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from pyomo.environ import (
     check_optimal_termination,

--- a/watertap/core/tests/test_zero_order_electricity.py
+++ b/watertap/core/tests/test_zero_order_electricity.py
@@ -17,7 +17,7 @@ import pytest
 from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import (
     check_optimal_termination,
     ConcreteModel,

--- a/watertap/core/tests/test_zero_order_pt.py
+++ b/watertap/core/tests/test_zero_order_pt.py
@@ -17,7 +17,7 @@ import pytest
 from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import ConcreteModel, value
 from pyomo.network import Port
 from pyomo.util.check_units import assert_units_consistent

--- a/watertap/core/tests/test_zero_order_sido.py
+++ b/watertap/core/tests/test_zero_order_sido.py
@@ -18,7 +18,7 @@ from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from pyomo.environ import (
     check_optimal_termination,

--- a/watertap/core/tests/test_zero_order_sido_reactive.py
+++ b/watertap/core/tests/test_zero_order_sido_reactive.py
@@ -19,7 +19,7 @@ from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from pyomo.environ import (
     check_optimal_termination,

--- a/watertap/core/tests/test_zero_order_siso.py
+++ b/watertap/core/tests/test_zero_order_siso.py
@@ -18,7 +18,7 @@ from types import MethodType
 from idaes.core import declare_process_block_class, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from pyomo.environ import (
     check_optimal_termination,

--- a/watertap/core/util/model_diagnostics/ipopt_initialization.py
+++ b/watertap/core/util/model_diagnostics/ipopt_initialization.py
@@ -12,7 +12,7 @@
 
 import pyomo.environ as pyo
 from idaes.core.util.scaling import get_scaling_factor, __none_left_mult
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 def assert_no_initialization_perturbation(blk, optarg=None, solver=None):

--- a/watertap/core/util/model_diagnostics/tests/test_ipopt_initialization.py
+++ b/watertap/core/util/model_diagnostics/tests/test_ipopt_initialization.py
@@ -12,7 +12,7 @@
 import pytest
 from pyomo.environ import Block, Var, SolverFactory
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.core.util.model_diagnostics.ipopt_initialization import (
     generate_initialization_perturbation,
     print_initialization_perturbation,

--- a/watertap/core/util/tests/test_initialization.py
+++ b/watertap/core/util/tests/test_initialization.py
@@ -14,7 +14,7 @@ import pytest
 
 from pyomo.environ import ConcreteModel, Var, Constraint
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.exceptions import InitializationError
 from watertap.core.util.initialization import (
     check_dof,

--- a/watertap/core/util/tests/test_scaling.py
+++ b/watertap/core/util/tests/test_scaling.py
@@ -21,7 +21,7 @@ from idaes.core.util.scaling import (
     calculate_scaling_factors,
 )
 import idaes.core.util.scaling as iscale
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 import watertap.property_models.NaCl_prop_pack as props
 

--- a/watertap/core/zero_order_diso.py
+++ b/watertap/core/zero_order_diso.py
@@ -17,7 +17,7 @@ outlet where composition changes, such as a generic bioreactor).
 from types import MethodType
 
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.core.util.exceptions import InitializationError
 

--- a/watertap/core/zero_order_pt.py
+++ b/watertap/core/zero_order_pt.py
@@ -18,7 +18,7 @@ from types import MethodType
 from pyomo.environ import check_optimal_termination
 
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import number_activated_constraints
 from idaes.core.util.exceptions import InitializationError
 

--- a/watertap/core/zero_order_sido.py
+++ b/watertap/core/zero_order_sido.py
@@ -16,7 +16,7 @@ zero-order single inlet-double outlet (SIDO) unit models.
 from types import MethodType
 
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.core.util.exceptions import InitializationError
 

--- a/watertap/core/zero_order_sido_reactive.py
+++ b/watertap/core/zero_order_sido_reactive.py
@@ -17,7 +17,7 @@ reactions.
 from types import MethodType
 
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.core.util.exceptions import InitializationError
 

--- a/watertap/core/zero_order_siso.py
+++ b/watertap/core/zero_order_siso.py
@@ -17,7 +17,7 @@ outlet where composition changes, such as a generic bioreactor).
 from types import MethodType
 
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.core.util.exceptions import InitializationError
 

--- a/watertap/costing/tests/test_util.py
+++ b/watertap/costing/tests/test_util.py
@@ -16,7 +16,7 @@ import idaes.core as idc
 import idaes.core.util.model_statistics as istat
 
 from pyomo.util.check_units import assert_units_consistent
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.costing.watertap_costing_package import WaterTAPCosting
 from watertap.costing.util import (
     cost_rectifier,

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -29,7 +29,7 @@ from pyomo.util.check_units import assert_units_consistent
 from pyomo.common.config import ConfigValue
 
 from idaes.core import FlowsheetBlock, declare_process_block_class
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core import UnitModelCostingBlock
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,

--- a/watertap/costing/unit_models/tests/test_electrolyzer.py
+++ b/watertap/costing/unit_models/tests/test_electrolyzer.py
@@ -16,7 +16,7 @@ import idaes.core.util.model_statistics as istat
 
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import UnitModelCostingBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.testing import initialization_tester
 from watertap.costing import WaterTAPCosting
 from watertap.unit_models.tests.test_electrolyzer import build

--- a/watertap/costing/unit_models/tests/test_gac.py
+++ b/watertap/costing/unit_models/tests/test_gac.py
@@ -18,7 +18,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core import (
     UnitModelCostingBlock,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.testing import initialization_tester
 from watertap.costing import WaterTAPCosting
 from watertap.unit_models.tests.test_gac import build_crittenden

--- a/watertap/examples/custom_model_demo/demo_simple_filter.py
+++ b/watertap/examples/custom_model_demo/demo_simple_filter.py
@@ -15,7 +15,7 @@ from idaes.core import FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 import idaes.core.util.scaling as iscale
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 import watertap.examples.custom_model_demo.simple_prop_pack as props
 from watertap.examples.custom_model_demo.simple_filter import Filtration

--- a/watertap/examples/custom_model_demo/demo_simple_prop_pack.py
+++ b/watertap/examples/custom_model_demo/demo_simple_prop_pack.py
@@ -14,7 +14,7 @@ from idaes.core import FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 import idaes.core.util.scaling as iscale
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 import watertap.examples.custom_model_demo.simple_prop_pack as props
 

--- a/watertap/examples/custom_model_demo/simple_prop_pack.py
+++ b/watertap/examples/custom_model_demo/simple_prop_pack.py
@@ -49,7 +49,7 @@ from idaes.core.util.model_statistics import (
 from idaes.core.util.exceptions import PropertyPackageError
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)

--- a/watertap/examples/custom_model_demo/tests/test_demo_simple_filter.py
+++ b/watertap/examples/custom_model_demo/tests/test_demo_simple_filter.py
@@ -12,7 +12,7 @@
 import pytest
 
 from pyomo.environ import value
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from watertap.examples.custom_model_demo.demo_simple_filter import main
 

--- a/watertap/examples/custom_model_demo/tests/test_demo_simple_prop_pack.py
+++ b/watertap/examples/custom_model_demo/tests/test_demo_simple_prop_pack.py
@@ -12,7 +12,7 @@
 import pytest
 
 from pyomo.environ import value
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from watertap.examples.custom_model_demo.demo_simple_prop_pack import main
 

--- a/watertap/examples/flowsheets/MD/MD_single_stage_continuous_recirculation.py
+++ b/watertap/examples/flowsheets/MD/MD_single_stage_continuous_recirculation.py
@@ -23,7 +23,7 @@ from pyomo.environ import (
 )
 from pyomo.network import Arc
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import (
     propagate_state,

--- a/watertap/examples/flowsheets/MD/tests/test_MD.py
+++ b/watertap/examples/flowsheets/MD/tests/test_MD.py
@@ -16,7 +16,7 @@ from pyomo.environ import (
     Var,
 )
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 from idaes.models.unit_models import Heater, Separator, Mixer, Product, Feed

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -21,7 +21,7 @@ from pyomo.environ import (
 )
 from pyomo.network import Arc
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import solve_indexed_blocks, propagate_state
 from idaes.models.unit_models import Mixer, Separator, Product, Feed

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery_ui.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery_ui.py
@@ -9,7 +9,7 @@
 # information, respectively. These files are also available online at the URL
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.ui.fsapi import FlowsheetInterface
 from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import (
     build,

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/monte_carlo_sampling_RO_ERD.py
@@ -10,7 +10,7 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.tools.parameter_sweep import (
     UniformSample,
     NormalSample,

--- a/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/examples/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -20,7 +20,7 @@ from pyomo.environ import (
 )
 from pyomo.network import Port
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom, number_total_objectives
 from idaes.models.unit_models import Mixer, Separator, Product, Feed
 from pyomo.util.check_units import assert_units_consistent

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/ASM1_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/ASM1_flowsheet.py
@@ -47,7 +47,7 @@ from idaes.models.unit_models import (
     Product,
 )
 from idaes.models.unit_models.separator import SplittingType
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet.py
@@ -387,7 +387,9 @@ def build_flowsheet():
     seq.set_guesses_for(m.fs.R3.inlet, tear_guesses)
 
     def function(unit):
-        unit.initialize(outlvl=idaeslog.INFO, optarg={"bound_push": 1e-8})
+        unit.initialize(
+            outlvl=idaeslog.INFO, optarg={"bound_push": 1e-8}, solver="ipopt-watertap"
+        )
         badly_scaled_vars = list(iscale.badly_scaled_var_generator(unit))
         if len(badly_scaled_vars) > 0:
             automate_rescale_variables(unit)

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet.py
@@ -33,7 +33,7 @@ from idaes.models.unit_models import (
     Product,
 )
 from idaes.models.unit_models.separator import SplittingType
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet_noPHA.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/ASM2D_flowsheet_noPHA.py
@@ -29,7 +29,7 @@ from idaes.models.unit_models import (
     Product,
 )
 from idaes.models.unit_models.separator import SplittingType
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/activated_sludge/modified_ASM2D_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/activated_sludge/modified_ASM2D_flowsheet.py
@@ -33,7 +33,7 @@ from idaes.models.unit_models import (
     Product,
 )
 from idaes.models.unit_models.separator import SplittingType
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/anaerobic_digester/ADM1_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/anaerobic_digester/ADM1_flowsheet.py
@@ -16,7 +16,7 @@ from pyomo.environ import (
     units,
 )
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.logger as idaeslog
 from watertap.unit_models.anaerobic_digester import AD
 from watertap.property_models.anaerobic_digestion.adm1_properties import (

--- a/watertap/examples/flowsheets/case_studies/electroNP/electroNP_flowsheet.py
+++ b/watertap/examples/flowsheets/case_studies/electroNP/electroNP_flowsheet.py
@@ -23,7 +23,7 @@ from idaes.core import (
     FlowsheetBlock,
     UnitModelCostingBlock,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 from watertap.unit_models.anaerobic_digester import AD

--- a/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2.py
+++ b/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2.py
@@ -32,7 +32,7 @@ from watertap.unit_models.translators.translator_asm1_adm1 import Translator_ASM
 from watertap.unit_models.translators.translator_adm1_asm1 import Translator_ADM1_ASM1
 
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from watertap.property_models.anaerobic_digestion.adm1_properties import (
     ADM1ParameterBlock,

--- a/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2_P_extension.py
+++ b/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2_P_extension.py
@@ -35,7 +35,7 @@ from idaes.models.unit_models import (
     PressureChanger,
 )
 from idaes.models.unit_models.separator import SplittingType
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/municipal_treatment/municipal_treatment.py
+++ b/watertap/examples/flowsheets/case_studies/municipal_treatment/municipal_treatment.py
@@ -20,7 +20,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/seawater_RO_desalination/seawater_RO_desalination.py
@@ -20,7 +20,7 @@ from pyomo.network import Arc
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import (
     propagate_state,
     fix_state_vars,

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/GLSD_anaerobic_digester/GLSD_anaerobic_digestion.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/GLSD_anaerobic_digester/GLSD_anaerobic_digestion.py
@@ -22,7 +22,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/GLSD_anaerobic_digester/tests/test_GLSD_anaerobic_digestion.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/GLSD_anaerobic_digester/tests/test_GLSD_anaerobic_digestion.py
@@ -11,7 +11,7 @@
 #################################################################################
 
 import pytest
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import value, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from watertap.core.util.initialization import assert_degrees_of_freedom

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/hrcs.py
@@ -25,7 +25,7 @@ from pyomo.network import Arc
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock, UnitModelCostingBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.models.unit_models import Product, Mixer, MomentumMixingType, MixingType
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/tests/test_hrcs.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_hrcs/tests/test_hrcs.py
@@ -11,7 +11,7 @@
 #################################################################################
 
 import pytest
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import value, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from watertap.core.util.initialization import assert_degrees_of_freedom

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_magprex/magprex.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_magprex/magprex.py
@@ -25,7 +25,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_magprex/tests/test_magprex.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1575_magprex/tests/test_magprex.py
@@ -11,7 +11,7 @@
 #################################################################################
 
 import pytest
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import value, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from watertap.core.util.initialization import assert_degrees_of_freedom

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1595_photothermal_membrane_candoP/amo_1595.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1595_photothermal_membrane_candoP/amo_1595.py
@@ -25,7 +25,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1690/amo_1690.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/amo_1690/amo_1690.py
@@ -25,7 +25,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/biomembrane_filtration/biomembrane_filtration.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/biomembrane_filtration/biomembrane_filtration.py
@@ -22,7 +22,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination.py
@@ -22,7 +22,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import (
     Product,
     Translator,

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/dye_desalination_withRO.py
@@ -38,7 +38,7 @@ from idaes.core import (
     MomentumBalanceType,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination.py
@@ -14,7 +14,7 @@ from pyomo.environ import (
     value,
     assert_optimal_termination,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.core.util.initialization import assert_degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 from watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.dye_desalination.dye_desalination import (

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/dye_desalination/tests/test_dye_desalination_withRO.py
@@ -14,7 +14,7 @@ from pyomo.environ import (
     value,
     assert_optimal_termination,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.core.util.initialization import assert_degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 from watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.dye_desalination.dye_desalination_withRO import (

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/electrochemical_nutrient_removal/electrochemical_nutrient_removal.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/electrochemical_nutrient_removal/electrochemical_nutrient_removal.py
@@ -23,7 +23,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.models.unit_models import Product
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/electrochemical_nutrient_removal/tests/test_electrochemical_nutrient_removal.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/electrochemical_nutrient_removal/tests/test_electrochemical_nutrient_removal.py
@@ -11,7 +11,7 @@
 #################################################################################
 
 import pytest
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import value, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from watertap.core.util.initialization import assert_degrees_of_freedom

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/groundwater_treatment/groundwater_treatment.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/groundwater_treatment/groundwater_treatment.py
@@ -25,7 +25,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/metab/metab.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/metab/metab.py
@@ -23,7 +23,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/metab/tests/test_metab.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/metab/tests/test_metab.py
@@ -14,7 +14,7 @@ from pyomo.environ import (
     value,
     assert_optimal_termination,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.util.check_units import assert_units_consistent
 
 from watertap.core.util.initialization import assert_degrees_of_freedom

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/peracetic_acid_disinfection/peracetic_acid_disinfection.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/peracetic_acid_disinfection/peracetic_acid_disinfection.py
@@ -26,7 +26,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 
 import idaes.core.util.scaling as iscale

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/suboxic_activated_sludge_process/suboxic_activated_sludge_process.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/suboxic_activated_sludge_process/suboxic_activated_sludge_process.py
@@ -23,7 +23,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.models.unit_models import Product
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/supercritical_sludge_to_gas/supercritical_sludge_to_gas.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/supercritical_sludge_to_gas/supercritical_sludge_to_gas.py
@@ -22,7 +22,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/supercritical_sludge_to_gas/tests/test_supercritical_sludge_to_gas.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/supercritical_sludge_to_gas/tests/test_supercritical_sludge_to_gas.py
@@ -11,7 +11,7 @@
 #################################################################################
 
 import pytest
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import value, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from watertap.core.util.initialization import assert_degrees_of_freedom

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/swine_wwt/swine_wwt.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/swine_wwt/swine_wwt.py
@@ -23,7 +23,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Product
 import idaes.core.util.scaling as iscale
 from idaes.core import UnitModelCostingBlock

--- a/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/swine_wwt/tests/test_swine_wwt.py
+++ b/watertap/examples/flowsheets/case_studies/wastewater_resource_recovery/swine_wwt/tests/test_swine_wwt.py
@@ -11,7 +11,7 @@
 #################################################################################
 
 import pytest
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import value, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from watertap.core.util.initialization import assert_degrees_of_freedom

--- a/watertap/examples/flowsheets/crystallization/sim_simple_crystallizer.py
+++ b/watertap/examples/flowsheets/crystallization/sim_simple_crystallizer.py
@@ -20,7 +20,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core import UnitModelCostingBlock
 
 from watertap.property_models import cryst_prop_pack as props

--- a/watertap/examples/flowsheets/electrodialysis/electrodialysis_1stack.py
+++ b/watertap/examples/flowsheets/electrodialysis/electrodialysis_1stack.py
@@ -23,7 +23,7 @@ import idaes.logger as idaeslog
 from pyomo.network import Arc
 
 from idaes.core import FlowsheetBlock, UnitModelCostingBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.core.util.model_statistics import report_statistics
 from idaes.models.unit_models import Feed, Product, Separator

--- a/watertap/examples/flowsheets/electrodialysis/electrodialysis_1stack.py
+++ b/watertap/examples/flowsheets/electrodialysis/electrodialysis_1stack.py
@@ -243,7 +243,7 @@ def initialize_system(m, solver=None):
     # populate intitial properties throughout the system
     m.fs.feed.initialize(optarg=optarg)
     propagate_state(m.fs.s01)
-    m.fs.separator.initialize(optarg=optarg)
+    m.fs.separator.initialize(optarg=optarg, solver="ipopt-watertap")
     propagate_state(m.fs.s02)
     propagate_state(m.fs.s03)
     m.fs.EDstack.initialize(optarg=optarg)

--- a/watertap/examples/flowsheets/electrodialysis/electrodialysis_1stack_conc_recirc.py
+++ b/watertap/examples/flowsheets/electrodialysis/electrodialysis_1stack_conc_recirc.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.network import Arc
 
 from idaes.core import FlowsheetBlock, UnitModelCostingBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 import idaes.core.util.model_statistics as mstat
 from idaes.models.unit_models import Feed, Product, Separator, Mixer

--- a/watertap/examples/flowsheets/electrodialysis/tests/test_electrodialysis_1stack_conc_recirc.py
+++ b/watertap/examples/flowsheets/electrodialysis/tests/test_electrodialysis_1stack_conc_recirc.py
@@ -12,7 +12,7 @@
 
 import pytest
 from pyomo.environ import value
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.core.util.initialization import check_dof
 import watertap.examples.flowsheets.electrodialysis.electrodialysis_1stack_conc_recirc as edfs
 

--- a/watertap/examples/flowsheets/gac/gac.py
+++ b/watertap/examples/flowsheets/gac/gac.py
@@ -20,7 +20,7 @@ from idaes.core import (
     FlowsheetBlock,
     UnitModelCostingBlock,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import (

--- a/watertap/examples/flowsheets/gac/gac_ui.py
+++ b/watertap/examples/flowsheets/gac/gac_ui.py
@@ -15,7 +15,7 @@ GUI configuration for the GAC model.
 
 from pyomo.environ import units as pyunits
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.property_models.multicomp_aq_sol_prop_pack import DiffusivityCalculation
 from watertap.unit_models.gac import (
     FilmTransferCoefficientType,

--- a/watertap/examples/flowsheets/gac/tests/test_gac.py
+++ b/watertap/examples/flowsheets/gac/tests/test_gac.py
@@ -15,7 +15,7 @@ import pytest
 from pyomo.environ import assert_optimal_termination, value
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from watertap.property_models.multicomp_aq_sol_prop_pack import DiffusivityCalculation
 from watertap.unit_models.gac import (

--- a/watertap/examples/flowsheets/ion_exchange/ion_exchange_demo.py
+++ b/watertap/examples/flowsheets/ion_exchange/ion_exchange_demo.py
@@ -19,7 +19,7 @@ from pyomo.environ import (
 from pyomo.network import Arc
 
 from idaes.core import FlowsheetBlock, UnitModelCostingBlock
-from idaes.core.solvers.get_solver import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.scaling import calculate_scaling_factors
 from idaes.core.util.initialization import propagate_state

--- a/watertap/examples/flowsheets/ion_exchange/tests/test_ion_exchange_demo.py
+++ b/watertap/examples/flowsheets/ion_exchange/tests/test_ion_exchange_demo.py
@@ -23,7 +23,7 @@ from pyomo.network import Port
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import Feed, Product
 from watertap.unit_models.ion_exchange_0D import (

--- a/watertap/examples/flowsheets/lsrro/lsrro.py
+++ b/watertap/examples/flowsheets/lsrro/lsrro.py
@@ -32,7 +32,7 @@ from pyomo.network import Arc, SequentialDecomposition
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock, UnitModelCostingBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.exceptions import InitializationError
 from idaes.core.util.initialization import propagate_state
 from idaes.core.util.misc import StrEnum

--- a/watertap/examples/flowsheets/mvc/mvc_single_stage.py
+++ b/watertap/examples/flowsheets/mvc/mvc_single_stage.py
@@ -457,7 +457,7 @@ def initialize_system(m, solver=None):
 
     # initialize feed pump
     propagate_state(m.fs.s01)
-    m.fs.pump_feed.initialize(optarg=optarg)
+    m.fs.pump_feed.initialize(optarg=optarg, solver="ipopt-watertap")
 
     # initialize separator
     propagate_state(m.fs.s02)
@@ -466,11 +466,11 @@ def initialize_system(m, solver=None):
     m.fs.separator_feed.split_fraction[0, "hx_distillate_cold"].fix(
         m.fs.recovery[0].value
     )
-    m.fs.separator_feed.mixed_state.initialize(optarg=optarg)
+    m.fs.separator_feed.mixed_state.initialize(optarg=optarg, solver="ipopt-watertap")
     # Touch properties for initialization
     m.fs.separator_feed.hx_brine_cold_state[0].mass_frac_phase_comp["Liq", "TDS"]
     m.fs.separator_feed.hx_distillate_cold_state[0].mass_frac_phase_comp["Liq", "TDS"]
-    m.fs.separator_feed.initialize(optarg=optarg)
+    m.fs.separator_feed.initialize(optarg=optarg, solver="ipopt-watertap")
     m.fs.separator_feed.split_fraction[0, "hx_distillate_cold"].unfix()
 
     # initialize distillate heat exchanger
@@ -489,7 +489,7 @@ def initialize_system(m, solver=None):
         m.fs.evaporator.outlet_brine.temperature[0].value
     )
     m.fs.hx_distillate.hot_inlet.pressure[0] = 101325
-    m.fs.hx_distillate.initialize()
+    m.fs.hx_distillate.initialize(solver="ipopt-watertap")
 
     # initialize brine heat exchanger
     propagate_state(m.fs.s04)
@@ -507,12 +507,12 @@ def initialize_system(m, solver=None):
         0
     ].value
     m.fs.hx_brine.hot_inlet.pressure[0] = 101325
-    m.fs.hx_brine.initialize()
+    m.fs.hx_brine.initialize(solver="ipopt-watertap")
 
     # initialize mixer
     propagate_state(m.fs.s05)
     propagate_state(m.fs.s06)
-    m.fs.mixer_feed.initialize()
+    m.fs.mixer_feed.initialize(solver="ipopt-watertap")
     m.fs.mixer_feed.pressure_equality_constraints[0, 2].deactivate()
 
     # initialize evaporator
@@ -520,21 +520,23 @@ def initialize_system(m, solver=None):
     m.fs.Q_ext[0].fix()
     m.fs.evaporator.properties_vapor[0].flow_mass_phase_comp["Vap", "H2O"].fix()
     # fixes and unfixes those values
-    m.fs.evaporator.initialize(delta_temperature_in=60)
+    m.fs.evaporator.initialize(delta_temperature_in=60, solver="ipopt-watertap")
     m.fs.Q_ext[0].unfix()
     m.fs.evaporator.properties_vapor[0].flow_mass_phase_comp["Vap", "H2O"].unfix()
 
     # initialize compressor
     propagate_state(m.fs.s08)
-    m.fs.compressor.initialize()
+    m.fs.compressor.initialize(solver="ipopt-watertap")
 
     # initialize condenser
     propagate_state(m.fs.s09)
-    m.fs.condenser.initialize(heat=-m.fs.evaporator.heat_transfer.value)
+    m.fs.condenser.initialize(
+        heat=-m.fs.evaporator.heat_transfer.value, solver="ipopt-watertap"
+    )
 
     # initialize brine pump
     propagate_state(m.fs.s10)
-    m.fs.pump_brine.initialize(optarg=optarg)
+    m.fs.pump_brine.initialize(optarg=optarg, solver="ipopt-watertap")
 
     # initialize distillate pump
     propagate_state(m.fs.s13)  # to translator block
@@ -545,7 +547,7 @@ def initialize_system(m, solver=None):
     m.fs.pump_distillate.control_volume.properties_in[0].pressure = (
         m.fs.condenser.control_volume.properties_out[0].pressure.value
     )
-    m.fs.pump_distillate.initialize(optarg=optarg)
+    m.fs.pump_distillate.initialize(optarg=optarg, solver="ipopt-watertap")
 
     # propagate brine state
     propagate_state(m.fs.s12)
@@ -562,24 +564,25 @@ def initialize_system(m, solver=None):
             unit.initialize(
                 heat=-unit.flowsheet().evaporator.heat_transfer.value,
                 optarg=solver.options,
+                solver="ipopt-watertap",
             )
         elif unit.local_name == "evaporator":
             unit.flowsheet().Q_ext[0].fix()
             unit.properties_vapor[0].flow_mass_phase_comp["Vap", "H2O"].fix()
-            unit.initialize(delta_temperature_in=60)
+            unit.initialize(delta_temperature_in=60, solver="ipopt-watertap")
             unit.flowsheet().Q_ext[0].unfix()
             unit.properties_vapor[0].flow_mass_phase_comp["Vap", "H2O"].unfix()
         elif unit.local_name == "separator_feed":
             unit.split_fraction[0, "hx_distillate_cold"].fix(
                 unit.flowsheet().recovery[0].value
             )
-            unit.initialize()
+            unit.initialize(solver="ipopt-watertap")
             unit.split_fraction[0, "hx_distillate_cold"].unfix()
         elif unit.local_name == "mixer_feed":
-            unit.initialize()
+            unit.initialize(solver="ipopt-watertap")
             unit.pressure_equality_constraints[0, 2].deactivate()
         else:
-            unit.initialize()
+            unit.initialize(solver="ipopt-watertap")
 
     seq.run(m, func_initialize)
 

--- a/watertap/examples/flowsheets/mvc/mvc_single_stage.py
+++ b/watertap/examples/flowsheets/mvc/mvc_single_stage.py
@@ -25,7 +25,7 @@ from pyomo.network import Arc, SequentialDecomposition
 
 import pyomo.environ as pyo
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import propagate_state
 from idaes.models.unit_models import Feed, Separator, Mixer, Product

--- a/watertap/examples/flowsheets/mvc/mvc_single_stage_ui.py
+++ b/watertap/examples/flowsheets/mvc/mvc_single_stage_ui.py
@@ -21,7 +21,7 @@ from watertap.examples.flowsheets.mvc.mvc_single_stage import (
     set_up_optimization,
 )
 from pyomo.environ import units as pyunits, assert_optimal_termination, Objective
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 def export_to_ui():

--- a/watertap/examples/flowsheets/mvc/tests/test_mvc_single_stage.py
+++ b/watertap/examples/flowsheets/mvc/tests/test_mvc_single_stage.py
@@ -21,7 +21,7 @@ from pyomo.environ import (
     assert_optimal_termination,
 )
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.models.unit_models import Feed, Product, Mixer, Separator
 from idaes.models.unit_models.heat_exchanger import HeatExchanger
 from idaes.models.unit_models.translator import Translator

--- a/watertap/examples/flowsheets/nf_dspmde/nf.py
+++ b/watertap/examples/flowsheets/nf_dspmde/nf.py
@@ -26,7 +26,7 @@ from idaes.core import (
     FlowsheetBlock,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import (

--- a/watertap/examples/flowsheets/nf_dspmde/nf_ui.py
+++ b/watertap/examples/flowsheets/nf_dspmde/nf_ui.py
@@ -14,7 +14,7 @@ from watertap.examples.flowsheets.nf_dspmde import nf
 from watertap.examples.flowsheets.nf_dspmde import nf_with_bypass
 from watertap.unit_models.nanofiltration_DSPMDE_0D import ConcentrationPolarizationType
 from pyomo.environ import units as pyunits
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 def export_to_ui():

--- a/watertap/examples/flowsheets/nf_dspmde/nf_with_bypass.py
+++ b/watertap/examples/flowsheets/nf_dspmde/nf_with_bypass.py
@@ -23,7 +23,7 @@ from pyomo.environ import (
 )
 
 import idaes.core.util.scaling as iscale
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import (

--- a/watertap/examples/flowsheets/nf_dspmde/nf_with_bypass_ui.py
+++ b/watertap/examples/flowsheets/nf_dspmde/nf_with_bypass_ui.py
@@ -12,7 +12,7 @@
 from watertap.ui.fsapi import FlowsheetInterface
 from watertap.examples.flowsheets.nf_dspmde import nf_with_bypass
 from watertap.examples.flowsheets.nf_dspmde import nf
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from pyomo.environ import (
     units as pyunits,

--- a/watertap/examples/flowsheets/oaro/oaro.py
+++ b/watertap/examples/flowsheets/oaro/oaro.py
@@ -24,7 +24,7 @@ from pyomo.environ import (
 )
 from pyomo.network import Arc
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import (
     propagate_state,

--- a/watertap/examples/flowsheets/oaro/oaro_multi.py
+++ b/watertap/examples/flowsheets/oaro/oaro_multi.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 )
 from pyomo.network import Arc
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import (
     propagate_state as _pro_state,

--- a/watertap/examples/flowsheets/oaro/oaro_multi_ui.py
+++ b/watertap/examples/flowsheets/oaro/oaro_multi_ui.py
@@ -9,7 +9,7 @@
 # information, respectively. These files are also available online at the URL
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.ui.fsapi import FlowsheetInterface
 from watertap.examples.flowsheets.oaro.oaro_multi import (
     build,

--- a/watertap/examples/flowsheets/oaro/tests/test_oaro.py
+++ b/watertap/examples/flowsheets/oaro/tests/test_oaro.py
@@ -16,7 +16,7 @@ from pyomo.environ import (
     value,
 )
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import Product, Feed
 from pyomo.util.check_units import assert_units_consistent

--- a/watertap/examples/flowsheets/oaro/tests/test_oaro_multi.py
+++ b/watertap/examples/flowsheets/oaro/tests/test_oaro_multi.py
@@ -16,7 +16,7 @@ from pyomo.environ import (
     value,
 )
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 import watertap.property_models.NaCl_prop_pack as props

--- a/watertap/property_models/NDMA_prop_pack.py
+++ b/watertap/property_models/NDMA_prop_pack.py
@@ -48,7 +48,7 @@ from idaes.core.util.initialization import (
     solve_indexed_blocks,
 )
 from idaes.core.util.misc import extract_data
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_unfixed_variables,

--- a/watertap/property_models/NaCl_T_dep_prop_pack.py
+++ b/watertap/property_models/NaCl_T_dep_prop_pack.py
@@ -49,7 +49,7 @@ from idaes.core.util.initialization import (
     solve_indexed_blocks,
 )
 from idaes.core.util.misc import extract_data
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_unfixed_variables,

--- a/watertap/property_models/NaCl_prop_pack.py
+++ b/watertap/property_models/NaCl_prop_pack.py
@@ -49,7 +49,7 @@ from idaes.core.util.initialization import (
     solve_indexed_blocks,
 )
 from idaes.core.util.misc import extract_data
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_unfixed_variables,

--- a/watertap/property_models/activated_sludge/tests/test_asm1_integration.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_integration.py
@@ -29,7 +29,7 @@ from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.models.unit_models import CSTR
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import propagate_state
 

--- a/watertap/property_models/activated_sludge/tests/test_asm1_reaction.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_reaction.py
@@ -29,7 +29,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
 from idaes.models.unit_models import CSTR
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 from watertap.property_models.activated_sludge.asm1_properties import (

--- a/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm1_thermo.py
@@ -28,7 +28,7 @@ from idaes.core.util.model_statistics import (
     activated_constraints_set,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/property_models/activated_sludge/tests/test_asm2d_reaction.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm2d_reaction.py
@@ -38,7 +38,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
 from idaes.models.unit_models import CSTR
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 from watertap.property_models.activated_sludge.asm2d_properties import (

--- a/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_asm2d_thermo.py
@@ -28,7 +28,7 @@ from idaes.core.util.model_statistics import (
     activated_constraints_set,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/property_models/activated_sludge/tests/test_modified_asm2d_reaction.py
+++ b/watertap/property_models/activated_sludge/tests/test_modified_asm2d_reaction.py
@@ -34,7 +34,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
 from idaes.models.unit_models import CSTR
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 from watertap.property_models.activated_sludge.modified_asm2d_properties import (

--- a/watertap/property_models/activated_sludge/tests/test_modified_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_modified_asm2d_thermo.py
@@ -28,7 +28,7 @@ from idaes.core.util.model_statistics import (
     activated_constraints_set,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.property_models.tests.property_test_harness import PropertyAttributeError
 
 

--- a/watertap/property_models/activated_sludge/tests/test_simple_modified_asm2d_reaction.py
+++ b/watertap/property_models/activated_sludge/tests/test_simple_modified_asm2d_reaction.py
@@ -38,7 +38,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
 from idaes.models.unit_models import CSTR
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 from watertap.property_models.activated_sludge.simple_modified_asm2d_properties import (

--- a/watertap/property_models/activated_sludge/tests/test_simple_modified_asm2d_thermo.py
+++ b/watertap/property_models/activated_sludge/tests/test_simple_modified_asm2d_thermo.py
@@ -28,7 +28,7 @@ from idaes.core.util.model_statistics import (
     activated_constraints_set,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/property_models/anaerobic_digestion/tests/test_adm1_reaction.py
+++ b/watertap/property_models/anaerobic_digestion/tests/test_adm1_reaction.py
@@ -36,7 +36,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
 from watertap.unit_models.anaerobic_digester import AD
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.core.util.model_statistics import degrees_of_freedom
 

--- a/watertap/property_models/anaerobic_digestion/tests/test_adm1_thermo.py
+++ b/watertap/property_models/anaerobic_digestion/tests/test_adm1_thermo.py
@@ -30,7 +30,7 @@ from idaes.core.util.model_statistics import (
     activated_constraints_set,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/property_models/anaerobic_digestion/tests/test_adm1_vapor_thermo.py
+++ b/watertap/property_models/anaerobic_digestion/tests/test_adm1_vapor_thermo.py
@@ -37,7 +37,7 @@ from idaes.core.util.model_statistics import (
     activated_constraints_set,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/property_models/anaerobic_digestion/tests/test_modified_adm1_reaction.py
+++ b/watertap/property_models/anaerobic_digestion/tests/test_modified_adm1_reaction.py
@@ -36,7 +36,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
 from watertap.unit_models.anaerobic_digester import AD
 from idaes.core import MaterialFlowBasis
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 from idaes.core.util.model_statistics import degrees_of_freedom
 from watertap.property_models.anaerobic_digestion.modified_adm1_properties import (

--- a/watertap/property_models/anaerobic_digestion/tests/test_modified_adm1_thermo.py
+++ b/watertap/property_models/anaerobic_digestion/tests/test_modified_adm1_thermo.py
@@ -31,7 +31,7 @@ from idaes.core.util.model_statistics import (
     activated_constraints_set,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/property_models/coagulation_prop_pack.py
+++ b/watertap/property_models/coagulation_prop_pack.py
@@ -56,7 +56,7 @@ from idaes.core.util.exceptions import (
 )
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from watertap.core.util.scaling import transform_property_constraints
 
 __author__ = "Austin Ladshaw"

--- a/watertap/property_models/cryst_prop_pack.py
+++ b/watertap/property_models/cryst_prop_pack.py
@@ -58,7 +58,7 @@ from idaes.core.util.initialization import (
     solve_indexed_blocks,
 )
 from idaes.core.util.misc import extract_data
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_unfixed_variables,

--- a/watertap/property_models/multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/multicomp_aq_sol_prop_pack.py
@@ -66,7 +66,7 @@ from idaes.core.util.initialization import (
     solve_indexed_blocks,
 )
 from idaes.core.util.misc import add_object_reference
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_unfixed_variables,

--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -51,7 +51,7 @@ from idaes.core.util.initialization import (
     revert_state_vars,
     solve_indexed_blocks,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_unfixed_variables,

--- a/watertap/property_models/tests/property_test_harness.py
+++ b/watertap/property_models/tests/property_test_harness.py
@@ -37,7 +37,7 @@ from idaes.core.util.scaling import (
     badly_scaled_var_generator,
 )
 from idaes.core.util.initialization import fix_state_vars
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 # -----------------------------------------------------------------------------

--- a/watertap/property_models/tests/test_coag_prop_pack.py
+++ b/watertap/property_models/tests/test_coag_prop_pack.py
@@ -33,7 +33,7 @@ from idaes.core import (
 from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 import idaes.core.util.scaling as iscale
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 __author__ = "Austin Ladshaw"
 

--- a/watertap/property_models/tests/test_multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/tests/test_multicomp_aq_sol_prop_pack.py
@@ -57,7 +57,7 @@ from idaes.core.util.scaling import (
 )
 from idaes.core.util.exceptions import ConfigurationError
 from watertap.property_models.tests.property_test_harness import PropertyAttributeError
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 # Imports from idaes core
 from idaes.core.base.components import Solvent, Solute, Cation, Anion

--- a/watertap/property_models/water_prop_pack.py
+++ b/watertap/property_models/water_prop_pack.py
@@ -50,7 +50,7 @@ from idaes.core.util.initialization import (
     revert_state_vars,
     solve_indexed_blocks,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_unfixed_variables,

--- a/watertap/tools/analysis_tools/loop_tool/loop_tool.py
+++ b/watertap/tools/analysis_tools/loop_tool/loop_tool.py
@@ -10,7 +10,7 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from watertap.tools.parameter_sweep import ParameterSweep, DifferentialParameterSweep
 from watertap.tools.parameter_sweep import ParameterSweepReader

--- a/watertap/tools/analysis_tools/loop_tool/tests/ro_setup.py
+++ b/watertap/tools/analysis_tools/loop_tool/tests/ro_setup.py
@@ -20,7 +20,7 @@ from watertap.tools.parameter_sweep.parameter_sweep_reader import ParameterSweep
 from watertap.tools.parameter_sweep.parameter_sweep_differential import (
     DifferentialParameterSweep,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import os
 
 __author__ = "Alexander V. Dudchenko (SLAC)"

--- a/watertap/tools/oli_api/util/state_block_helper_functions.py
+++ b/watertap/tools/oli_api/util/state_block_helper_functions.py
@@ -20,7 +20,7 @@ from pyomo.environ import (
 
 from idaes.core import FlowsheetBlock, MaterialFlowBasis
 from idaes.core.util.scaling import calculate_scaling_factors
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from watertap.property_models.multicomp_aq_sol_prop_pack import MCASParameterBlock
 

--- a/watertap/tools/parameter_sweep/parameter_sweep.py
+++ b/watertap/tools/parameter_sweep/parameter_sweep.py
@@ -16,7 +16,7 @@ import copy
 import time
 
 from abc import abstractmethod, ABC
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from idaes.core.surrogate.pysmo import sampling
 from pyomo.common.deprecation import deprecation_warning

--- a/watertap/unit_models/MD/membrane_distillation_base.py
+++ b/watertap/unit_models/MD/membrane_distillation_base.py
@@ -21,7 +21,7 @@ from pyomo.environ import (
 )
 
 from idaes.core import UnitModelBlockData
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util import scaling as iscale
 from idaes.core.util.exceptions import InitializationError
 from idaes.core.util.misc import add_object_reference

--- a/watertap/unit_models/anaerobic_digester.py
+++ b/watertap/unit_models/anaerobic_digester.py
@@ -61,7 +61,7 @@ from idaes.core.util.config import (
 
 import idaes.logger as idaeslog
 from idaes.core.util import scaling as iscale
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.constants import Constants
 from idaes.core.util.exceptions import ConfigurationError, InitializationError

--- a/watertap/unit_models/boron_removal.py
+++ b/watertap/unit_models/boron_removal.py
@@ -35,7 +35,7 @@ from idaes.core import (
     useDefault,
 )
 from idaes.core.util.constants import Constants
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale

--- a/watertap/unit_models/coag_floc_model.py
+++ b/watertap/unit_models/coag_floc_model.py
@@ -34,7 +34,7 @@ from idaes.core import (
     useDefault,
 )
 from idaes.core.util.constants import Constants
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.scaling as iscale

--- a/watertap/unit_models/crystallizer.py
+++ b/watertap/unit_models/crystallizer.py
@@ -29,7 +29,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.constants import Constants
 from idaes.core.util.config import is_physical_parameter_block

--- a/watertap/unit_models/electrodialysis_0D.py
+++ b/watertap/unit_models/electrodialysis_0D.py
@@ -35,7 +35,7 @@ from idaes.core import (
     useDefault,
 )
 from idaes.core.util.misc import add_object_reference
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.config import is_physical_parameter_block
 

--- a/watertap/unit_models/electrodialysis_1D.py
+++ b/watertap/unit_models/electrodialysis_1D.py
@@ -40,7 +40,7 @@ from idaes.core import (
     useDefault,
 )
 from idaes.core.util.constants import Constants
-from idaes.core.solvers.get_solver import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, InitializationError

--- a/watertap/unit_models/electrolyzer.py
+++ b/watertap/unit_models/electrolyzer.py
@@ -30,7 +30,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.constants import Constants
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.tables import create_stream_table_dataframe

--- a/watertap/unit_models/gac.py
+++ b/watertap/unit_models/gac.py
@@ -32,7 +32,7 @@ from idaes.core import (
     MaterialFlowBasis,
     useDefault,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.constants import Constants
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.tables import create_stream_table_dataframe

--- a/watertap/unit_models/ion_exchange_0D.py
+++ b/watertap/unit_models/ion_exchange_0D.py
@@ -33,7 +33,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.solvers.get_solver import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.constants import Constants
 from idaes.core.util.config import is_physical_parameter_block

--- a/watertap/unit_models/mvc/components/complete_condenser.py
+++ b/watertap/unit_models/mvc/components/complete_condenser.py
@@ -24,7 +24,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import InitializationError
 from idaes.core.util.model_statistics import degrees_of_freedom

--- a/watertap/unit_models/mvc/components/compressor.py
+++ b/watertap/unit_models/mvc/components/compressor.py
@@ -29,7 +29,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import InitializationError
 import idaes.core.util.scaling as iscale

--- a/watertap/unit_models/mvc/components/evaporator.py
+++ b/watertap/unit_models/mvc/components/evaporator.py
@@ -29,7 +29,7 @@ from idaes.core import (
     MomentumBalanceType,
     UnitModelBlockData,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 from idaes.core.util.functions import functions_lib

--- a/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
+++ b/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
@@ -14,7 +14,7 @@ import pytest
 from pyomo.environ import ConcreteModel, assert_optimal_termination, value
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models.heat_exchanger import (
     HeatExchanger,

--- a/watertap/unit_models/mvc/components/tests/test_complete_condenser.py
+++ b/watertap/unit_models/mvc/components/tests/test_complete_condenser.py
@@ -14,7 +14,7 @@ import pytest
 from pyomo.environ import ConcreteModel, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.core.util.scaling as iscale
 

--- a/watertap/unit_models/mvc/components/tests/test_compressor.py
+++ b/watertap/unit_models/mvc/components/tests/test_compressor.py
@@ -14,7 +14,7 @@ import pytest
 from pyomo.environ import ConcreteModel, assert_optimal_termination, value
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.core.util.scaling as iscale
 

--- a/watertap/unit_models/mvc/components/tests/test_evaporator.py
+++ b/watertap/unit_models/mvc/components/tests/test_evaporator.py
@@ -14,7 +14,7 @@ import pytest
 from pyomo.environ import ConcreteModel, assert_optimal_termination
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.core.util.scaling as iscale
 

--- a/watertap/unit_models/mvc/tests/test_mvc.py
+++ b/watertap/unit_models/mvc/tests/test_mvc.py
@@ -20,7 +20,7 @@ from pyomo.network import Arc
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog

--- a/watertap/unit_models/nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/nanofiltration_DSPMDE_0D.py
@@ -41,7 +41,7 @@ from idaes.core import (
     useDefault,
     MaterialFlowBasis,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.math import smooth_min
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.config import is_physical_parameter_block

--- a/watertap/unit_models/nanofiltration_ZO.py
+++ b/watertap/unit_models/nanofiltration_ZO.py
@@ -32,7 +32,7 @@ from idaes.core import (
     useDefault,
     MaterialFlowBasis,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, InitializationError

--- a/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
+++ b/watertap/unit_models/osmotically_assisted_reverse_osmosis_base.py
@@ -24,7 +24,7 @@ from pyomo.environ import (
     value,
 )
 from idaes.core import UnitModelBlockData
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util import scaling as iscale
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 from idaes.core.util.misc import add_object_reference

--- a/watertap/unit_models/pressure_exchanger.py
+++ b/watertap/unit_models/pressure_exchanger.py
@@ -33,7 +33,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 from idaes.core.util.tables import create_stream_table_dataframe

--- a/watertap/unit_models/reverse_osmosis_base.py
+++ b/watertap/unit_models/reverse_osmosis_base.py
@@ -23,7 +23,7 @@ from pyomo.environ import (
     units as pyunits,
 )
 from idaes.core import UnitModelBlockData
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util import scaling as iscale
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 from idaes.core.util.misc import add_object_reference

--- a/watertap/unit_models/stoichiometric_reactor.py
+++ b/watertap/unit_models/stoichiometric_reactor.py
@@ -42,7 +42,7 @@ from idaes.models.unit_models.separator import (
     SplittingType,
     EnergySplittingType,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.config import is_physical_parameter_block
 import idaes.core.util.scaling as iscale

--- a/watertap/unit_models/tests/test_aeration_tank.py
+++ b/watertap/unit_models/tests/test_aeration_tank.py
@@ -38,7 +38,7 @@ from idaes.core.util.testing import (
     initialization_tester,
 )
 from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 
 from watertap.unit_models.aeration_tank import AerationTank, ElectricityConsumption

--- a/watertap/unit_models/tests/test_anaerobic_digester.py
+++ b/watertap/unit_models/tests/test_anaerobic_digester.py
@@ -27,7 +27,7 @@ from idaes.core import (
     FlowsheetBlock,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from watertap.unit_models.anaerobic_digester import AD
 from watertap.property_models.anaerobic_digestion.adm1_properties import (

--- a/watertap/unit_models/tests/test_boron_removal.py
+++ b/watertap/unit_models/tests/test_boron_removal.py
@@ -64,7 +64,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 import idaes.core.util.scaling as iscale
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import re
 
 __author__ = "Austin Ladshaw"

--- a/watertap/unit_models/tests/test_clarifier.py
+++ b/watertap/unit_models/tests/test_clarifier.py
@@ -22,7 +22,7 @@ from idaes.core import (
     FlowsheetBlock,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from watertap.unit_models.tests.unit_test_harness import UnitTestHarness
 import idaes.core.util.scaling as iscale

--- a/watertap/unit_models/tests/test_coag_floc_model.py
+++ b/watertap/unit_models/tests/test_coag_floc_model.py
@@ -29,7 +29,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 import idaes.core.util.scaling as iscale
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import re
 
 __author__ = "Austin Ladshaw"

--- a/watertap/unit_models/tests/test_crystallizer.py
+++ b/watertap/unit_models/tests/test_crystallizer.py
@@ -18,7 +18,7 @@ from idaes.core import (
     FlowsheetBlock,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core import UnitModelCostingBlock
 
 from watertap.unit_models.tests.unit_test_harness import UnitTestHarness

--- a/watertap/unit_models/tests/test_cstr.py
+++ b/watertap/unit_models/tests/test_cstr.py
@@ -58,7 +58,7 @@ from idaes.core.util.testing import (
     ReactionParameterTestBlock,
     initialization_tester,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.initialization import (
     BlockTriangularizationInitializer,
     SingleControlVolumeUnitInitializer,

--- a/watertap/unit_models/tests/test_cstr_injection.py
+++ b/watertap/unit_models/tests/test_cstr_injection.py
@@ -46,7 +46,7 @@ from idaes.core.util.testing import (
     initialization_tester,
 )
 from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 
 from watertap.unit_models.cstr_injection import CSTR_Injection, ElectricityConsumption

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -33,7 +33,7 @@ from pyomo.environ import (
     units,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/tests/test_electroNP_ZO.py
+++ b/watertap/unit_models/tests/test_electroNP_ZO.py
@@ -22,7 +22,7 @@ from watertap.unit_models.electroNP_ZO import ElectroNPZO
 from watertap.property_models.activated_sludge.simple_modified_asm2d_properties import (
     SimpleModifiedASM2dParameterBlock,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core.util.scaling import calculate_scaling_factors

--- a/watertap/unit_models/tests/test_electrodialysis_0D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_0D.py
@@ -41,7 +41,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 import idaes.core.util.scaling as iscale
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 

--- a/watertap/unit_models/tests/test_electrodialysis_1D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_1D.py
@@ -40,7 +40,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 import idaes.core.util.scaling as iscale
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 

--- a/watertap/unit_models/tests/test_electrolyzer.py
+++ b/watertap/unit_models/tests/test_electrolyzer.py
@@ -14,7 +14,7 @@ import pytest
 import pyomo.environ as pyo
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.scaling import (
     calculate_scaling_factors,
 )

--- a/watertap/unit_models/tests/test_gac.py
+++ b/watertap/unit_models/tests/test_gac.py
@@ -18,7 +18,7 @@ from idaes.core import (
     FlowsheetBlock,
     UnitModelCostingBlock,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.exceptions import ConfigurationError
 from watertap.property_models.multicomp_aq_sol_prop_pack import MCASParameterBlock
 from watertap.unit_models.gac import GAC

--- a/watertap/unit_models/tests/test_ion_exchange_0D.py
+++ b/watertap/unit_models/tests/test_ion_exchange_0D.py
@@ -27,7 +27,7 @@ from idaes.core import (
     FlowsheetBlock,
     UnitModelCostingBlock,
 )
-from idaes.core.solvers.get_solver import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     number_variables,
     number_total_constraints,

--- a/watertap/unit_models/tests/test_membrane_distillation_0D.py
+++ b/watertap/unit_models/tests/test_membrane_distillation_0D.py
@@ -19,10 +19,10 @@ from pyomo.environ import (
     assert_optimal_termination,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from pyomo.environ import *
 from pyomo.network import Port
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/tests/test_membrane_distillation_1D.py
+++ b/watertap/unit_models/tests/test_membrane_distillation_1D.py
@@ -1,6 +1,6 @@
 from pyomo.environ import ConcreteModel
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 
 from idaes.core import (

--- a/watertap/unit_models/tests/test_nanofiltration_DSPMDE_0D.py
+++ b/watertap/unit_models/tests/test_nanofiltration_DSPMDE_0D.py
@@ -45,7 +45,7 @@ from watertap.unit_models.nanofiltration_DSPMDE_0D import (
 )
 from watertap.core.util.initialization import check_dof
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     number_variables,
     number_total_constraints,

--- a/watertap/unit_models/tests/test_nanofiltration_ZO.py
+++ b/watertap/unit_models/tests/test_nanofiltration_ZO.py
@@ -31,7 +31,7 @@ import watertap.property_models.multicomp_aq_sol_prop_pack as props
 from watertap.core.util.initialization import assert_no_degrees_of_freedom
 from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     number_variables,
     number_total_constraints,

--- a/watertap/unit_models/tests/test_osmotically_assisted_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_osmotically_assisted_reverse_osmosis_0D.py
@@ -34,7 +34,7 @@ from watertap.unit_models.osmotically_assisted_reverse_osmosis_0D import (
 from watertap.unit_models.reverse_osmosis_base import TransportModel
 import watertap.property_models.NaCl_prop_pack as props
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/tests/test_osmotically_assisted_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_osmotically_assisted_reverse_osmosis_1D.py
@@ -33,7 +33,7 @@ from watertap.unit_models.osmotically_assisted_reverse_osmosis_1D import (
 from watertap.unit_models.reverse_osmosis_base import TransportModel
 import watertap.property_models.NaCl_prop_pack as props
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/tests/test_pressure_changer.py
+++ b/watertap/unit_models/tests/test_pressure_changer.py
@@ -22,7 +22,7 @@ from pyomo.environ import (
 
 from pyomo.util.check_units import assert_units_consistent
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core.util.scaling import (

--- a/watertap/unit_models/tests/test_pressure_exchanger.py
+++ b/watertap/unit_models/tests/test_pressure_exchanger.py
@@ -39,7 +39,7 @@ from idaes.core.util.model_statistics import (
     number_total_constraints,
     number_unused_variables,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.testing import initialization_tester
 from idaes.core.util.scaling import (
     calculate_scaling_factors,

--- a/watertap/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_0D.py
@@ -11,7 +11,7 @@
 #################################################################################
 from pyomo.environ import ConcreteModel
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from idaes.core import FlowsheetBlock
 

--- a/watertap/unit_models/tests/test_reverse_osmosis_1D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_1D.py
@@ -11,7 +11,7 @@
 #################################################################################
 from pyomo.environ import ConcreteModel
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 
 from idaes.core import FlowsheetBlock
 

--- a/watertap/unit_models/tests/test_stoichiometric_reactor.py
+++ b/watertap/unit_models/tests/test_stoichiometric_reactor.py
@@ -23,7 +23,7 @@ from idaes.core import (
     FlowsheetBlock,
     UnitModelCostingBlock,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
 )

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -32,7 +32,7 @@ from pyomo.environ import (
     units,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/tests/test_uv_aop.py
+++ b/watertap/unit_models/tests/test_uv_aop.py
@@ -31,7 +31,7 @@ import watertap.property_models.NDMA_prop_pack as props
 from watertap.property_models.multicomp_aq_sol_prop_pack import (
     MCASParameterBlock,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/tests/unit_test_harness.py
+++ b/watertap/unit_models/tests/unit_test_harness.py
@@ -18,7 +18,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.testing import initialization_tester
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog

--- a/watertap/unit_models/translators/tests/test_translator_adm1_asm1.py
+++ b/watertap/unit_models/translators/tests/test_translator_adm1_asm1.py
@@ -30,7 +30,7 @@ from idaes.core import FlowsheetBlock
 
 from pyomo.environ import units
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/translators/tests/test_translator_adm1_asm2d.py
+++ b/watertap/unit_models/translators/tests/test_translator_adm1_asm2d.py
@@ -32,7 +32,7 @@ from pyomo.environ import (
     units,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/translators/tests/test_translator_adm1_simple_asm2d.py
+++ b/watertap/unit_models/translators/tests/test_translator_adm1_simple_asm2d.py
@@ -32,7 +32,7 @@ from pyomo.environ import (
     units,
 )
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/translators/tests/test_translator_asm1_adm1.py
+++ b/watertap/unit_models/translators/tests/test_translator_asm1_adm1.py
@@ -26,7 +26,7 @@ from idaes.core import FlowsheetBlock
 
 from pyomo.environ import units
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/translators/tests/test_translator_asm2d_adm1.py
+++ b/watertap/unit_models/translators/tests/test_translator_asm2d_adm1.py
@@ -31,7 +31,7 @@ from idaes.core import FlowsheetBlock
 
 from pyomo.environ import units
 
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import (
     degrees_of_freedom,
     number_variables,

--- a/watertap/unit_models/translators/translator_adm1_asm1.py
+++ b/watertap/unit_models/translators/translator_adm1_asm1.py
@@ -32,7 +32,7 @@ from idaes.core.util.config import (
     is_reaction_parameter_block,
 )
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 

--- a/watertap/unit_models/translators/translator_adm1_asm2d.py
+++ b/watertap/unit_models/translators/translator_adm1_asm2d.py
@@ -33,7 +33,7 @@ from idaes.core.util.config import (
     is_reaction_parameter_block,
 )
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 

--- a/watertap/unit_models/translators/translator_adm1_simple_asm2d.py
+++ b/watertap/unit_models/translators/translator_adm1_simple_asm2d.py
@@ -33,7 +33,7 @@ from idaes.core.util.config import (
     is_reaction_parameter_block,
 )
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 

--- a/watertap/unit_models/translators/translator_asm1_adm1.py
+++ b/watertap/unit_models/translators/translator_asm1_adm1.py
@@ -33,7 +33,7 @@ from idaes.core.util.config import (
     is_reaction_parameter_block,
 )
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 

--- a/watertap/unit_models/translators/translator_asm2d_adm1.py
+++ b/watertap/unit_models/translators/translator_asm2d_adm1.py
@@ -32,7 +32,7 @@ from idaes.core.util.config import (
     is_reaction_parameter_block,
 )
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.logger as idaeslog
 
 from pyomo.environ import (

--- a/watertap/unit_models/uv_aop.py
+++ b/watertap/unit_models/uv_aop.py
@@ -37,7 +37,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.exceptions import ConfigurationError, InitializationError

--- a/watertap/unit_models/zero_order/feed_zo.py
+++ b/watertap/unit_models/zero_order/feed_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from idaes.models.unit_models.feed import FeedData
 from idaes.core import declare_process_block_class
 import idaes.logger as idaeslog
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.exceptions import InitializationError
 
 from watertap.core import InitializationMixin

--- a/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_reactive_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_reactive_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_autothermal_hydrothermal_liquefaction_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_autothermal_hydrothermal_liquefaction_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_centrifuge_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_centrifuge_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
@@ -19,7 +19,7 @@ from pyomo.environ import Block, ConcreteModel, Constraint, Param, value, Var
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core.util.exceptions import ConfigurationError

--- a/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_cloth_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cloth_media_filtration_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
@@ -28,7 +28,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_electrocoagulation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrocoagulation_zo.py
@@ -28,7 +28,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_feed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_feed_zo.py
@@ -18,7 +18,7 @@ from pyomo.environ import ConcreteModel, value, Var
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 

--- a/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_gac_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_gac_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
+++ b/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
@@ -18,7 +18,7 @@ from types import MethodType
 from idaes.core import FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 import idaes.core.util.scaling as iscale
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_hrcs_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_hrcs_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_hydrothermal_gasification_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_hydrothermal_gasification_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_landfill_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_landfill_zo.py
@@ -19,7 +19,7 @@ from pyomo.environ import Block, ConcreteModel, Constraint, value, Var
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_mabr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mabr_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_magprex_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_magprex_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_mbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mbr_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_membrane_evaporator.py
+++ b/watertap/unit_models/zero_order/tests/test_membrane_evaporator.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_metab_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_metab_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_microbial_battery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microbial_battery_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
@@ -27,7 +27,7 @@ from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_ozone_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_zo.py
@@ -27,7 +27,7 @@ from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_peracetic_acid_disinfection_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_peracetic_acid_disinfection_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_pump_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_zo.py
@@ -19,7 +19,7 @@ from pyomo.environ import Block, ConcreteModel, Constraint, value, Var
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_screen_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_screen_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_smp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_smp_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_struvite_classifier_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_struvite_classifier_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_suboxic_activated_sludge_process_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_suboxic_activated_sludge_process_zo.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_supercritical_salt_precipitation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_supercritical_salt_precipitation_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_surface_discharge.py
+++ b/watertap/unit_models/zero_order/tests/test_surface_discharge.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
@@ -19,7 +19,7 @@ from pyomo.environ import Block, ConcreteModel, Constraint, value, Var
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_uv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_waiv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_waiv_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock

--- a/watertap/unit_models/zero_order/tests/test_well_field_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_well_field_zo.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from idaes.core.solvers import get_solver
+from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import initialization_tester
 from idaes.core import UnitModelCostingBlock


### PR DESCRIPTION
## Fixes #1348

## Summary/Motivation:
Presently, when `import watertap` runs we change the IDAES default to utilize the `ipopt-watertap` solver. This can mess with down stream projects as it is a side-effect of importing WaterTAP, e.g., https://github.com/prommis/prommis/issues/52.

This PR would remove this behavior, and replace it with WaterTAP's own implementation of `get_solver` which works identically to the IDAES version except it returns `ipopt-watertap` by default.

However, as a consequence, the behavior of `get_solver` _within_ IDAES has changed for WaterTAP -- it now gets the IDAES defaults when imported from `idaes.core.solvers`. As a result, we would need to specify the `ipopt-watertap` solver when calling certain IDAES methods, e.g., f5a55cc, to get the `ipopt-watertap` solver for initialization. Usually this does not matter, but this PR would make this change on flowsheets that fail without `ipopt-watertap` for unit model initialization.

## Changes proposed in this PR:
- Implement new `get_solver` method for WaterTAP (e8d7b85)
- Remove code which changes the default IDAES sovler to `ipopt-watertap` (510b948)
- Update all imports of `get_solver` to `watertap.core.solvers` (f628c03)
- Several fixes for affected flowsheets (519a85f, b99eee9, f5a55cc)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
