### PR TITLE
Workaround for LSRRO Sweep Circular Import

### DIFF
--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -59,7 +59,6 @@ from watertap.costing import (
 )
 import watertap.property_models.NaCl_prop_pack as props
 from parameter_sweep import LinearSample, parameter_sweep
-from watertap.flowsheets.lsrro.multi_sweep import _lsrro_presweep
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -1455,6 +1454,8 @@ def feed_concentration_recovery_profile(
     outputs = {}
     nx = points_per_sweep
     if m is None:
+        from watertap.flowsheets.lsrro.multi_sweep import _lsrro_presweep
+
         m = _lsrro_presweep(number_of_stages=number_of_stages, quick_start=quick_start)
     else:
         if (m.fs.NumberOfStages == number_of_stages) or (m.fs.NumberOfStages is None):


### PR DESCRIPTION
## Summary/Motivation:
The LSRRO sweep test could not be run due to a circular import:

`ImportError: cannot import name '_lsrro_presweep' from partially initialized module 'watertap.flowsheets.lsrro.multi_sweep' (most likely due to a circular import)`

## Changes proposed in this PR:
- Imports _lsrro_presweep inside of the function rather than at the top of the lsrro flowsheet file

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
