### PR TITLE
CSTR and Clarifier Unit Model Documentation

### DIFF
--- a/docs/technical_reference/flowsheets/ASM1.rst
+++ b/docs/technical_reference/flowsheets/ASM1.rst
@@ -34,8 +34,8 @@ The flowsheet relies on the following key assumptions:
 
 Documentation for each of the unit models can be found below. All unit models were set up with their default configuration arguments.
     * `CSTR <https://idaes-pse.readthedocs.io/en/latest/reference_guides/model_libraries/generic/unit_models/cstr.html>`_
-    * Aeration tank
-    * Secondary clarifier
+    * `Aeration tank <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/aeration_tank.html>`_
+    * `Secondary clarifier <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/clarifier.html>`_
 
 Documentation for the property model can be found below.
     * `ASM1 <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_

--- a/docs/technical_reference/flowsheets/ASM2d.rst
+++ b/docs/technical_reference/flowsheets/ASM2d.rst
@@ -34,8 +34,8 @@ The flowsheet relies on the following key assumptions:
 
 Documentation for each of the unit models can be found below. All unit models were set up with their default configuration arguments.
     * `CSTR <https://idaes-pse.readthedocs.io/en/latest/reference_guides/model_libraries/generic/unit_models/cstr.html>`_
-    * Aeration tank
-    * Secondary clarifier
+    * `Aeration tank <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/aeration_tank.html>`_
+    * `Secondary clarifier <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/clarifier.html>`_
 
 Documentation for the property model can be found below.
     * `ASM2d <https://watertap.readthedocs.io/en/stable/technical_reference/property_models/ASM2D.html>`_

--- a/docs/technical_reference/flowsheets/BSM2.rst
+++ b/docs/technical_reference/flowsheets/BSM2.rst
@@ -43,9 +43,9 @@ Documentation for each of the unit models can be found below. All unit models we
     * `CSTR <https://idaes-pse.readthedocs.io/en/latest/reference_guides/model_libraries/generic/unit_models/cstr.html>`_
     * `ADM1 to ASM1 Translator <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/translators/translator_adm1_asm1.html>`_
     * `ASM1 to ADM1 Translator <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/translators/translator_asm1_adm1.html>`_
-    * Aeration tank
-    * Primary clarifier
-    * Secondary clarifier
+    * `Aeration tank <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/aeration_tank.html>`_
+    * `Primary clarifier <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/clarifier.html>`_
+    * `Secondary clarifier <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/clarifier.html>`_
 
 Documentation for each of the property models can be found below.
     * `ASM1 <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_

--- a/docs/technical_reference/flowsheets/extended_BSM2.rst
+++ b/docs/technical_reference/flowsheets/extended_BSM2.rst
@@ -47,9 +47,9 @@ Documentation for each of the unit models can be found below. All unit models we
     * `CSTR <https://idaes-pse.readthedocs.io/en/latest/reference_guides/model_libraries/generic/unit_models/cstr.html>`_
     * `ADM1 to ASM2d Translator <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/translators/translator_adm1_asm2d.html>`_
     * `ASM2d to ADM1 Translator <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/translators/translator_asm2d_adm1.html>`_
-    * Aeration tank
-    * Primary clarifier
-    * Secondary clarifier
+    * `Aeration tank <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/aeration_tank.html>`_
+    * `Primary clarifier <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/clarifier.html>`_
+    * `Secondary clarifier <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/clarifier.html>`_
 
 Documentation for each of the property models can be found below.
     * `Modified ASM2d <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/modified_ASM2D.html>`_

--- a/docs/technical_reference/unit_models/aeration_tank.rst
+++ b/docs/technical_reference/unit_models/aeration_tank.rst
@@ -4,9 +4,10 @@ Aeration Tank
 .. index::
    pair: watertap.unit_models.aeration_tank;aeration_tank
 
