### PR TITLE
Address CI failures described in #1514

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,6 +102,7 @@ jobs:
       with:
         activate-environment: watertap-dev
         python-version: ${{ matrix.python-version }}
+        miniforge-version: latest
     - name: Install dependencies
       run: |
         echo '::group::Output of "conda install" commands'


### PR DESCRIPTION
## Resolves: #1514

## Proposed changes

- Configure `actions/setup-miniconda` so that Miniforge (and, more relevantly, the `conda-forge` channel) is used to create and manage Conda environments

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
