### PR TITLE
Exclude flexparser 0.4 as workaround for IDAES/idaes-pse#1524

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         # maintainers: switch to SPECIAL_DEPENDENCIES_FOR_RELEASE when cutting a release of watertap
         *SPECIAL_DEPENDENCIES_FOR_PRERELEASE,
         "pyomo>=6.6.1",
+        "flexparser != 0.4",  # IDAES/idaes-pse#1524
         "pyyaml",  # watertap.core.wt_database
         # for parameter_sweep
         "parameter-sweep>=0.1.dev5",


### PR DESCRIPTION
## Summary/Motivation:
- Work around failures due to IDAES/idaes-pse#1524 while the issue is dealt with upstream

## Changes proposed in this PR:
- Add requirement to exclude flexparser 0.4 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