-This aeration tank unit model inherits from the `CSTR with injection <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/cstr_injection.html>`_
-and assumes oxygen will be injected. The model makes the following assumptions:
+This aeration tank unit model inherits from the `CSTR with injection <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/cstr_injection.html>`_ .
+The model makes the following assumptions:
 
+   * oxygen is injected into the tank
    * is 0-dimensional
    * supports a single liquid phase only
    * supports steady-state only

--- a/docs/technical_reference/unit_models/aeration_tank.rst
+++ b/docs/technical_reference/unit_models/aeration_tank.rst
@@ -1,0 +1,77 @@
+Thickener
+=========
+
+.. index::
+   pair: watertap.unit_models.thickener;thickener
+
+The main assumptions of the implemented model are as follows:
+
+1) Single liquid phase only
+2) Steady state only
+3) Has no volume
+
+Introduction
+------------
+Sludge thickening is a process commonly used in wastewater treatment plants to increase the sludge concentration of a stream
+as well as reduce its volume by removing free water. In doing so, the thickener reduces the load of downstream processes,
+such as digestion and dewatering. This implementation of the thickener unit is based on the `IDAES separator unit <https://idaes-pse.readthedocs.io/en/stable/reference_guides/model_libraries/generic/unit_models/separator.html>`_.
+
+Degrees of Freedom
+------------------
+The degrees of freedom in a thickener unit model are the inlet feed state variables:
+
+    * temperature
+    * pressure
+    * component mass compositions
+
+Model Structure
+---------------
+The thickener unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum
+balances to split the inlet stream into two outlet streams. Thickener models have a single inlet Port
+(named inlet) and two outlet Ports (named overflow and underflow).
+
+Sets
+----
+.. csv-table::
+   :header: "Description", "Symbol", "Indices"
+
+   "Time", ":math:`t`", "[0]"
+   "Phases", ":math:`p`", "['Liq']"
+   "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
+   "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
+
+NOTE: These components are defined in the `ASM1 Property Package <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_ documentation.
+
+Parameters
+----------
+.. csv-table::
+   :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
+
+   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
+   "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
+
+
+Equations and Relationships
+---------------------------
+
+.. csv-table::
+   :header: "Description", "Equation"
+
+   "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
+   "Thickening factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
+   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
+   "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
+   "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
+
+Class Documentation
+-------------------
+.. currentmodule:: watertap.unit_models.thickener
+
+.. autoclass:: Thickener
+    :members:
+    :noindex:
+
+References
+----------
+J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson, I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer & P. A. Vanrolleghem
+Benchmark Simulation Model no. 2 (BSM2)

--- a/docs/technical_reference/unit_models/clarifier.rst
+++ b/docs/technical_reference/unit_models/clarifier.rst
@@ -1,0 +1,77 @@
+Thickener
+=========
+
+.. index::
+   pair: watertap.unit_models.thickener;thickener
+
+The main assumptions of the implemented model are as follows:
+
+1) Single liquid phase only
+2) Steady state only
+3) Has no volume
+
+Introduction
+------------
+Sludge thickening is a process commonly used in wastewater treatment plants to increase the sludge concentration of a stream
+as well as reduce its volume by removing free water. In doing so, the thickener reduces the load of downstream processes,
+such as digestion and dewatering. This implementation of the thickener unit is based on the `IDAES separator unit <https://idaes-pse.readthedocs.io/en/stable/reference_guides/model_libraries/generic/unit_models/separator.html>`_.
+
+Degrees of Freedom
+------------------
+The degrees of freedom in a thickener unit model are the inlet feed state variables:
+
+    * temperature
+    * pressure
+    * component mass compositions
+
+Model Structure
+---------------
+The thickener unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum
+balances to split the inlet stream into two outlet streams. Thickener models have a single inlet Port
+(named inlet) and two outlet Ports (named overflow and underflow).
+
+Sets
+----
+.. csv-table::
+   :header: "Description", "Symbol", "Indices"
+
+   "Time", ":math:`t`", "[0]"
+   "Phases", ":math:`p`", "['Liq']"
+   "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
+   "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
+
+NOTE: These components are defined in the `ASM1 Property Package <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_ documentation.
+
+Parameters
+----------
+.. csv-table::
+   :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
+
+   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
+   "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
+
+
+Equations and Relationships
+---------------------------
+
+.. csv-table::
+   :header: "Description", "Equation"
+
+   "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
+   "Thickening factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
+   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
+   "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
+   "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
+
+Class Documentation
+-------------------
+.. currentmodule:: watertap.unit_models.thickener
+
+.. autoclass:: Thickener
+    :members:
+    :noindex:
+
+References
+----------
+J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson, I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer & P. A. Vanrolleghem
+Benchmark Simulation Model no. 2 (BSM2)

--- a/docs/technical_reference/unit_models/clarifier.rst
+++ b/docs/technical_reference/unit_models/clarifier.rst
@@ -1,34 +1,29 @@
-Thickener
+Clarifier
 =========
 
 .. index::
-   pair: watertap.unit_models.thickener;thickener
+   pair: watertap.unit_models.clarifier;clarifier
 
-The main assumptions of the implemented model are as follows:
+This clarifier unit model is based on the `IDAES separator <https://idaes-pse.readthedocs.io/en/latest/reference_guides/model_libraries/generic/unit_models/separator.html>`_
+and makes the following assumptions:
 
