### PR TITLE
Use nbviewer for statically browsing tutorials

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,8 +1,16 @@
 Tutorials
 =========
 
+Browsing the tutorials
+----------------------
+
 The tutorials included with WaterTAP are available in the "tutorials" directory
-on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree/main/tutorials/00-index.ipynb>`_.
+of the WaterTAP GitHub repository: `<https://github.com/watertap-org/watertap/tree/main/tutorials/>`_.
+
+To view a static version of the notebooks online, you can use the following link: `<https://nbviewer.org/github/watertap-org/watertap/blob/main/tutorials/00-index.ipynb>`_.
+
+Running the notebooks
+---------------------
 
 .. note::
     For important details on running tutorial notebooks, refer to :ref:`this guide<notebooks>`.
@@ -13,6 +21,9 @@ on the WaterTAP GitHub Homepage: `<https://github.com/watertap-org/watertap/tree
     **The use of Binder is currently an experimental effort for WaterTAP. Binder may take a long time to launch completely or may not launch successfully at all in some cases. If this happens, please follow the link to tutorials that was provided above.**
 
     |Binder launch button|
+
+Additional resources
+--------------------
 
 Since WaterTAP is based on the IDAES platform and follows its conventions,
 the `IDAES tutorials <https://idaes-pse.readthedocs.io/en/stable/tutorials/tutorials_examples.html>`_ are a good starting point for learning how to use WaterTAP.


### PR DESCRIPTION
## Fixes/Resolves:

- Notebooks not rendering using GitHub
- This might or might not be a temporary problem on the side of GitHub's infrastructure

![image](https://github.com/watertap-org/watertap/assets/48035537/0cad470c-42b6-48e6-bfbd-3b1620bc8c12)

## Summary/Motivation:

- nbviewer should provide a more reliable and dedicated interface for users for browsing the tutorials: https://nbviewer.org/github/watertap-org/watertap/blob/main/tutorials/00-index.ipynb

## Changes proposed in this PR:

- Use nbviewer instead of GitHub for browsing tutorials
- Add some subsections to improve clarity

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
