### PR TITLE
Ensure no unhandled warnings are emitted during pytest run

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,7 +126,7 @@ jobs:
       if: matrix.coverage
       run:
         |
-        echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --cov-report=xml" >> $GITHUB_ENV
+        echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --cov --cov-report=xml" >> $GITHUB_ENV
     - name: Test with pytest
       run: |
         pytest --pyargs watertap --idaes-flowsheets --entry-points-group watertap.flowsheets

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ defaults:
 env:
   # --color=yes needed for colorized output to be shown in GHA logs
   # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py
-  PYTEST_ADDOPTS: "--color=yes -Werror"
+  PYTEST_ADDOPTS: "--color=yes"
   PIP_PROGRESS_BAR: "off"
   WATERTAP_KERNEL_NAME: watertap-dev
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ defaults:
 env:
   # --color=yes needed for colorized output to be shown in GHA logs
   # --pyargs watertap is needed to be able to define CLI options in watertap/conftest.py
-  PYTEST_ADDOPTS: "--color=yes"
+  PYTEST_ADDOPTS: "--color=yes -Werror"
   PIP_PROGRESS_BAR: "off"
   WATERTAP_KERNEL_NAME: watertap-dev
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,3 @@ log_file = pytest.log
 log_file_date_format = %Y-%m-%dT%H:%M:%S
 log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(message)s
 log_file_level = INFO
-filterwarnings =
-    ignore::DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,7 @@ log_file_level = INFO
 filterwarnings =
     error
     # see IDAES/idaes-pse#1549
-   ignore:unclosed file .*Visualization-data/SA-.*\.bin:ResourceWarning
+   ignore:unclosed file .*Visualization-data.*SA-.*\.bin:ResourceWarning
    # emitted sporadically during nbmake tests
    ignore:unclosed <socket\.socket .*>:ResourceWarning
    ignore:unclosed event loop .*:ResourceWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,4 +11,5 @@ filterwarnings =
     error
     # see IDAES/idaes-pse#1549
    ignore:unclosed file .*Visualization-data/SA-.*\.bin:ResourceWarning
-   ignore::pytest.PytestUnraisableExceptionWarning
+   # emitted sporadically during nbmake tests
+   ignore:unclosed <socket\.socket .*>:ResourceWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,7 @@ log_file = pytest.log
 log_file_date_format = %Y-%m-%dT%H:%M:%S
 log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(message)s
 log_file_level = INFO
+filterwarnings =
+    error
+    # see IDAES/idaes-pse#1549
+   ignore:unclosed file .*Visualization-data/SA-.*\.bin:ResourceWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
-addopts = --durations=100
-          --cov=watertap
+addopts = --durations=10
           --cov-config=.coveragerc
 testpaths = watertap
 log_file = pytest.log

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ filterwarnings =
     error
     # see IDAES/idaes-pse#1549
    ignore:unclosed file .*Visualization-data/SA-.*\.bin:ResourceWarning
