### PR TITLE
Update RO and Pump Costing Docs

### DIFF
--- a/docs/technical_reference/costing/pump.rst
+++ b/docs/technical_reference/costing/pump.rst
@@ -12,10 +12,10 @@ The following parameters are constructed for the unit on the FlowsheetCostingBlo
    :header: "Description", "Symbol", "Parameter Name", "Default Value", "Units"
 
    "**High-pressure pump** (cost method = ``cost_high_pressure_pump``)"
-   "Pump unit cost", ":math:`C_{pump}`", "``high_pressure_pump_cost``", "1.908", ":math:`\text{USD}_{2018}\text{/W}`"
+   "Pump unit cost", ":math:`C_{pump}`", "``cost``", "1.908", ":math:`\text{USD}_{2018}\text{/W}`"
 
    "**Low-pressure pump** (cost method = ``cost_low_pressure_pump``)"
-   "Pump unit cost", ":math:`C_{pump}`", "``low_pressure_pump_cost``", "889", ":math:`\text{USD}_{2018}\text{/L/s}`"
+   "Pump unit cost", ":math:`C_{pump}`", "``cost``", "889", ":math:`\text{USD}_{2018}\text{/L/s}`"
 
 Costing Method Variables
 ++++++++++++++++++++++++

--- a/docs/technical_reference/costing/pump.rst
+++ b/docs/technical_reference/costing/pump.rst
@@ -11,11 +11,11 @@ The following parameters are constructed for the unit on the FlowsheetCostingBlo
 .. csv-table::
    :header: "Description", "Symbol", "Parameter Name", "Default Value", "Units"
 
-   "**High-pressure pump**"
-   "Pump unit cost", ":math:`C_{pump}`", "``cost``", "1.908", ":math:`\text{USD}_{2018}\text{/W}`"
+   "**High-pressure pump**", " ", "``high_pressure``"
+   "Pump unit cost", ":math:`C_{pump}`", "``high_pressure_pump_cost``", "1.908", ":math:`\text{USD}_{2018}\text{/W}`"
 
-   "**Low-pressure pump**"
-   "Pump unit cost", ":math:`C_{pump}`", "``cost``", "889", ":math:`\text{USD}_{2018}\text{/L/s}`"
+   "**Low-pressure pump**", " ", "``low_pressure``"
+   "Pump unit cost", ":math:`C_{pump}`", "``low_pressure_pump_cost``", "889", ":math:`\text{USD}_{2018}\text{/L/s}`"
 
 Costing Method Variables
 ++++++++++++++++++++++++

--- a/docs/technical_reference/costing/pump.rst
+++ b/docs/technical_reference/costing/pump.rst
@@ -11,10 +11,10 @@ The following parameters are constructed for the unit on the FlowsheetCostingBlo
 .. csv-table::
    :header: "Description", "Symbol", "Parameter Name", "Default Value", "Units"
 
-   "**High-pressure pump**", " ", "``high_pressure``"
+   "**High-pressure pump** (cost method = ``cost_high_pressure_pump``)"
    "Pump unit cost", ":math:`C_{pump}`", "``high_pressure_pump_cost``", "1.908", ":math:`\text{USD}_{2018}\text{/W}`"
 
-   "**Low-pressure pump**", " ", "``low_pressure``"
+   "**Low-pressure pump** (cost method = ``cost_low_pressure_pump``)"
    "Pump unit cost", ":math:`C_{pump}`", "``low_pressure_pump_cost``", "889", ":math:`\text{USD}_{2018}\text{/L/s}`"
 
 Costing Method Variables

--- a/docs/technical_reference/costing/reverse_osmosis.rst
+++ b/docs/technical_reference/costing/reverse_osmosis.rst
@@ -9,13 +9,13 @@ The following parameters are constructed for the unit on the FlowsheetCostingBlo
 .. csv-table::
    :header: "Description", "Symbol", "Parameter Name", "Default Value", "Units"
 
-   "**Standard RO**"
+   "**Standard RO**", " ", "``standard``"
    "Membrane replacement factor (fraction of membrane replaced/year)", ":math:`f_{mem,\, replace}`", "``factor_membrane_replacement``", "0.2", ":math:`\text{yr}^{-1}`"
-   "Membrane unit cost", ":math:`C_{mem}`", "``membrane_unit_cost``", "30", ":math:`\text{USD}_{2018}\text{/m}^2`"
+   "Membrane unit cost", ":math:`C_{mem}`", "``membrane_cost``", "30", ":math:`\text{USD}_{2018}\text{/m}^2`"
 
-   "**High-pressure RO**"
+   "**High-pressure RO**", " ", "``high_pressure``"
    "Membrane replacement factor (fraction of membrane replaced/year)", ":math:`f_{mem,\, replace}`", "``factor_membrane_replacement``", "0.2", ":math:`\text{yr}^{-1}`"
-   "Membrane unit cost", ":math:`C_{mem}`", "``membrane_unit_cost``", "75", ":math:`\text{USD}_{2018}\text{/m}^2`"
+   "Membrane unit cost", ":math:`C_{mem}`", "``high_pressure_membrane_cost``", "75", ":math:`\text{USD}_{2018}\text{/m}^2`"
 
 Costing Method Variables
 ++++++++++++++++++++++++

