### PR TITLE
Update BSM2-P CSTR Model

### DIFF
--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
@@ -742,6 +742,11 @@ def add_costing(m):
         if isinstance(block, UnitModelBlockData) and hasattr(block, "costing"):
             iscale.set_scaling_factor(block.costing.capital_cost, 1e-5)
 
+    iscale.constraint_scaling_transform(m.fs.AD.costing.capital_cost_constraint, 1e-6)
+    iscale.constraint_scaling_transform(
+        m.fs.dewater.costing.capital_cost_constraint, 1e-6
+    )
+
 
 def display_costing(m):
     print("Levelized cost of water: %.2f $/m3" % pyo.value(m.fs.costing.LCOW))

--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
@@ -29,7 +29,6 @@ from idaes.core import (
     UnitModelBlockData,
 )
 from idaes.models.unit_models import (
-    CSTR,
     Feed,
     Separator,
     Product,
@@ -68,6 +67,7 @@ from watertap.unit_models.translators.translator_adm1_asm2d import (
 from idaes.models.unit_models.mixer import MomentumMixingType
 from watertap.unit_models.translators.translator_asm2d_adm1 import Translator_ASM2d_ADM1
 from watertap.unit_models.anaerobic_digester import AD
+from watertap.unit_models.cstr import CSTR
 from watertap.unit_models.dewatering import (
     DewateringUnit,
     ActivatedSludgeModelType as dewater_type,
@@ -537,6 +537,10 @@ def set_operating_conditions(m):
             if "conc_mass_comp" in var.name:
                 iscale.set_scaling_factor(var, 1e1)
 
+    for unit in ("R1", "R2", "R3", "R4"):
+        block = getattr(m.fs, unit)
+        iscale.set_scaling_factor(block.hydraulic_retention_time, 1e-3)
+
     for unit in ("R1", "R2", "R3", "R4", "R5", "R6", "R7"):
         block = getattr(m.fs, unit)
         iscale.set_scaling_factor(
@@ -550,7 +554,7 @@ def set_operating_conditions(m):
 
     iscale.set_scaling_factor(m.fs.AD.KH_co2, 1e1)
     iscale.set_scaling_factor(m.fs.AD.KH_ch4, 1e1)
-    iscale.set_scaling_factor(m.fs.AD.KH_h2, 1e1)
+    iscale.set_scaling_factor(m.fs.AD.KH_h2, 1e2)
 
     # Apply scaling
     scale_variables(m)

--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
@@ -88,7 +88,6 @@ from watertap.costing.unit_models.clarifier import (
     cost_circular_clarifier,
     cost_primary_clarifier,
 )
-from idaes.core.util import DiagnosticsToolbox
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)
@@ -141,11 +140,6 @@ def main(bio_P=False):
 
     results = solve(m)
     pyo.assert_optimal_termination(results)
-
-    dt = DiagnosticsToolbox(m)
-    dt.report_numerical_issues()
-    dt.display_variables_with_extreme_jacobians()
-    dt.display_constraints_with_extreme_jacobians()
 
     display_costing(m)
     display_performance_metrics(m)

--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension_ui.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension_ui.py
@@ -3873,7 +3873,7 @@ def build_flowsheet(build_options=None, **kwargs):
 
         m = build(bio_P=bioP)
 
-        set_operating_conditions(m)
+        set_operating_conditions(m, bio_P=bioP)
 
         for mx in m.fs.mixers:
             mx.pressure_equality_constraints[0.0, 2].deactivate()
@@ -3912,7 +3912,7 @@ def build_flowsheet(build_options=None, **kwargs):
     else:
         m = build(bio_P=False)
 
-        set_operating_conditions(m)
+        set_operating_conditions(m, bio_P=False)
 
         for mx in m.fs.mixers:
             mx.pressure_equality_constraints[0.0, 2].deactivate()

--- a/watertap/unit_models/anaerobic_digester.py
+++ b/watertap/unit_models/anaerobic_digester.py
@@ -838,7 +838,7 @@ see reaction package for documentation.}""",
 
         # TODO: improve this later; for now, this resolved some scaling issues for modified adm1 test file
         if "S_IP" in self.config.liquid_property_package.component_list:
-            iscale.set_scaling_factor(self.liquid_phase.heat, 1e-6)
+            # iscale.set_scaling_factor(self.liquid_phase.heat, 1e-6)
             sf = iscale.get_scaling_factor(
                 self.liquid_phase.properties_out[0].conc_mass_comp["S_IP"],
                 default=1e-5,

--- a/watertap/unit_models/anaerobic_digester.py
+++ b/watertap/unit_models/anaerobic_digester.py
@@ -838,7 +838,6 @@ see reaction package for documentation.}""",
 
         # TODO: improve this later; for now, this resolved some scaling issues for modified adm1 test file
         if "S_IP" in self.config.liquid_property_package.component_list:
-            # iscale.set_scaling_factor(self.liquid_phase.heat, 1e-6)
             sf = iscale.get_scaling_factor(
                 self.liquid_phase.properties_out[0].conc_mass_comp["S_IP"],
                 default=1e-5,


### PR DESCRIPTION
## Summary/Motivation:
The BSM2-P flowsheet used the IDAES CSTR, but it should be using the WaterTAP CSTR, which adds a constraint for hydraulic retention time.

## Changes proposed in this PR:
- Substitutes IDAES CSTR for WaterTAP CSTR in BSM2-P flowsheet
- Updates the flowsheet's scaling factor

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
