### PR TITLE
Ensure `interval_initializer` always restores bounds

### DIFF
--- a/watertap/core/util/tests/test_initialization.py
+++ b/watertap/core/util/tests/test_initialization.py
@@ -179,3 +179,39 @@ class TestIntervalImproveInitial:
         assert m.y.ub == None
         assert m.z.lb == None
         assert m.z.ub == None
+
+    @pytest.fixture(scope="class")
+    def m_infeas(self):
+
+        # This is the same model used in the pyomo fbbt test at
+        # https://github.com/Pyomo/pyomo/blob/0e749d0c993df960af6cde0e775bef7cab6e2568/pyomo/contrib/fbbt/tests/test_fbbt.py#L957C9-L966C32
+
+        m = ConcreteModel()
+        m.x = Var(bounds=(-3, 3))
+        m.y = Var(bounds=(0, None))
+        m.z = Var()
+        m.c = ConstraintList()
+        m.c.add(m.x + m.y >= -1)
+        m.c.add(m.x + m.y <= -2)
+        m.c.add(m.y - m.x * m.z <= 2)
+        m.c.add(m.y - m.x * m.z >= -2)
+        m.c.add(m.x + m.z == 1)
+
+        return m
+
+    @pytest.mark.unit
+    def test_interval_initializer_failure_restores_bounds(self, m_infeas):
+        m = m_infeas
+        feasibility_tol = 1.0e-6
+        try:
+            interval_initializer(m, feasibility_tol=feasibility_tol)
+        except:
+            pass
+
+        # Assert the restored bounds
+        assert m.x.lb == -3.0
+        assert m.x.ub == 3.0
+        assert m.y.lb == 0.0
+        assert m.y.ub == None
+        assert m.z.lb == None
+        assert m.z.ub == None


### PR DESCRIPTION
## Fixes/Resolves:
If FBBT raises an exception which is caught, the interval initializer will fail to restore the bounds. This PR ensures the interval initializer will always restore the bounds even if an exception is caught.

## Summary/Motivation:
See above

## Changes proposed in this PR:
- Add failing test
- Wrap FBBT and value setting in try / except block to ensure we always execute the bounds restoration.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