-1) Single liquid phase only
-2) Steady state only
-3) Has no volume
-
-Introduction
-------------
-Sludge thickening is a process commonly used in wastewater treatment plants to increase the sludge concentration of a stream
-as well as reduce its volume by removing free water. In doing so, the thickener reduces the load of downstream processes,
-such as digestion and dewatering. This implementation of the thickener unit is based on the `IDAES separator unit <https://idaes-pse.readthedocs.io/en/stable/reference_guides/model_libraries/generic/unit_models/separator.html>`_.
+   * supports a single liquid phase only
+   * supports steady-state only
 
 Degrees of Freedom
 ------------------
-The degrees of freedom in a thickener unit model are the inlet feed state variables:
+Clarifier units have a number of degrees of freedom based on the separation type chosen, where the default configuration is `componentFlow`.
 
-    * temperature
-    * pressure
-    * component mass compositions
+* If `split_basis` = 'componentFlow', degrees of freedom are generally :math:`(no. outlets-1) \times no. components`
+* If `split_basis` = 'phaseFlow', degrees of freedom are generally :math:`(no. outlets-1) \times no. phases`
+* If `split_basis` = 'phaseComponentFlow', degrees of freedom are generally :math:`(no. outlets-1) \times no. phases \times no. components`
+* If `split_basis` = 'totalFlow', degrees of freedom are generally :math:`(no. outlets-1) \times no. phases \times no. components`
+
 
 Model Structure
 ---------------
-The thickener unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum
-balances to split the inlet stream into two outlet streams. Thickener models have a single inlet Port
-(named inlet) and two outlet Ports (named overflow and underflow).
+The clarifier unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum balances to split the inlet stream into a number of outlet streams.
+There is a single inlet port (named inlet) and a user-defined number of outlet ports.
 
 Sets
 ----
@@ -37,19 +32,17 @@ Sets
 
    "Time", ":math:`t`", "[0]"
    "Phases", ":math:`p`", "['Liq']"
-   "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
-   "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
+   "Components", ":math:`j`", "['H2O', 'NaCl']*"
 
