### PR TITLE
Fix 1624

### DIFF
--- a/docs/how_to_guides/how_to_run_differential_parameter_sweep.rst
+++ b/docs/how_to_guides/how_to_run_differential_parameter_sweep.rst
@@ -197,10 +197,6 @@ With the flowsheet defined and suitably initialized, along with the definitions 
             seed=seed,
         )
 
-.. testoutput::
-
-    ...
-
 .. testcleanup::
 
     import os

--- a/docs/how_to_guides/how_to_use_debugging_solver_wrapper.rst
+++ b/docs/how_to_guides/how_to_use_debugging_solver_wrapper.rst
@@ -29,6 +29,11 @@ In a python module containing the model and script to solve that model, the user
  
     If you ran your python file in an interactive window, this debugging mode may not work as expected. We recommend running your python file in a terminal.
 
+.. testcleanup::
+
+   from watertap_solvers.model_debug_mode import deactivate
+   deactivate()
+
 Example behavior without debugging mode
 ---------------------------------------
 

--- a/docs/how_to_guides/how_to_use_parameter_sweep.rst
+++ b/docs/how_to_guides/how_to_use_parameter_sweep.rst
@@ -142,10 +142,6 @@ future versions. The preferred way is to pass in generating functions as shown b
 
     parameter_sweep(build_model, build_sweep_params, build_outputs, csv_results_file_name='outputs_results.csv', h5_results_file_name='outputs_results.h5')
 
-.. testoutput::
-
-    ...
-
 .. testcleanup::
 
     import os

--- a/docs/how_to_guides/how_to_use_parameter_sweep_monte_carlo.rst
+++ b/docs/how_to_guides/how_to_use_parameter_sweep_monte_carlo.rst
@@ -110,10 +110,6 @@ With the generating functions defined and suitably initialized, we can call the 
         optimize_function=RO_flowsheet.optimize, debugging_data_dir=debugging_data_dir, num_samples=num_samples, seed=seed,
         build_sweep_params_kwargs=dict(num_samples=num_samples))
 
-.. testoutput::
-
-    ...
-
 Note that ``num_samples`` must be provided for any of the random sample classes.  For the very small problem size and simple model used here, parallel hardware is almost certainly not necessary.  However, for larger total numbers of samples or more computationally demanding models, a significant speedup may be attained on a multi-core workstation or high performance computing (HPC) cluster.  To distribute the workload between more than one worker, simply call the scipt using the ``mpirun`` command from the command line
 
 .. code:: bash

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         # for parameter_sweep
         "parameter-sweep >=0.1.0",
         "numpy",
+        "pint<0.25",
     ],
     extras_require={
         "testing": [


### PR DESCRIPTION
## Fixes #1624

## Summary/Motivation:
Changes in Pint 0.25 are causing the Python 3.11 failures. Fix problematic doctests.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
