### PR TITLE
Add SLAC/Stanford to Collaborating Institutions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,8 @@ The WaterTAP development team is composed of researchers from:
 * Lawrence Berkeley National Laboratory
 * National Renewable Energy Laboratory
 * Oak Ridge National Laboratory
+* SLAC National Accelerator Laboratory
+* Stanford University
 
 Cite this work
 --------------


### PR DESCRIPTION
## Fixes/Resolves:

Currently, SLAC/Stanford are not listed as a partner institution; this rectifies their exclusion from the list. 

## Summary/Motivation:
Update the list of partner institutions to be consistent with contributions in WaterTAP. 

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