+   ignore::pytest.PytestUnraisableExceptionWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,3 @@ log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(messag
 log_file_level = INFO
 filterwarnings =
     ignore::DeprecationWarning
-markers =
-    unit: mark test as unit tests.
-    component: mark test as longer, bigger, more complex than unit tests.
-    ui: mark test as relevant to the ui

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,4 @@ filterwarnings =
    ignore:unclosed file .*Visualization-data/SA-.*\.bin:ResourceWarning
    # emitted sporadically during nbmake tests
    ignore:unclosed <socket\.socket .*>:ResourceWarning
+   ignore:unclosed event loop .*:ResourceWarning

--- a/watertap/core/tests/test_zero_order_base.py
+++ b/watertap/core/tests/test_zero_order_base.py
@@ -210,7 +210,7 @@ class TestZOBase:
         with pytest.raises(
             KeyError,
             match="fs.unit - no value provided for recovery_vol"
-            " \(index: None\) in database.",
+            r" \(index: None\) in database.",
         ):
             model.fs.unit.set_param_from_data(
                 model.fs.unit.recovery_vol, {"recovery_vol": {}}
@@ -230,7 +230,7 @@ class TestZOBase:
         with pytest.raises(
             KeyError,
             match="fs.unit - no units provided for recovery_vol"
-            " \(index: None\) in database.",
+            r" \(index: None\) in database.",
         ):
             model.fs.unit.set_param_from_data(
                 model.fs.unit.recovery_vol, {"recovery_vol": {"value": 0.42}}

--- a/watertap/flowsheets/RO_with_energy_recovery/tests/test_monte_carlo_sampling_RO_ERD.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/tests/test_monte_carlo_sampling_RO_ERD.py
@@ -18,6 +18,11 @@ from watertap.flowsheets.RO_with_energy_recovery.monte_carlo_sampling_RO_ERD imp
 )
 
 
+_parameter_sweep_expected_warning = pytest.warns(
+    UserWarning, match="No results .* to disk .*"
+)
+
+
 @pytest.mark.integration
 def test_monte_carlo_sampling():
 
@@ -38,7 +43,8 @@ def test_monte_carlo_sampling():
     )
 
     # Run the parameter sweep
-    global_results = run_parameter_sweep(None, seed=1)
+    with _parameter_sweep_expected_warning:
+        global_results = run_parameter_sweep(None, seed=1)
 
     # Compare individual values for specificity
     for value, truth_value in zip(global_results.flatten(), truth_values.flatten()):
@@ -73,13 +79,14 @@ def test_monte_carlo_sampling_with_files():
     print("default_config_fpath = ", default_config_fpath)
 
     # Run the parameter sweep
-    global_results = run_parameter_sweep(
-        seed=1,
-        read_sweep_params_from_file=True,
-        sweep_params_fname=sweep_params_fpath,
-        read_model_defauls_from_file=True,
-        defaults_fname=default_config_fpath,
-    )
+    with _parameter_sweep_expected_warning:
+        global_results = run_parameter_sweep(
+            seed=1,
+            read_sweep_params_from_file=True,
+            sweep_params_fname=sweep_params_fpath,
+            read_model_defauls_from_file=True,
+            defaults_fname=default_config_fpath,
+        )
 
     # Compare individual values for specificity
     for value, truth_value in zip(global_results.flatten(), truth_values.flatten()):
@@ -166,7 +173,8 @@ def test_lhs_sampling():
     )
 
     # Run the parameter sweep
-    global_results = run_parameter_sweep(seed=1, use_LHS=True)
+    with _parameter_sweep_expected_warning:
+        global_results = run_parameter_sweep(seed=1, use_LHS=True)
 
     # Compare individual values for specificity
     for value, truth_value in zip(global_results.flatten(), truth_values.flatten()):

--- a/watertap/flowsheets/activated_sludge/tests/test_modified_asm2d_flowsheet.py
+++ b/watertap/flowsheets/activated_sludge/tests/test_modified_asm2d_flowsheet.py
@@ -31,6 +31,11 @@ from watertap.flowsheets.activated_sludge.modified_ASM2D_flowsheet import (
 from idaes.core.util import DiagnosticsToolbox
 
 
+# lbianchi-lbl 2024-12-12: adding this as part of watertap-org/watertap#1540
+# this was only observed for macOS (EXPERIMENTAL) CI env which is slated for removal soon
+@pytest.mark.filterwarnings(
+    "ignore:divide by zero encountered in divide:RuntimeWarning"
+)
 class TestASM2DFlowsheet:
     @pytest.fixture(scope="class")
     def model(self):

--- a/watertap/flowsheets/anaerobic_digester/tests/test_modified_ADM1_flowsheet_with_translators.py
+++ b/watertap/flowsheets/anaerobic_digester/tests/test_modified_ADM1_flowsheet_with_translators.py
@@ -34,22 +34,20 @@ from watertap.core.solvers import get_solver
 solver = get_solver()
 
 
+@pytest.mark.requires_idaes_solver
 class TestADM1BioPFalse:
-    @pytest.mark.requires_idaes_solver
     @pytest.fixture(scope="class")
     def system_frame(self):
         m, res = main(bio_P=False)
         m.results = res
         return m
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.integration
     def test_structure(self, system_frame):
         assert_units_consistent(system_frame)
         assert degrees_of_freedom(system_frame) == 0
         assert_optimal_termination(system_frame.results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, system_frame):
         m = system_frame
@@ -113,22 +111,20 @@ class TestADM1BioPFalse:
         )
 
 
