### PR TITLE
Remove xfail marker for Pyomo/pyomo#3295

### DIFF
--- a/watertap/core/plugins/tests/test_solvers.py
+++ b/watertap/core/plugins/tests/test_solvers.py
@@ -233,9 +233,6 @@ class TestIpoptWaterTAP:
         )
 
     @pytest.mark.unit
-    @pytest.mark.xfail(
-        reason="Needs https://github.com/Pyomo/pyomo/pull/3295", strict=True
-    )
     @pytest.mark.skipif(
         not pyo.SolverFactory("cyipopt").available(exception_flag=False),
         reason="cyipopt not available",


### PR DESCRIPTION
## Summary/Motivation

From https://github.com/watertap-org/watertap/pull/1471#issuecomment-2302082373

> > @bknueven @andrewlee94 @lbianchi-lbl We are currently pointing to IDAES main in this PR to incorporate the changes that were merged in IDAES PR #[1460](https://github.com/IDAES/idaes-pse/pulls?q=is%3Apr+is%3Aclosed)
> > I think that as a result of this, we are seeing a test failure related to cyipopt, and I was hoping one of you might be familiar with this issue or what might be causing it: `FAILED watertap/core/plugins/tests/test_solvers.py::TestIpoptWaterTAP::test_cyipopt_bound_relax_small ` If there is a quick fix for this, we could try resolving in a separate PR. Otherwise, my plan was to create an earlier tag that would incorporate the needed, aformentioned IDAES changes, and hopefully those changes went in before whatever is causing the cyipopt discrepancy. Thoughts?
> 
> I've encountered this in #1483, specifically [ecad89c](https://github.com/watertap-org/watertap/commit/ecad89c8260014a7d183336a8c08bae72c39ed3c). As I understand it was due to that test being marked `xfail` (with `strict=True`, i.e. causing a failure if the test unexpectedly passes), because of a feature being implemented in a Pyomo PR ([Pyomo/pyomo#3295](https://github.com/Pyomo/pyomo/pull/3295)) that ended up being in the release. In other words: the test was expected to fail before 6.8.0, and expected to pass after 6.8.0.
> 
> The change is already in #1483, but I should probably open a separate dedicated PR so that it can be merged ASAP.



### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
