### PR TITLE
fail flag arg for interval_initializer

### DIFF
--- a/watertap/core/util/initialization.py
+++ b/watertap/core/util/initialization.py
@@ -14,7 +14,7 @@ This module contains utility functions for initialization of WaterTAP models.
 """
 
 
-__author__ = "Adam Atia"
+__author__ = "Adam Atia, Ben Knueven"
 
 from pyomo.environ import check_optimal_termination, ComponentMap, Var
 from pyomo.contrib.fbbt.fbbt import fbbt
@@ -151,7 +151,8 @@ def interval_initializer(
         feasibility_tol : tolerance to use for FBBT (default: 1e-6)
         default_initial_value: set uninitialized variables to this value (default: 0.0)
         logger : logger to use (default: watertap.core.util.initialization)
-        fail_flag: boolean that raises exception if True or logs warning when an exception occurs
+        fail_flag : Boolean argument to specify error or warning (Default: fail_flag=False produces logger warning.
+                        set fail_flag=True to raise an error and when interval initialization encounters exception.)
     Returns:
         None
 

--- a/watertap/core/util/initialization.py
+++ b/watertap/core/util/initialization.py
@@ -141,7 +141,7 @@ def assert_no_degrees_of_freedom(blk):
 
 
 def interval_initializer(
-    blk, feasibility_tol=1e-6, default_initial_value=0.0, logger=_log
+    blk, feasibility_tol=1e-6, default_initial_value=0.0, logger=_log, fail_flag=False
 ):
     """
     Improve the initialization of ``blk`` utilizing interval arithmetic.