+@pytest.mark.requires_idaes_solver
 class TestADM1BioPTrue:
-    @pytest.mark.requires_idaes_solver
     @pytest.fixture(scope="class")
     def system_frame(self):
         m, res = main(bio_P=True)
         m.results = res
         return m
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.integration
     def test_structure(self, system_frame):
         assert_units_consistent(system_frame)
         assert degrees_of_freedom(system_frame) == 0
         assert_optimal_termination(system_frame.results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, system_frame):
         m = system_frame

--- a/watertap/flowsheets/electroNP/tests/test_BSM2_electroNP_no_bioP.py
+++ b/watertap/flowsheets/electroNP/tests/test_BSM2_electroNP_no_bioP.py
@@ -28,9 +28,9 @@ from watertap.flowsheets.electroNP.BSM2_electroNP_no_bioP import (
 )
 
 
+@pytest.mark.requires_idaes_solver
 class TestElectroNPFlowsheet:
     @pytest.fixture(scope="class")
-    @pytest.mark.requires_idaes_solver
     def model(self):
         m, res = m, results = main(has_electroNP=True)
 
@@ -38,14 +38,12 @@ class TestElectroNPFlowsheet:
 
         return m
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.integration
     def test_structure(self, model):
         assert_units_consistent(model)
         assert degrees_of_freedom(model) == 0
         assert_optimal_termination(model.results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.integration
     def test_results(self, model):
         # Treated water

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
@@ -34,22 +34,20 @@ from watertap.core.solvers import get_solver
 solver = get_solver()
 
 
+@pytest.mark.requires_idaes_solver
 class TestFullFlowsheetBioPFalse:
-    @pytest.mark.requires_idaes_solver
     @pytest.fixture(scope="class")
     def system_frame(self):
         m, res = main(bio_P=False)
         m.results = res
         return m
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.integration
     def test_structure(self, system_frame):
         assert_units_consistent(system_frame)
         assert degrees_of_freedom(system_frame) == 0
         assert_optimal_termination(system_frame.results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, system_frame):
         m = system_frame
@@ -112,7 +110,6 @@ class TestFullFlowsheetBioPFalse:
             0.00021570, rel=1e-3
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing(self, system_frame):
         m = system_frame
@@ -127,22 +124,20 @@ class TestFullFlowsheetBioPFalse:
         )
 
 
+@pytest.mark.requires_idaes_solver
 class TestFullFlowsheetBioPTrue:
-    @pytest.mark.requires_idaes_solver
     @pytest.fixture(scope="class")
     def system_frame(self):
         m, res = main(bio_P=True)
         m.results = res
         return m
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.integration
     def test_structure(self, system_frame):
         assert_units_consistent(system_frame)
         assert degrees_of_freedom(system_frame) == 0
         assert_optimal_termination(system_frame.results)
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_solve(self, system_frame):
         m = system_frame
@@ -205,7 +200,6 @@ class TestFullFlowsheetBioPTrue:
             0.00022424, rel=1e-3
         )
 
-    @pytest.mark.requires_idaes_solver
     @pytest.mark.component
     def test_costing(self, system_frame):
         m = system_frame

--- a/watertap/flowsheets/lsrro/tests/test_lssro_multi_sweep.py
+++ b/watertap/flowsheets/lsrro/tests/test_lssro_multi_sweep.py
@@ -33,7 +33,8 @@ def test_against_multisweep(number_of_stages, tmp_path):
     csv_baseline_file_name = os.path.join(
         _this_file_path, "parameter_sweep_baselines", csv_file_name
     )
