### PR TITLE
Change `electricity_cost` units to be `base_currency`

### DIFF
--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -503,7 +503,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         self.electricity_cost = pyo.Var(
             initialize=0.07,
             doc="Electricity cost",
-            units=pyo.units.USD_2018 / pyo.units.kWh,
+            units=self.base_currency / pyo.units.kWh,
         )
         self.defined_flows["electricity"] = self.electricity_cost
 

--- a/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
+++ b/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
@@ -124,8 +124,8 @@ class TestDyewithROFlowsheetwithPretreatment:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(14.87513, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(11.3793, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(14.91054, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(11.4088, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):
@@ -224,8 +224,8 @@ class TestDyewithROFlowsheetDefault:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(14.78139, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(11.29644, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(14.81836, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(11.32730, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):
@@ -324,8 +324,8 @@ class TestDyewith0DROFlowsheet:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(15.266753, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(11.354839, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(15.305355, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(11.386109, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):
@@ -426,8 +426,8 @@ class TestDyewithROFlowsheetwithDewatering:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(0.9423, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(-0.287357, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(0.97535, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(-0.256495, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     @pytest.mark.requires_idaes_solver
@@ -523,8 +523,8 @@ class TestDyewithROFlowsheetwithGAC:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(0.402766, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(-0.792087, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(0.435911, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(-0.76109, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     @pytest.mark.requires_idaes_solver


### PR DESCRIPTION
## Fixes/Resolves:

#1587 

## Summary/Motivation:


## Changes proposed in this PR:
- change the units for `electricity_cost` to be `base_currency`
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