-NOTE: These components are defined in the `ASM1 Property Package <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_ documentation.
+\*Solute depends on the imported property model; example shown here is for the NaCl property model.
 
-Parameters
-----------
+Variables
+---------
 .. csv-table::
-   :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
+   :header: "Description", "Symbol", "Variable Name", "Index", "Units"
 
-   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
-   "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
-
+   "Surface area", ":math:`A_{s}`", "surface_area", "None", ":math:`\text{m}^2`"
+   "Electricity intensity", ":math:`E_{I}`", "energy_electric_flow_vol_inlet", "None", ":math:`\text{kWh/}\text{m}^3`"
 
 Equations and Relationships
 ---------------------------
@@ -57,21 +50,12 @@ Equations and Relationships
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
-   "Thickening factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
-   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
-   "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
-   "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
+   "Electricity consumption", ":math:`E = E_{I} * Q_{in}`"
 
 Class Documentation
 -------------------
-.. currentmodule:: watertap.unit_models.thickener
+.. currentmodule:: watertap.unit_models.clarifier
 
-.. autoclass:: Thickener
+.. autoclass:: Clarifier
     :members:
     :noindex:
-
-References
-----------
-J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson, I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer & P. A. Vanrolleghem
-Benchmark Simulation Model no. 2 (BSM2)

--- a/docs/technical_reference/unit_models/cstr.rst
+++ b/docs/technical_reference/unit_models/cstr.rst
@@ -1,34 +1,26 @@
-Thickener
-=========
+Continuously Stirred Tank Reactor
+=================================
 
 .. index::
-   pair: watertap.unit_models.thickener;thickener
+   pair: watertap.unit_models.cstr;cstr
 
-The main assumptions of the implemented model are as follows:
+This CSTR unit model is based on the `IDAES CSTR <https://idaes-pse.readthedocs.io/en/latest/reference_guides/model_libraries/generic/unit_models/cstr.html>`_
+and makes the following assumptions:
 
-1) Single liquid phase only
-2) Steady state only
-3) Has no volume
-
-Introduction
-------------
-Sludge thickening is a process commonly used in wastewater treatment plants to increase the sludge concentration of a stream
-as well as reduce its volume by removing free water. In doing so, the thickener reduces the load of downstream processes,
-such as digestion and dewatering. This implementation of the thickener unit is based on the `IDAES separator unit <https://idaes-pse.readthedocs.io/en/stable/reference_guides/model_libraries/generic/unit_models/separator.html>`_.
+   * is 0-dimensional
+   * supports a single liquid phase only
+   * supports steady-state only
 
 Degrees of Freedom
 ------------------
-The degrees of freedom in a thickener unit model are the inlet feed state variables:
+Aside from the inlet feed state variables (i.e. temperature, pressure, component flowrates), the CSTR model has
+one degree of freedom that should be fixed for the unit to be fully specified.
 
-    * temperature
-    * pressure
-    * component mass compositions
+    * volume OR hydraulic retention time
 
 Model Structure
 ---------------
-The thickener unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum
-balances to split the inlet stream into two outlet streams. Thickener models have a single inlet Port
-(named inlet) and two outlet Ports (named overflow and underflow).
+The CSTR unit model consists of a single ControlVolume0D (named control_volume) with one inlet port (named inlet) and one outlet port (named outlet).
 
 Sets
 ----
@@ -36,20 +28,18 @@ Sets
    :header: "Description", "Symbol", "Indices"
 
    "Time", ":math:`t`", "[0]"
+   "Inlet/outlet", ":math:`x`", "['in', 'out']"
    "Phases", ":math:`p`", "['Liq']"
-   "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
-   "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
+   "Components", ":math:`j`", "['H2O', 'NaCl']*"
 
