### PR TITLE
Update GHA macOS version to macos-13 since macos-11 is deprecated

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -281,7 +281,7 @@ jobs:
 
   macos:
     name: macOS setup (EXPERIMENTAL)
-    runs-on: macos-11
+    runs-on: macos-13
     needs: [code-formatting]
     strategy:
       fail-fast: false


### PR DESCRIPTION
![image](https://github.com/watertap-org/watertap/assets/48035537/7af37d4c-ce06-4171-9a4d-732407f5386f)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
