### PR TITLE
Update runner images in GitHub Actions workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,9 +87,9 @@ jobs:
           # - macos
         include:
           - os: linux
-            os-version: ubuntu-20.04
+            os-version: ubuntu-22.04
           - os: win64
-            os-version: windows-2019
+            os-version: windows-2022
           # - os: macos
           #   os-version: macos-10.15
           - python-version: '3.10'
@@ -186,9 +186,9 @@ jobs:
           - win64
         include:
           - os: linux
-            os-version: ubuntu-20.04
+            os-version: ubuntu-22.04
           - os: win64
-            os-version: windows-2019
+            os-version: windows-2022
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v3
@@ -240,9 +240,9 @@ jobs:
           - win64
         include:
           - os: linux
-            os-version: ubuntu-20.04
+            os-version: ubuntu-22.04
           - os: win64
-            os-version: windows-2019
+            os-version: windows-2022
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary/Motivation:

- `ubuntu-20.04` is deprecated and scheduled to be removed shortly (next week)
- This PR updates the OS images (for Linux and, while we're at it, Windows as well)
- These changes should be transparent, i.e. CI checks are expected to pass without other changes

## Changes proposed in this PR:

- `ubuntu-20.04` -> `ubuntu-22.04`
- `windows-2019` -> `windows-2022`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