-NOTE: These components are defined in the `ASM1 Property Package <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_ documentation.
+\*Solute depends on the imported property model; example shown here is for the NaCl property model.
 
-Parameters
-----------
+Variables
+---------
 .. csv-table::
    :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
 
-   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
-   "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
-
+   "Hydraulic retention time", ":math:`HRT`", "hydraulic_retention_time", "[t]", "4", ":math:`\text{s}`"
 
 Equations and Relationships
 ---------------------------
@@ -57,21 +47,12 @@ Equations and Relationships
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
-   "Thickening factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
-   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
-   "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
-   "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
+   "CSTR retention time", ":math:`HRT = V / Q_{in}`"
 
 Class Documentation
 -------------------
-.. currentmodule:: watertap.unit_models.thickener
+.. currentmodule:: watertap.unit_models.cstr
 
-.. autoclass:: Thickener
+.. autoclass:: CSTR
     :members:
     :noindex:
-
-References
-----------
-J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson, I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer & P. A. Vanrolleghem
-Benchmark Simulation Model no. 2 (BSM2)

--- a/docs/technical_reference/unit_models/cstr.rst
+++ b/docs/technical_reference/unit_models/cstr.rst
@@ -1,0 +1,77 @@
+Thickener
+=========
+
+.. index::
+   pair: watertap.unit_models.thickener;thickener
+
+The main assumptions of the implemented model are as follows:
+
+1) Single liquid phase only
+2) Steady state only
+3) Has no volume
+
+Introduction
+------------
+Sludge thickening is a process commonly used in wastewater treatment plants to increase the sludge concentration of a stream
+as well as reduce its volume by removing free water. In doing so, the thickener reduces the load of downstream processes,
+such as digestion and dewatering. This implementation of the thickener unit is based on the `IDAES separator unit <https://idaes-pse.readthedocs.io/en/stable/reference_guides/model_libraries/generic/unit_models/separator.html>`_.
+
+Degrees of Freedom
+------------------
+The degrees of freedom in a thickener unit model are the inlet feed state variables:
+
+    * temperature
+    * pressure
+    * component mass compositions
+
+Model Structure
+---------------
+The thickener unit model does not use ControlVolumes, and instead writes a set of material, energy and momentum
+balances to split the inlet stream into two outlet streams. Thickener models have a single inlet Port
+(named inlet) and two outlet Ports (named overflow and underflow).
+
+Sets
+----
+.. csv-table::
+   :header: "Description", "Symbol", "Indices"
+
+   "Time", ":math:`t`", "[0]"
+   "Phases", ":math:`p`", "['Liq']"
+   "Particulate Components", ":math:`j`", "['X_I', 'X_S', 'X_P', 'X_BH', 'X_BA', 'X_ND']"
+   "Non-particulate Components", ":math:`j`", "['H2O', 'S_I', 'S_S', 'S_O', 'S_NO', 'S_NH', 'S_ND', 'S_ALK']"
+
+NOTE: These components are defined in the `ASM1 Property Package <https://watertap.readthedocs.io/en/latest/technical_reference/property_models/ASM1.html>`_ documentation.
+
+Parameters
+----------
+.. csv-table::
+   :header: "Description", "Symbol", "Variable Name", "Index", "Value", "Units"
+
+   "Percentage of suspended solids in the underflow", ":math:`p_{thick}`", "p_thick", "None", "0.07", ":math:`\text{dimensionless}`"
+   "Percentage of suspended solids removed", ":math:`TSS_{rem}`", "TSS_rem", "None", "0.98", ":math:`\text{dimensionless}`"
+
+
+Equations and Relationships
+---------------------------
+
+.. csv-table::
+   :header: "Description", "Equation"
+
+   "Suspended solid concentration", ":math:`C_{TSS} = 0.75 (C_{X_{I}} + C_{X_{IP}} + C_{X_{BH}} + C_{X_{BA}} + C_{X_{S}})`"
+   "Thickening factor", ":math:`f_{thick} = p_{thick} (\frac{10}{C_{TSS}})`"
+   "Remove factor", ":math:`f_{q_{du}} = \frac{TSS_{rem}}{100 * f_{thick}}`"
+   "Overflow particulate fraction", ":math:`split_{particulate} = 1 - TSS_{rem}`"
+   "Overflow soluble fraction", ":math:`split_{soluble} = 1 - f_{q_{du}}`"
+
+Class Documentation
+-------------------
+.. currentmodule:: watertap.unit_models.thickener
+
+.. autoclass:: Thickener
+    :members:
+    :noindex:
+
+References
+----------
+J. Alex, L. Benedetti, J.B. Copp, K.V. Gernaey, U. Jeppsson, I. Nopens, M.N. Pons, C. Rosen, J.P. Steyer & P. A. Vanrolleghem
+Benchmark Simulation Model no. 2 (BSM2)

