### PR TITLE
Correct Handling of Sludge Product in BSM2 Flowsheets

### DIFF
--- a/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2.py
+++ b/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2.py
@@ -175,6 +175,7 @@ def build():
 
     # Product Blocks
     m.fs.Treated = Product(property_package=m.fs.props_ASM1)
+    m.fs.Sludge = Product(property_package=m.fs.props_ASM1)
     # Recycle pressure changer - use a simple isothermal unit for now
     m.fs.P1 = PressureChanger(property_package=m.fs.props_ASM1)
 
@@ -263,6 +264,7 @@ def build():
     m.fs.stream9adm = Arc(source=m.fs.CL.underflow, destination=m.fs.MX4.clarifier)
     m.fs.stream4adm = Arc(source=m.fs.adm_asm.outlet, destination=m.fs.DU.inlet)
     m.fs.stream5adm = Arc(source=m.fs.DU.overflow, destination=m.fs.MX2.recycle1)
+    m.fs.stream11adm = Arc(source=m.fs.DU.underflow, destination=m.fs.Sludge.inlet)
     m.fs.stream01 = Arc(source=m.fs.FeedWater.outlet, destination=m.fs.MX2.feed_water1)
     m.fs.stream02 = Arc(source=m.fs.MX2.outlet, destination=m.fs.MX3.feed_water2)
     m.fs.stream03 = Arc(source=m.fs.MX3.outlet, destination=m.fs.CL.inlet)
@@ -592,6 +594,7 @@ def display_results(m):
         "SP6",
         "MX6",
         "Treated",
+        "Sludge",
         "P1",
         "asm_adm",
         "RADM",

--- a/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2_P_extension.py
+++ b/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/BSM2_P_extension.py
@@ -282,9 +282,8 @@ def build_flowsheet():
     m.fs.stream12 = Arc(source=m.fs.SP1.underflow, destination=m.fs.MX2.clarifier)
     m.fs.stream13 = Arc(source=m.fs.CL2.effluent, destination=m.fs.Treated.inlet)
     m.fs.stream14 = Arc(source=m.fs.CL2.underflow, destination=m.fs.SP2.inlet)
-    m.fs.stream15 = Arc(source=m.fs.SP2.waste, destination=m.fs.Sludge.inlet)
-    m.fs.stream16 = Arc(source=m.fs.SP2.recycle, destination=m.fs.P1.inlet)
-    m.fs.stream17 = Arc(source=m.fs.P1.outlet, destination=m.fs.MX1.recycle)
+    m.fs.stream15 = Arc(source=m.fs.SP2.recycle, destination=m.fs.P1.inlet)
+    m.fs.stream16 = Arc(source=m.fs.P1.outlet, destination=m.fs.MX1.recycle)
 
     # Link units related to AD section
     m.fs.stream_AD_translator = Arc(
@@ -304,6 +303,9 @@ def build_flowsheet():
     m.fs.stream1a = Arc(source=m.fs.FeedWater.outlet, destination=m.fs.MX3.feed_water)
     m.fs.stream1b = Arc(source=m.fs.MX3.outlet, destination=m.fs.CL.inlet)
     m.fs.stream1c = Arc(source=m.fs.CL.effluent, destination=m.fs.MX1.feed_water)
+    m.fs.stream_dewater_sludge = Arc(
+        source=m.fs.dewater.underflow, destination=m.fs.Sludge.inlet
+    )
     m.fs.stream_dewater_mixer = Arc(
         source=m.fs.dewater.overflow, destination=m.fs.MX3.recycle1
     )

--- a/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
+++ b/watertap/examples/flowsheets/case_studies/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
@@ -142,12 +142,12 @@ class TestFullFlowsheet:
         assert degrees_of_freedom(system_frame) == 10
 
         # check costing
-        assert value(m.fs.costing.LCOW) == pytest.approx(0.34972758073141264, rel=1e-5)
+        assert value(m.fs.costing.LCOW) == pytest.approx(0.3497531, rel=1e-5)
         assert value(m.fs.costing.total_capital_cost) == pytest.approx(
-            17442292.403007757, rel=1e-5
+            17441736.89749642, rel=1e-5
         )
         assert value(m.fs.costing.total_operating_cost) == pytest.approx(
-            629551.5401543011, rel=1e-5
+            629780.1104274583, rel=1e-5
         )
 
 
@@ -257,10 +257,10 @@ class TestFullFlowsheet_with_equal_reactor_vols:
         assert degrees_of_freedom(system_frame) == 8
 
         # check costing
-        assert value(m.fs.costing.LCOW) == pytest.approx(0.3497275473625334, rel=1e-5)
+        assert value(m.fs.costing.LCOW) == pytest.approx(0.3497531, rel=1e-5)
         assert value(m.fs.costing.total_capital_cost) == pytest.approx(
-            17442295.41949518, rel=1e-5
+            17441740.61915915, rel=1e-5
         )
         assert value(m.fs.costing.total_operating_cost) == pytest.approx(
-            629551.0120138308, rel=1e-5
+            629779.9546967598, rel=1e-5
         )


### PR DESCRIPTION
## Fixes/Resolves:

Fixes an issue where `m.fs.SP2.waste` was mistakenly set as the source in two separate arcs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
