### PR TITLE
Update Getting Started Documentation

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -21,7 +21,7 @@ Create a Conda environment (in this example, named ``watertap``) where WaterTAP 
 
 .. code-block:: shell
 
-   conda create --name watertap --yes python=3.9 pip=21.1
+   conda create --name watertap --yes python=3.11
 
 Activate the ``watertap`` environment using the command given below. If the environment was activated successfully, the environment's name will be displayed in the terminal prompt such as ``(watertap) project-directory $``.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -21,7 +21,7 @@ Create a Conda environment (in this example, named ``watertap``) where WaterTAP 
 
 .. code-block:: shell
 
-   conda create --name watertap --yes python=3.8 pip=21.1
+   conda create --name watertap --yes python=3.9 pip=21.1
 
 Activate the ``watertap`` environment using the command given below. If the environment was activated successfully, the environment's name will be displayed in the terminal prompt such as ``(watertap) project-directory $``.
 
@@ -58,7 +58,7 @@ Create a Conda environment (in this example, named ``watertap``) where WaterTAP 
 
 .. code-block:: shell
 
-   conda create --name watertap --yes python=3.8 pip=21.1
+   conda create --name watertap --yes python=3.9 pip=21.1
 
 Activate the ``watertap`` environment using the command given below. If the environment was activated successfully, the environment's name will be displayed in the terminal prompt such as ``(watertap) project-directory $``.
 
@@ -143,7 +143,7 @@ Create a Conda environment (in this example, named ``watertap-dev``) where Water
 
 .. code-block:: shell
 
-   conda create --name watertap-dev --yes python=3.8 pip=21.1 && conda activate watertap-dev
+   conda create --name watertap-dev --yes python=3.9 pip=21.1 && conda activate watertap-dev
 
 Clone the WaterTAP repository to your local development machine using ``git clone``, then enter the newly created ``watertap`` subdirectory:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -58,7 +58,7 @@ Create a Conda environment (in this example, named ``watertap``) where WaterTAP 
 
 .. code-block:: shell
 
-   conda create --name watertap --yes python=3.9 pip=21.1
+   conda create --name watertap --yes python=3.11
 
 Activate the ``watertap`` environment using the command given below. If the environment was activated successfully, the environment's name will be displayed in the terminal prompt such as ``(watertap) project-directory $``.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -143,7 +143,7 @@ Create a Conda environment (in this example, named ``watertap-dev``) where Water
 
 .. code-block:: shell
 
-   conda create --name watertap-dev --yes python=3.9 pip=21.1 && conda activate watertap-dev
+   conda create --name watertap-dev --yes python=3.11 && conda activate watertap-dev
 
 Clone the WaterTAP repository to your local development machine using ``git clone``, then enter the newly created ``watertap`` subdirectory:
 


### PR DESCRIPTION
## Summary/Motivation:
The Getting Started documentation still recommends python 3.8, which is no longer compatible with IDAES 2.6

## Changes proposed in this PR:
- Changes the default python version from 3.8 to 3.11
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