--- a/docs/technical_reference/unit_models/cstr_injection.rst
+++ b/docs/technical_reference/unit_models/cstr_injection.rst
@@ -54,7 +54,7 @@ Variables
    "Hydraulic retention time", ":math:`HRT`", "hydraulic_retention_time", "[t]", ":math:`\text{s}`"
    "Dissolved oxygen concentration at equilibrium", ":math:`S_{O, eq}`", "S_O_eq", "None", ":math:`\text{kg/}\text{m}^3`"
    "Component injection", ":math:`I`", "injection", "[t, p, j]", ":math:`\text{kg/hr}`"
-   "Electricity intensity", ":math:`E_{I}`", "energy_electric_flow_vol_inlet", "None", ":math:`\text{s}`"
+   "Electricity intensity", ":math:`E_{I}`", "energy_electric_flow_vol_inlet", "None", ":math:`\text{kWh/}\text{m}^3`"
 
 Equations and Relationships
 ---------------------------

--- a/docs/technical_reference/unit_models/cstr_injection.rst
+++ b/docs/technical_reference/unit_models/cstr_injection.rst
@@ -1,11 +1,11 @@
-Aeration Tank
-=============
+Continuously Stirred Tank Reactor with Injection
+================================================
 
 .. index::
-   pair: watertap.unit_models.aeration_tank;aeration_tank
+   pair: watertap.unit_models.cstr_injection;cstr_injection
 
-This aeration tank unit model inherits from the `CSTR with injection <https://watertap.readthedocs.io/en/latest/technical_reference/unit_models/cstr_injection.html>`_
-and assumes oxygen will be injected. The model makes the following assumptions:
+This CSTR with injection unit model is based on the `IDAES CSTR <https://idaes-pse.readthedocs.io/en/latest/reference_guides/model_libraries/generic/unit_models/cstr.html>`_
+with the addition of mass transfer terms. The model makes the following assumptions:
 
    * is 0-dimensional
    * supports a single liquid phase only
@@ -13,13 +13,11 @@ and assumes oxygen will be injected. The model makes the following assumptions:
 
 Degrees of Freedom
 ------------------
-Aside from the inlet feed state variables (i.e. temperature, pressure, component flowrates), the aeration tank model has
-four degree of freedoms, and additional degrees of freedom may need to be specified depending on the configuration options.
+Aside from the inlet feed state variables (i.e. temperature, pressure, component flowrates), the CSTR with injection model has
+two degree of freedoms, and additional degrees of freedom may need to be specified depending on the configuration options.
 
     * volume OR hydraulic retention time
     * injection rates for all components
-    * lumped mass transfer coefficient for oxygen (KLa)*
-    * dissolved oxygen concentration at equilibrium (:math:`S_{O, eq}`)*
 
 If heat transfer is included:
     * heat duty
@@ -27,11 +25,14 @@ If heat transfer is included:
 If pressure change is included:
     * change in pressure (ΔP)
 
-\*These degrees of freedom should only be included if the oxygen injection rate is not specified and needs to be calculated
+If aeration is included, the following degrees of freedom could replace the oxygen injection rate:
+    * lumped mass transfer coefficient for oxygen (KLa)
+    * dissolved oxygen concentration at equilibrium (:math:`S_{O, eq}`)
+
 
 Model Structure
 ---------------
-The aeration tank unit model consists of a single ControlVolume0D (named control_volume) with one inlet port (named inlet) and one outlet port (named outlet).
+The CSTR with injection unit model consists of a single ControlVolume0D (named control_volume) with one inlet port (named inlet) and one outlet port (named outlet).
 
 Sets
 ----
