### PR TITLE
Add __getattr__ for _BaseDebugSolverWrapper

### DIFF
--- a/watertap/core/plugins/solvers.py
+++ b/watertap/core/plugins/solvers.py
@@ -394,6 +394,13 @@ class _BaseDebugSolverWrapper:
 
         self._value_cache = pyo.ComponentMap()
 
+    def __getattr__(self, attr):
+        # if not available here, ask the base_solver
+        try:
+            return getattr(pyo.SolverFactory(self._base_solver), attr)
+        except AttributeError:
+            raise
+
     def restore_initial_values(self, blk):
         for var in blk.component_data_objects(pyo.Var, descend_into=True):
             var.set_value(self._value_cache[var], skip_validation=True)


### PR DESCRIPTION
## Fixes/Resolves: N/A

## Summary/Motivation:
Adding a slight convenience when using the debug solver wrapper so it completely mimics the underlying solver.

## Changes proposed in this PR:

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
