### PR TITLE
Add WaterTAP Acronym into Docs

### DIFF
--- a/docs/background/what_is_watertap.rst
+++ b/docs/background/what_is_watertap.rst
@@ -1,7 +1,7 @@
 What is WaterTAP
 ------------------
 
-WaterTAP is a Python-based, open-source library of water treatment models than can be used to assess water treatment trains through simulation, optimization, and other advanced methods.
+The Water treatment Technoeconomic Assessment Platform (WaterTAP) is a Python-based, open-source library of water treatment models than can be used to assess water treatment trains through simulation, optimization, and other advanced methods.
 WaterTAP development is funded by the `National Alliance for Water Innovation (NAWI) <https://www.nawihub.org/>`_, the U.S. Department of Energy’s Energy-Water Desalination Hub.
 
 Motivation


### PR DESCRIPTION
## Summary/Motivation:
I realized the readthedocs don't actually spell out the WaterTAP acronym... at least, if it does, it's so well hidden that I couldn't find it.

## Changes proposed in this PR:
- Adds the meaning of the WaterTAP acronym to the "Background" tab

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