@@ -53,7 +54,7 @@ Variables
    "Hydraulic retention time", ":math:`HRT`", "hydraulic_retention_time", "[t]", ":math:`\text{s}`"
    "Dissolved oxygen concentration at equilibrium", ":math:`S_{O, eq}`", "S_O_eq", "None", ":math:`\text{kg/}\text{m}^3`"
    "Component injection", ":math:`I`", "injection", "[t, p, j]", ":math:`\text{kg/hr}`"
-   "Electricity intensity", ":math:`E_{I}`", "energy_electric_flow_vol_inlet", "None", ":math:`\text{kWh/}\text{m}^3`"
+   "Electricity intensity", ":math:`E_{I}`", "energy_electric_flow_vol_inlet", "None", ":math:`\text{s}`"
 
 Equations and Relationships
 ---------------------------
@@ -61,15 +62,15 @@ Equations and Relationships
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Aeration tank retention time", ":math:`HRT = V / Q_{in}`"
+   "CSTR retention time", ":math:`HRT = V / Q_{in}`"
    "Oxygen mass transfer", ":math:`I_{O} = KLa * V * (S_{O, eq} - C_{O})`"
    "Electricity consumption (without aeration)", ":math:`E = E_{I} * Q_{in}`"
    "Electricity consumption (with aeration)", ":math:`E = \frac{S_{O, eq}}{1.8} * V * KLa`"
 
 Class Documentation
 -------------------
-.. currentmodule:: watertap.unit_models.aeration_tank
+.. currentmodule:: watertap.unit_models.cstr_injection
 
-.. autoclass:: AerationTank
+.. autoclass:: CSTR_Injection
     :members:
     :noindex:

--- a/docs/technical_reference/unit_models/index.rst
+++ b/docs/technical_reference/unit_models/index.rst
@@ -11,6 +11,7 @@ Unit Models
    coag_floc_model
    crystallizer_0D
    cstr
+   cstr_injection
    dewatering
    electrodialysis_0D
    electrodialysis_1D

--- a/docs/technical_reference/unit_models/index.rst
+++ b/docs/technical_reference/unit_models/index.rst
@@ -4,28 +4,31 @@ Unit Models
 .. toctree::
    :maxdepth: 1
 
-   reverse_osmosis_0D
-   reverse_osmosis_1D
-   nanofiltration_ZO
-   nanofiltration_dspmde_0D
-   pressure_exchanger
+   anaerobic_digester
+   aeration_tank
+   boron_removal
+   clarifier
    coag_floc_model
    crystallizer_0D
-   boron_removal
+   cstr
+   dewatering
    electrodialysis_0D
    electrodialysis_1D
    electrolyzer
-   uv_aop
+   electroNP_ZO
    gac
-   osmotically_assisted_reverse_osmosis_0D
-   osmotically_assisted_reverse_osmosis_1D
-   anaerobic_digester
    ion_exchange_0D
    membrane_distillation_0D
    mvc
-   thickener
-   dewatering
-   electroNP_ZO
-   translators/index
-   zero_order_unit_models/index
+   nanofiltration_ZO
+   nanofiltration_dspmde_0D
+   osmotically_assisted_reverse_osmosis_0D
+   osmotically_assisted_reverse_osmosis_1D
+   pressure_exchanger
+   reverse_osmosis_0D
+   reverse_osmosis_1D
    stoichiometric_reactor
+   thickener
+   translators/index
+   uv_aop
+   zero_order_unit_models/index


### PR DESCRIPTION
## Fixes/Resolves:

Issue #1219 


## Changes proposed in this PR:
- Alphabetizes the index list of unit models
- Adds unit model documentation for CSTR, CSTR_injection, aeration tank, and clarifier
- Adds links to these new unit model docs in the BSM2 and ASM flowsheet documentation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
