### PR TITLE
Off boarding lbianchi-lbl from code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
-* @lbianchi-lbl
+* @ksbeattie @sufikaur
 
-.binder/ @lbianchi-lbl
-.github/ @lbianchi-lbl
-setup.py @lbianchi-lbl
-pyproject.toml @lbianchi-lbl
-pytest*.ini @lbianchi-lbl
-docs/conf.py @lbianchi-lbl
-conftest.py @lbianchi-lbl
-requirements*.txt @lbianchi-lbl
-environment*.yml @lbianchi-lbl
-.git* @lbianchi-lbl
+.binder/ @ksbeattie
+.github/ @sufikaur
+setup.py @sufikaur
+pyproject.toml @sufikaur
+pytest*.ini @sufikaur
+docs/conf.py @sufikaur
+conftest.py @sufikaur
+requirements*.txt @sufikaur
+environment*.yml @sufikaur
+.git* @sufikaur
 
 /docs/ @MarcusHolly @adam-a-a
 


### PR DESCRIPTION
## Fixes/Resolves:

[Issue 1640](https://github.com/watertap-org/watertap/issues/1640)

## Summary/Motivation:

Remove ludovico's required approval of certain PRs/ as code owner. 

## Changes proposed in this PR:
- Remove or replace lbnianchi-lbl from code ownership document

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
