### PR TITLE
Update idaes-pse requirement to support Pyomo 6.7.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ SPECIAL_DEPENDENCIES_FOR_PRERELEASE = [
     # update with a tag from the nawi-hub/idaes-pse
     # when a version of IDAES newer than the latest stable release from PyPI
     # will become needed for the watertap development
-    "idaes-pse @ git+https://github.com/IDAES/idaes-pse@refs/pull/1406/merge",
+    "idaes-pse @ git+https://github.com/watertap-org/idaes-pse@2.5.0.dev0.watertap.24.05.09",
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ SPECIAL_DEPENDENCIES_FOR_PRERELEASE = [
     # update with a tag from the nawi-hub/idaes-pse
     # when a version of IDAES newer than the latest stable release from PyPI
     # will become needed for the watertap development
-    "idaes-pse==2.4.0",
+    "idaes-pse @ git+https://github.com/IDAES/idaes-pse@refs/pull/1406/merge",
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.


### PR DESCRIPTION
## Summary/Motivation:

~~Test compatibility of upcoming Pyomo and/or IDAES releases~~
Ensure compatibility of IDAES with Pyomo 6.7.2 by updating `idaes-pse` requirement to a version that includes IDAES/idaes-pse#1402

## Next steps

- [x] Wait for IDAES/idaes-pse#1406 to get merged
- [x] Update watertap-org/idaes-pse
- [x] Update this PR so that the `idaes-pse` requirement points to the latest tag on `watertap-org/idaes-pse`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