@@ -151,7 +151,7 @@ def interval_initializer(
         feasibility_tol : tolerance to use for FBBT (default: 1e-6)
         default_initial_value: set uninitialized variables to this value (default: 0.0)
         logger : logger to use (default: watertap.core.util.initialization)
-
+        fail_flag: boolean that raises exception if True or logs warning when an exception occurs 
     Returns:
         None
 
@@ -190,9 +190,12 @@ def interval_initializer(
                     )
                     v.set_value(v.ub, skip_validation=True)
 
-    except:
-        raise
-
+    except Exception as e:
+        if fail_flag:
+            _log.error(f"Interval initializer failed for {blk} because of the following: {e}")
+            raise e
+        else:
+            _log.warning(f"Interval initializer failed for {blk} because of the following: {e}")
     finally:
         # restore the bounds before leaving this function
         for v, bounds in bound_cache.items():

--- a/watertap/core/util/initialization.py
+++ b/watertap/core/util/initialization.py
@@ -151,7 +151,7 @@ def interval_initializer(
         feasibility_tol : tolerance to use for FBBT (default: 1e-6)
         default_initial_value: set uninitialized variables to this value (default: 0.0)
         logger : logger to use (default: watertap.core.util.initialization)
-        fail_flag: boolean that raises exception if True or logs warning when an exception occurs 
+        fail_flag: boolean that raises exception if True or logs warning when an exception occurs
     Returns:
         None
 
@@ -192,10 +192,14 @@ def interval_initializer(
 
     except Exception as e:
         if fail_flag:
-            _log.error(f"Interval initializer failed for {blk} because of the following: {e}")
+            _log.error(
+                f"Interval initializer failed for {blk} because of the following: {e}"
+            )
             raise e
         else:
-            _log.warning(f"Interval initializer failed for {blk} because of the following: {e}")
+            _log.warning(
+                f"Interval initializer failed for {blk} because of the following: {e}"
+            )
     finally:
         # restore the bounds before leaving this function
         for v, bounds in bound_cache.items():

--- a/watertap/core/util/tests/test_initialization.py
+++ b/watertap/core/util/tests/test_initialization.py
@@ -203,9 +203,9 @@ class TestIntervalImproveInitial:
     def test_interval_initializer_failure_restores_bounds(self, m_infeas):
         m = m_infeas
         feasibility_tol = 1.0e-6
-  
+
         interval_initializer(m, feasibility_tol=feasibility_tol, fail_flag=False)
-  
+
         # Assert the restored bounds
         assert m.x.lb == -3.0
         assert m.x.ub == 3.0
@@ -217,15 +217,21 @@ class TestIntervalImproveInitial:
     @pytest.mark.unit
     def test_interval_initializer_raise_failure(self, m_infeas, caplog):
         caplog.set_level(idaeslog.INFO, logger="watertap.core.util.initialization")
-        
+
         m = m_infeas
         feasibility_tol = 1.0e-6
 
-        with pytest.raises(InfeasibleConstraintException, match=re.escape("Detected an infeasible constraint during FBBT: c[5]")):
+        with pytest.raises(
+            InfeasibleConstraintException,
+            match=re.escape("Detected an infeasible constraint during FBBT: c[5]"),
+        ):
             interval_initializer(m, feasibility_tol=feasibility_tol, fail_flag=True)
-            assert "Interval initializer failed for m_infeas because of the following: Detected an infeasible constraint during FBBT: c[5]" in caplog.text
+            assert (
+                "Interval initializer failed for m_infeas because of the following: Detected an infeasible constraint during FBBT: c[5]"
+                in caplog.text
+            )
             assert "ERROR" in caplog.text
-          
+
         # Assert the restored bounds
         assert m.x.lb == -3.0
         assert m.x.ub == 3.0
@@ -233,12 +239,15 @@ class TestIntervalImproveInitial:
         assert m.y.ub == None
         assert m.z.lb == None
         assert m.z.ub == None
-        
+
         interval_initializer(m, feasibility_tol=feasibility_tol, fail_flag=False)
-        
-        assert "Interval initializer failed for m_infeas because of the following: Detected an infeasible constraint during FBBT: c[5]" in caplog.text
+
+        assert (
+            "Interval initializer failed for m_infeas because of the following: Detected an infeasible constraint during FBBT: c[5]"
+            in caplog.text
+        )
         assert "WARNING" in caplog.text
-       
+
         # Assert the restored bounds
         assert m.x.lb == -3.0
         assert m.x.ub == 3.0

--- a/watertap/core/util/tests/test_initialization.py
+++ b/watertap/core/util/tests/test_initialization.py
@@ -1,5 +1,5 @@
 #################################################################################
-# WaterTAP Copyright (c) 2020-2024, The Regents of the University of California,
+# WaterTAP Copyright (c) 2020-2025, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory, Oak Ridge National Laboratory,
 # National Renewable Energy Laboratory, and National Energy Technology
 # Laboratory (subject to receipt of any required approvals from the U.S. Dept.
@@ -10,12 +10,12 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
+import re
 import pytest
 from pyomo.common.errors import InfeasibleConstraintException
 from pyomo.environ import ConcreteModel, Var, Constraint, ConstraintList
-import re
-from watertap.core.solvers import get_solver
 from idaes.core.util.exceptions import InitializationError
+from watertap.core.solvers import get_solver
 from watertap.core.util.initialization import (
     check_dof,
     assert_degrees_of_freedom,


### PR DESCRIPTION
## Fixes/Resolves:
## Summary/Motivation:
The `interval_initializer` utility function was previously implemented to improve model initialization, which it achieves for the most part. However, there are select cases where `InfeasibleConstraintException` will be raised, halting the initialization and subsequent optimization attempts (e.g., for a flowsheet where you might be ok with an imperfect initialization that gets the model to just the right point where it can be solved successfully). 

Here, I simply add a `fail_flag` arg to interval_initializer, set to False as default, so that it will log a warning if an exception is raised during interval_initializer calls. If the user wants to debug a troubled model, or just be more restrictive, the user can set fail_flag=True, which will log the error then raise the exception.

## Changes proposed in this PR:
- add fail_flag as arg to interval_initializer
- add tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