-    run_case(number_of_stages, 2, output_filename=csv_test_file_name)
+    with pytest.warns(UserWarning, match="Too few points to perform interpolation\."):
+        run_case(number_of_stages, 2, output_filename=csv_test_file_name)
 
     baseline = pd.read_csv(csv_baseline_file_name).astype(float).T.to_dict()
     test = pd.read_csv(csv_test_file_name).astype(float).T.to_dict()

--- a/watertap/flowsheets/lsrro/tests/test_lssro_multi_sweep.py
+++ b/watertap/flowsheets/lsrro/tests/test_lssro_multi_sweep.py
@@ -33,7 +33,7 @@ def test_against_multisweep(number_of_stages, tmp_path):
     csv_baseline_file_name = os.path.join(
         _this_file_path, "parameter_sweep_baselines", csv_file_name
     )
-    with pytest.warns(UserWarning, match="Too few points to perform interpolation\."):
+    with pytest.warns(UserWarning, match=r"Too few points to perform interpolation\."):
         run_case(number_of_stages, 2, output_filename=csv_test_file_name)
 
     baseline = pd.read_csv(csv_baseline_file_name).astype(float).T.to_dict()

--- a/watertap/tools/oli_api/client.py
+++ b/watertap/tools/oli_api/client.py
@@ -54,7 +54,7 @@ import json
 import time
 from pyomo.common.dependencies import attempt_import
 
-requests, requests_available = attempt_import("requests", defer_check=False)
+requests, requests_available = attempt_import("requests", defer_import=False)
 from watertap.tools.oli_api.util.watertap_to_oli_helper_functions import get_oli_name
 
 

--- a/watertap/tools/oli_api/credentials.py
+++ b/watertap/tools/oli_api/credentials.py
@@ -56,10 +56,12 @@ from datetime import datetime, timedelta, timezone
 
 from pyomo.common.dependencies import attempt_import
 
-cryptography, cryptography_available = attempt_import("cryptography", defer_check=False)
+cryptography, cryptography_available = attempt_import(
+    "cryptography", defer_import=False
+)
 if cryptography_available:
     from cryptography.fernet import Fernet
-requests, requests_available = attempt_import("requests", defer_check=False)
+requests, requests_available = attempt_import("requests", defer_import=False)
 
 _logger = logging.getLogger(__name__)
 # set to info level, so user can see what is going on

--- a/watertap/unit_models/tests/test_generic_desalter.py
+++ b/watertap/unit_models/tests/test_generic_desalter.py
@@ -88,4 +88,3 @@ def test_solve():
     assert value(m.fs.unit.brine_solids_concentration) == pytest.approx(
         180.180, rel=1e-3
     )
-    return m

--- a/watertap/unit_models/tests/test_generic_desalter.py
+++ b/watertap/unit_models/tests/test_generic_desalter.py
@@ -65,7 +65,7 @@ def build():
     return m
 
 
-@pytest.mark.unit
+@pytest.mark.component
 def test_solve():
     m = build()
     m.fs.unit.initialize()

--- a/watertap/unit_models/tests/test_generic_separator.py
+++ b/watertap/unit_models/tests/test_generic_separator.py
@@ -83,5 +83,3 @@ def test_solve():
     assert value(
         m.fs.unit.treated.flow_mass_phase_comp[0, "Liq", "X"]
     ) == pytest.approx(0.005, rel=1e-3)
-
-    return m

--- a/watertap/unit_models/tests/test_generic_separator.py
+++ b/watertap/unit_models/tests/test_generic_separator.py
@@ -66,7 +66,7 @@ def build():
     return m
 
 
-@pytest.mark.unit
+@pytest.mark.component
 def test_solve():
     m = build()
     m.fs.unit.initialize()


### PR DESCRIPTION
## Resolves: #1508

## Changes proposed in this PR:
- Address warnings emitted by pytest for improper use
- Add handling for known warnings emitted by 3rd-party code (e.g. `parameter_sweep`) when running tests
- Add `-Werror` to default pytest flags used in CI to cause failure if new unhandled warnings appear
- Misc fixes to `pytest.ini` and test files

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
