### PR TITLE
Passing through the base solver attributes for solver wrapper

### DIFF
--- a/watertap/core/plugins/solvers.py
+++ b/watertap/core/plugins/solvers.py
@@ -51,8 +51,12 @@ class IpoptWaterTAP:
         for opt_key, opt_val in kwds.get("options", {}).items():
             setattr(self.options, opt_key, opt_val)
 
-    def executable(self):
-        return self._base_solver().executable()
+    def __getattr__(self, attr):
+        # if not available here, ask the _base_solver
+        try:
+            return getattr(self._base_solver(), attr)
+        except AttributeError:
+            raise
 
     def solve(self, blk, *args, **kwds):
 

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -75,6 +75,11 @@ class TestIpoptWaterTAP:
         assert s.available()
 
     @pytest.mark.unit
+    def test_attribute_nonpassthrough(self, s):
+        with pytest.raises(AttributeError, match=".*this_attribute_should_not_exist.*"):
+            s.this_attribute_should_not_exist
+
+    @pytest.mark.unit
     def test_presolve_scales_constraints_and_relaxes_bounds(self, m, s):
         s._scale_constraints(m)
         for c, sf in s._scaling_cache:

--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -70,6 +70,11 @@ class TestIpoptWaterTAP:
         assert get_solver().__class__ is IpoptWaterTAP
 
     @pytest.mark.unit
+    @pytest.mark.requires_idaes_solver
+    def test_attribute_passthrough(self, s):
+        assert s.available()
+
+    @pytest.mark.unit
     def test_presolve_scales_constraints_and_relaxes_bounds(self, m, s):
         s._scale_constraints(m)
         for c, sf in s._scaling_cache:


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
@hunterbarber found that `ipopt-watertap` does not have an `available` attribute, which is used in some Pyomo workflows. This PR would update the solver wrapper for `ipopt-watertap` to pass-through the attributes for the base solver.

## Changes proposed in this PR:
- Generalize `executable` implementation in the `ipopt-watertap` wrapper to `__getattr__` to retrieve missing attributes from the `_base_solver`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
