### PR TITLE
Fix broken link in readthedocs

### DIFF
--- a/docs/technical_reference/tools/index.rst
+++ b/docs/technical_reference/tools/index.rst
@@ -2,4 +2,4 @@ Tools for Flowsheet Analysis
 ============================
 
 * `Parameter Sweep <https://parameter-sweep.readthedocs.io/en/latest/getting_started/parameter_sweep.html>`_
-* `Parallel Manager <https://parameter-sweep.readthedocs.io/en/latest/getting_started.html>`_
+* `Parallel Manager <https://parameter-sweep.readthedocs.io/en/latest/getting_started/parallel_manager.html>`_


### PR DESCRIPTION
## Fixes/Resolves:
[Issue 1705](https://github.com/watertap-org/watertap/issues/1705)
(replace this with the issue # fixed or resolved, if no issue exists then a brief statement of what this PR does)

## Summary/Motivation:

Parallel Manager link is broken on this page: https://watertap.readthedocs.io/en/latest/technical_reference/tools/index.html

## Changes proposed in this PR:
- Fix path to link for parallel manager
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
