### PR TITLE
Update IDAES requirement in preparation to 2.7.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,14 @@ cwd = Path(__file__).parent
 long_description = (cwd / "README.md").read_text()
 
 SPECIAL_DEPENDENCIES_FOR_RELEASE = [
-    "idaes-pse>=2.6.0,<2.7.0rc0",  # from PyPI
+    "idaes-pse>=2.7.0,<2.8.0rc0",  # from PyPI
 ]
 
 SPECIAL_DEPENDENCIES_FOR_PRERELEASE = [
     # update with a tag from the nawi-hub/idaes-pse
     # when a version of IDAES newer than the latest stable release from PyPI
     # will become needed for the watertap development
-    "idaes-pse==2.6.0",
+    "idaes-pse @ git+https://github.com/watertap-org/idaes-pse@2.7.0.dev0.watertap.24.11.19",
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
         # maintainers: switch to SPECIAL_DEPENDENCIES_FOR_RELEASE when cutting a release of watertap
         *SPECIAL_DEPENDENCIES_FOR_PRERELEASE,
         "pyomo>=6.6.1",
-        "flexparser != 0.4",  # IDAES/idaes-pse#1524
         "pyyaml",  # watertap.core.wt_database
         # for parameter_sweep
         "parameter-sweep>=0.1.dev5",


### PR DESCRIPTION
## Needed by

- #1519 

## Changes proposed in this PR:
- Update `idaes-pse` requirement to latest tag `2.7.0.dev0.watertap.24.11.19`, corresponding to IDAES/idaes-pse@c4336ba
- Remove version constraints for `flexparser` added in #1521 as the issue IDAES/idaes-pse#1524 has been solved upstream and it is no longer necessary

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