--- a/docs/technical_reference/costing/reverse_osmosis.rst
+++ b/docs/technical_reference/costing/reverse_osmosis.rst
@@ -13,7 +13,7 @@ The following parameters are constructed for the unit on the FlowsheetCostingBlo
    "Membrane replacement factor (fraction of membrane replaced/year)", ":math:`f_{mem,\, replace}`", "``factor_membrane_replacement``", "0.2", ":math:`\text{yr}^{-1}`"
    "Membrane unit cost", ":math:`C_{mem}`", "``membrane_cost``", "30", ":math:`\text{USD}_{2018}\text{/m}^2`"
 
-   "**High-pressure RO** (cost method = ``cost_high_pressure reverse_osmosis``)"
+   "**High-pressure RO** (cost method = ``cost_high_pressure_reverse_osmosis``)"
    "Membrane replacement factor (fraction of membrane replaced/year)", ":math:`f_{mem,\, replace}`", "``factor_membrane_replacement``", "0.2", ":math:`\text{yr}^{-1}`"
    "Membrane unit cost", ":math:`C_{mem}`", "``high_pressure_membrane_cost``", "75", ":math:`\text{USD}_{2018}\text{/m}^2`"
 

--- a/docs/technical_reference/costing/reverse_osmosis.rst
+++ b/docs/technical_reference/costing/reverse_osmosis.rst
@@ -9,11 +9,11 @@ The following parameters are constructed for the unit on the FlowsheetCostingBlo
 .. csv-table::
    :header: "Description", "Symbol", "Parameter Name", "Default Value", "Units"
 
-   "**Standard RO**", " ", "``standard``"
+   "**Standard RO** (cost method = ``cost_reverse_osmosis``)"
    "Membrane replacement factor (fraction of membrane replaced/year)", ":math:`f_{mem,\, replace}`", "``factor_membrane_replacement``", "0.2", ":math:`\text{yr}^{-1}`"
    "Membrane unit cost", ":math:`C_{mem}`", "``membrane_cost``", "30", ":math:`\text{USD}_{2018}\text{/m}^2`"
 
-   "**High-pressure RO**", " ", "``high_pressure``"
+   "**High-pressure RO** (cost method = ``cost_high_pressure reverse_osmosis``)"
    "Membrane replacement factor (fraction of membrane replaced/year)", ":math:`f_{mem,\, replace}`", "``factor_membrane_replacement``", "0.2", ":math:`\text{yr}^{-1}`"
    "Membrane unit cost", ":math:`C_{mem}`", "``high_pressure_membrane_cost``", "75", ":math:`\text{USD}_{2018}\text{/m}^2`"
 

--- a/watertap/costing/unit_models/pump.py
+++ b/watertap/costing/unit_models/pump.py
@@ -51,8 +51,8 @@ def cost_pump(blk, pump_type=PumpType.high_pressure, cost_electricity_flow=True)
 
 def build_high_pressure_pump_cost_param_block(blk):
 
-    blk.cost = pyo.Var(
-        initialize=53 / 1e5 * 3600,
+    blk.high_pressure_pump_cost = pyo.Var(
+        initialize=53 / 1e5 * 3600,  # 1.908
         bounds=(0, None),
         doc="High pressure pump cost",
         units=pyo.units.USD_2018 / pyo.units.watt,
@@ -102,7 +102,7 @@ def cost_high_pressure_pump(blk, cost_electricity_flow=True):
 
 def build_low_pressure_pump_cost_param_block(blk):
 
-    blk.cost = pyo.Var(
+    blk.low_pressure_pump_cost = pyo.Var(
         initialize=889,
         doc="Low pressure pump cost",
         units=pyo.units.USD_2018 / (pyo.units.liter / pyo.units.second),

--- a/watertap/costing/unit_models/pump.py
+++ b/watertap/costing/unit_models/pump.py
@@ -51,7 +51,7 @@ def cost_pump(blk, pump_type=PumpType.high_pressure, cost_electricity_flow=True)
 
 def build_high_pressure_pump_cost_param_block(blk):
 
-    blk.high_pressure_pump_cost = pyo.Var(
+    blk.cost = pyo.Var(
         initialize=53 / 1e5 * 3600,  # 1.908
         bounds=(0, None),
         doc="High pressure pump cost",
@@ -102,7 +102,7 @@ def cost_high_pressure_pump(blk, cost_electricity_flow=True):
 
 def build_low_pressure_pump_cost_param_block(blk):
 
-    blk.low_pressure_pump_cost = pyo.Var(
+    blk.cost = pyo.Var(
         initialize=889,
         doc="Low pressure pump cost",
         units=pyo.units.USD_2018 / (pyo.units.liter / pyo.units.second),


### PR DESCRIPTION
## Summary/Motivation:
The name of costing method arguments could not be found directly in the documentation. These documentation updates should probably be carried over to other unit models as well, but just adding these here as they are necessary for https://github.com/watertap-org/watertap_academy_fall_2025/pull/21

## Changes proposed in this PR:
- Updates RO and pump costing docs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
