### PR TITLE
Updating black to 26.1.0 and re-running it

### DIFF
--- a/docs/technical_reference/unit_models/zero_order_unit_models/automate_rst_file_wt3.py
+++ b/docs/technical_reference/unit_models/zero_order_unit_models/automate_rst_file_wt3.py
@@ -29,7 +29,6 @@ import os
 from glob import glob
 from pathlib import Path
 
-
 sidor_db_path = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==24.3.0
+black==26.1.0
 pre-commit
 
 # coverage

--- a/watertap/core/tests/test_wt_database.py
+++ b/watertap/core/tests/test_wt_database.py
@@ -12,6 +12,7 @@
 """
 Tests for WaterTAP database wrapper
 """
+
 import pytest
 import os
 

--- a/watertap/core/tests/test_zero_order_base.py
+++ b/watertap/core/tests/test_zero_order_base.py
@@ -12,6 +12,7 @@
 """
 Tests for general zero-order base class
 """
+
 import pytest
 
 from types import MethodType

--- a/watertap/core/tests/test_zero_order_diso.py
+++ b/watertap/core/tests/test_zero_order_diso.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order DISO unit model
 """
+
 import pytest
 
 from types import MethodType

--- a/watertap/core/tests/test_zero_order_electricity.py
+++ b/watertap/core/tests/test_zero_order_electricity.py
@@ -12,6 +12,7 @@
 """
 Tests for general zero-order property package
 """
+
 import pytest
 
 from types import MethodType

--- a/watertap/core/tests/test_zero_order_properties.py
+++ b/watertap/core/tests/test_zero_order_properties.py
@@ -12,6 +12,7 @@
 """
 Tests for general zero-order proeprty package
 """
+
 import pytest
 
 from idaes.core import (

--- a/watertap/core/tests/test_zero_order_pt.py
+++ b/watertap/core/tests/test_zero_order_pt.py
@@ -12,6 +12,7 @@
 """
 Tests for general zero-order property package
 """
+
 import pytest
 
 from types import MethodType

--- a/watertap/core/tests/test_zero_order_sido.py
+++ b/watertap/core/tests/test_zero_order_sido.py
@@ -12,6 +12,7 @@
 """
 Tests for general zero-order property package
 """
+
 import pytest
 
 from types import MethodType

--- a/watertap/core/tests/test_zero_order_sido_reactive.py
+++ b/watertap/core/tests/test_zero_order_sido_reactive.py
@@ -12,6 +12,7 @@
 """
 Tests for general zero-order property package
 """
+
 import pytest
 import os
 from types import MethodType

--- a/watertap/core/tests/test_zero_order_siso.py
+++ b/watertap/core/tests/test_zero_order_siso.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order SISO unit model
 """
+
 import pytest
 from types import MethodType
 

--- a/watertap/core/util/initialization.py
+++ b/watertap/core/util/initialization.py
@@ -13,7 +13,6 @@
 This module contains utility functions for initialization of WaterTAP models.
 """
 
-
 __author__ = "Adam Atia, Ben Knueven"
 
 from pyomo.environ import check_optimal_termination, ComponentMap, Var

--- a/watertap/core/util/model_diagnostics/infeasible.py
+++ b/watertap/core/util/model_diagnostics/infeasible.py
@@ -12,6 +12,7 @@
 """
 This module contains utility functions for infeasibility diagnostics of WaterTAP models.
 """
+
 import logging, sys
 
 from contextlib import contextmanager

--- a/watertap/core/util/model_diagnostics/tests/test_infeasible.py
+++ b/watertap/core/util/model_diagnostics/tests/test_infeasible.py
@@ -34,20 +34,16 @@ class TestInfeasible:
     def test_var_not_set(self, m, capsys):
         print_variables_close_to_bounds(m)
         captured = capsys.readouterr()
-        assert (
-            captured.out
-            == """No value for Var a
+        assert captured.out == """No value for Var a
 No value for Var b
 """
-        )
 
     @pytest.mark.unit
     def test_var_not_set_con(self, m, capsys):
         print_constraints_close_to_bounds(m)
         captured = capsys.readouterr()
         assert (
-            captured.out
-            == """Cannot evaluate Constraint abcon: missing variable value
+            captured.out == """Cannot evaluate Constraint abcon: missing variable value
 """
         )
 
@@ -65,12 +61,9 @@ No value for Var b
         m.b.value = 0
         print_close_to_bounds(m)
         captured = capsys.readouterr()
-        assert (
-            captured.out
-            == """a near UB of 10
+        assert captured.out == """a near UB of 10
 abcon near UB of 10
 """
-        )
 
     @pytest.mark.unit
     def test_close_LB(self, m, capsys):
@@ -78,13 +71,10 @@ abcon near UB of 10
         m.b.value = -10
         print_close_to_bounds(m)
         captured = capsys.readouterr()
-        assert (
-            captured.out
-            == """a near UB of 10
+        assert captured.out == """a near UB of 10
 b near LB of -10
 abcon near LB of 0
 """
-        )
 
     @pytest.mark.unit
     def test_infeasible_bounds_none(self, m, capsys):
@@ -104,20 +94,14 @@ abcon near LB of 0
         m.b.value = -20
         print_infeasible_bounds(m)
         captured = capsys.readouterr()
-        assert (
-            captured.out
-            == """VAR a: 20 </= UB 10
+        assert captured.out == """VAR a: 20 </= UB 10
 VAR b: LB -10 </= -20
 """
-        )
 
     @pytest.mark.unit
     def test_infeasible_constraints(self, m, capsys):
         m.a.value = -20
         print_infeasible_constraints(m)
         captured = capsys.readouterr()
-        assert (
-            captured.out
-            == """CONSTR abcon: 0.0 </= -40 <= 10.0
+        assert captured.out == """CONSTR abcon: 0.0 </= -40 <= 10.0
 """
-        )

--- a/watertap/core/util/scaling.py
+++ b/watertap/core/util/scaling.py
@@ -12,6 +12,7 @@
 """
 This module contains a utility function for the scaling of WaterTAP property model constraints.
 """
+
 import pyomo.environ as pyo
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog

--- a/watertap/core/wt_database.py
+++ b/watertap/core/wt_database.py
@@ -13,6 +13,7 @@
 This module contains the base class for interacting with WaterTAP data files
 with zero-order model parameter data.
 """
+
 import os
 import yaml
 from copy import deepcopy

--- a/watertap/core/zero_order_base.py
+++ b/watertap/core/zero_order_base.py
@@ -22,7 +22,6 @@ from idaes.core.util.tables import create_stream_table_dataframe
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 import pyomo.environ as pyo
 
-
 # Some more information about this module
 __author__ = "Andrew Lee, Adam Atia"
 

--- a/watertap/core/zero_order_diso.py
+++ b/watertap/core/zero_order_diso.py
@@ -14,6 +14,7 @@ This module contains the methods for constructing the material balances for
 zero-order double-input/single-output (DISO) unit models (i.e. units with two inlets and single
 outlet where composition changes, such as a generic bioreactor).
 """
+
 from types import MethodType
 
 import idaes.logger as idaeslog

--- a/watertap/core/zero_order_properties.py
+++ b/watertap/core/zero_order_properties.py
@@ -14,6 +14,7 @@ This module contains the general purpose property package for zero-order
 unit models. Zero-order models do not track temperature and pressure, or any
 form of energy flow.
 """
+
 from idaes.core import (
     EnergyBalanceType,
     MaterialBalanceType,

--- a/watertap/core/zero_order_pt.py
+++ b/watertap/core/zero_order_pt.py
@@ -14,6 +14,7 @@ This module contains the methods for constructing the material balances for
 zero-order pass-through unit models (i.e. units with a single inlet and single
 outlet where flow and composition do not change, such as pumps).
 """
+
 from types import MethodType
 from pyomo.environ import check_optimal_termination
 

--- a/watertap/core/zero_order_sido.py
+++ b/watertap/core/zero_order_sido.py
@@ -13,6 +13,7 @@
 This module contains methods for constructing the material balances for
 zero-order single inlet-double outlet (SIDO) unit models.
 """
+
 from types import MethodType
 
 import idaes.logger as idaeslog

--- a/watertap/core/zero_order_sido_reactive.py
+++ b/watertap/core/zero_order_sido_reactive.py
@@ -14,6 +14,7 @@ This module contains methods for constructing the material balances for
 zero-order single inlet-double outlet (SIDO) unit models with chemical
 reactions.
 """
+
 from types import MethodType
 
 import idaes.logger as idaeslog

--- a/watertap/core/zero_order_siso.py
+++ b/watertap/core/zero_order_siso.py
@@ -14,6 +14,7 @@ This module contains the methods for constructing the material balances for
 zero-order single-input/single-output (SISO) unit models (i.e. units with a single inlet and single
 outlet where composition changes, such as a generic bioreactor).
 """
+
 from types import MethodType
 
 import idaes.logger as idaeslog

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -12,6 +12,7 @@
 """
 Tests for general zero-order costing methods
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/costing/unit_models/clarifier.py
+++ b/watertap/costing/unit_models/clarifier.py
@@ -18,6 +18,7 @@ Journal of Infrastructure Systems 19.4 (2013): 451-464.
 Benchmark Model for Wastewater Treatment Using an Activated Sludge Process.
 United States: N.p., 21 Jan, 2022. Web. doi: 10.7481/1844539.
 """
+
 import pyomo.environ as pyo
 from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util.misc import StrEnum

--- a/watertap/costing/unit_models/tests/test_gac.py
+++ b/watertap/costing/unit_models/tests/test_gac.py
@@ -23,7 +23,6 @@ from idaes.core.util.testing import initialization_tester
 from watertap.costing import WaterTAPCosting
 from watertap.unit_models.tests.test_gac import build_crittenden
 
-
 __author__ = "Hunter Barber"
 
 solver = get_solver()

--- a/watertap/costing/zero_order_costing.py
+++ b/watertap/costing/zero_order_costing.py
@@ -12,6 +12,7 @@
 """
 General costing package for zero-order processes.
 """
+
 import os
 import yaml
 

--- a/watertap/data/techno_economic/tests/test_unit_parameter_files.py
+++ b/watertap/data/techno_economic/tests/test_unit_parameter_files.py
@@ -12,6 +12,7 @@
 """
 Tests for loading water source definitions
 """
+
 import pytest
 import os
 

--- a/watertap/data/techno_economic/tests/test_water_sources.py
+++ b/watertap/data/techno_economic/tests/test_water_sources.py
@@ -12,6 +12,7 @@
 """
 Tests for loading water source definitions
 """
+
 import pytest
 import yaml
 import os

--- a/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/RO_with_energy_recovery.py
@@ -44,7 +44,6 @@ from watertap.unit_models.pressure_changer import Pump, EnergyRecoveryDevice
 from watertap.core.util.initialization import assert_degrees_of_freedom
 from watertap.costing import WaterTAPCosting
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/tests/test_RO_with_energy_recovery_simulation.py
@@ -42,7 +42,6 @@ from watertap.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import 
     ERDtype,
 )
 
-
 solver = get_solver()
 
 
@@ -298,9 +297,7 @@ class TestROwithPX:
 
         captured = capsys.readouterr()
 
-        assert (
-            captured.out
-            == """---system metrics---
+        assert captured.out == """---system metrics---
 Feed: 1.02 kg/s, 35000 ppm
 Product: 0.493 kg/s, 240 ppm
 Volumetric recovery: 49.5%
@@ -308,7 +305,6 @@ Water recovery: 50.0%
 Energy Consumption: 2.8 kWh/m3
 Levelized cost of water: 0.44 $/m3
 """
-        )
 
     @pytest.mark.component
     def test_display_design(self, system_frame, capsys):
@@ -317,9 +313,7 @@ Levelized cost of water: 0.44 $/m3
 
         captured = capsys.readouterr()
 
-        assert (
-            captured.out
-            == """---decision variables---
+        assert captured.out == """---decision variables---
 Operating pressure 74.9 bar
 Membrane area 54.3 m2
 ---design variables---
@@ -332,7 +326,6 @@ Pump 2
 outlet pressure: 74.9 bar
 power 0.38 kW
 """
-        )
 
     @pytest.mark.component
     def test_display_state(self, system_frame, capsys):
@@ -341,9 +334,7 @@ power 0.38 kW
 
         captured = capsys.readouterr()
 
-        assert (
-            captured.out
-            == """---state---
+        assert captured.out == """---state---
 Feed      : 1.021 kg/s, 35000 ppm, 1.0 bar
 Split 1   : 0.505 kg/s, 35000 ppm, 1.0 bar
 P1 out    : 0.505 kg/s, 35000 ppm, 74.9 bar
@@ -355,7 +346,6 @@ RO perm   : 0.493 kg/s, 240 ppm, 1.0 bar
 RO reten  : 0.528 kg/s, 67424 ppm, 72.4 bar
 PXR brine out: 0.528 kg/s, 67424 ppm, 1.0 bar
 """
-        )
 
     @pytest.mark.component
     def test_optimization(self, system_frame):
@@ -596,9 +586,7 @@ class TestROnoERD:
 
         captured = capsys.readouterr()
 
-        assert (
-            captured.out
-            == """---system metrics---
+        assert captured.out == """---system metrics---
 Feed: 1.02 kg/s, 35000 ppm
 Product: 0.493 kg/s, 240 ppm
 Volumetric recovery: 49.5%
@@ -606,7 +594,6 @@ Water recovery: 50.0%
 Energy Consumption: 5.2 kWh/m3
 Levelized cost of water: 0.74 $/m3
 """
-        )
 
     @pytest.mark.component
     def test_display_design(self, system_frame, capsys):
@@ -615,9 +602,7 @@ Levelized cost of water: 0.74 $/m3
 
         captured = capsys.readouterr()
 
-        assert (
-            captured.out
-            == """---decision variables---
+        assert captured.out == """---decision variables---
 Operating pressure 74.9 bar
 Membrane area 54.3 m2
 ---design variables---
@@ -625,7 +610,6 @@ Pump 1
 outlet pressure: 74.9 bar
 power 9.24 kW
 """
-        )
 
     @pytest.mark.component
     def test_display_state(self, system_frame, capsys):
@@ -634,15 +618,12 @@ power 9.24 kW
 
         captured = capsys.readouterr()
 
-        assert (
-            captured.out
-            == """---state---
+        assert captured.out == """---state---
 Feed      : 1.021 kg/s, 35000 ppm, 1.0 bar
 P1 out    : 1.021 kg/s, 35000 ppm, 74.9 bar
 RO perm   : 0.493 kg/s, 240 ppm, 1.0 bar
 RO reten  : 0.528 kg/s, 67424 ppm, 72.4 bar
 """
-        )
 
     @pytest.mark.component
     def test_optimization(self, system_frame):

--- a/watertap/flowsheets/RO_with_energy_recovery/tests/test_monte_carlo_sampling_RO_ERD.py
+++ b/watertap/flowsheets/RO_with_energy_recovery/tests/test_monte_carlo_sampling_RO_ERD.py
@@ -17,7 +17,6 @@ from watertap.flowsheets.RO_with_energy_recovery.monte_carlo_sampling_RO_ERD imp
     run_parameter_sweep,
 )
 
-
 _parameter_sweep_expected_warning = pytest.warns(
     UserWarning, match="No results .* to disk .*"
 )

--- a/watertap/flowsheets/activated_sludge/ASM2D_flowsheet_noPHA.py
+++ b/watertap/flowsheets/activated_sludge/ASM2D_flowsheet_noPHA.py
@@ -9,9 +9,7 @@
 # information, respectively. These files are also available online at the URL
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
-"""
-
-"""
+""" """
 
 # Some more information about this module
 __author__ = "Alejandro Garciadiego, Andrew Lee"

--- a/watertap/flowsheets/dye_desalination/dye_desalination.py
+++ b/watertap/flowsheets/dye_desalination/dye_desalination.py
@@ -18,6 +18,7 @@ Journal of Chemical and Pharmaceutical Research, pp. 710-717
 Adsorption of Congo Red by Activated Carbon", 2014, Korean Chemical Engineering Research,
 Vol. 53 Iss. 1, pp. 64-70
 """
+
 import os
 import idaes.logger as idaeslog
 from pyomo.environ import (

--- a/watertap/flowsheets/electrodialysis/electrodialysis_1stack.py
+++ b/watertap/flowsheets/electrodialysis/electrodialysis_1stack.py
@@ -35,7 +35,6 @@ from watertap.unit_models.electrodialysis_1D import Electrodialysis1D
 from watertap.costing import WaterTAPCosting
 from watertap.property_models.multicomp_aq_sol_prop_pack import MCASParameterBlock
 
-
 # Set up logger
 _log = idaeslog.getLogger(__name__)
 

--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2.py
@@ -17,6 +17,7 @@ The flowsheet follows the same formulation as benchmark simulation model no.2 (B
 but comprises different specifications for default values than BSM2.
 
 """
+
 __author__ = "Alejandro Garciadiego, Adam Atia, Marcus Holly, Chenyu Wang, Ben Knueven, Xinhong Liu,"
 
 import pyomo.environ as pyo

--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
@@ -109,7 +109,6 @@ from watertap.costing.unit_models.clarifier import (
     cost_primary_clarifier,
 )
 
-
 # Set up logger
 _log = idaeslog.getLogger(__name__)
 

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
@@ -10,7 +10,7 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 """
-Tests for full Water Resource Recovery Facility 
+Tests for full Water Resource Recovery Facility
 (WRRF; a.k.a., wastewater treatment plant) flowsheet example with ASM1 and ADM1.
 The flowsheet follows the same formulation as benchmark simulation model no.2 (BSM2)
 but comprises different specifications for default values than BSM2.

--- a/watertap/flowsheets/generic_desalination_train/generic_train_ui.py
+++ b/watertap/flowsheets/generic_desalination_train/generic_train_ui.py
@@ -14,7 +14,6 @@ from watertap.flowsheets.generic_desalination_train import generic_train
 from pyomo.environ import units as pyunits
 from idaes.core.solvers import get_solver
 
-
 __author__ = "Alexander V. Dudchenko"
 
 

--- a/watertap/flowsheets/generic_desalination_train/unit_operations/mixer.py
+++ b/watertap/flowsheets/generic_desalination_train/unit_operations/mixer.py
@@ -16,7 +16,6 @@ import idaes.core.util.scaling as iscale
 from idaes.models.unit_models import Mixer
 from idaes.models.unit_models.mixer import MomentumMixingType, MixingType
 
-
 __author__ = "Alexander V. Dudchenko"
 
 

--- a/watertap/flowsheets/generic_desalination_train/unit_operations/separator.py
+++ b/watertap/flowsheets/generic_desalination_train/unit_operations/separator.py
@@ -23,7 +23,6 @@ from watertap.flowsheets.generic_desalination_train.costing import (
 )
 import logging
 
-
 _logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
 formatter = logging.Formatter(

--- a/watertap/flowsheets/ion_exchange/ion_exchange_demo.py
+++ b/watertap/flowsheets/ion_exchange/ion_exchange_demo.py
@@ -32,7 +32,6 @@ from watertap.core.solvers import get_solver
 
 import math
 
-
 solver = get_solver()
 
 

--- a/watertap/flowsheets/lsrro/lsrro.py
+++ b/watertap/flowsheets/lsrro/lsrro.py
@@ -63,7 +63,6 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
-
 _log = idaeslogger.getLogger(__name__)
 
 

--- a/watertap/flowsheets/mvc/tests/test_mvc_single_stage.py
+++ b/watertap/flowsheets/mvc/tests/test_mvc_single_stage.py
@@ -45,7 +45,6 @@ import watertap.property_models.water_prop_pack as props_water
 from watertap.unit_models.pressure_changer import Pump
 from watertap.unit_models.mvc.components import Evaporator, Compressor, Condenser
 
-
 solver = get_solver()
 
 

--- a/watertap/property_models/NaCl_T_dep_prop_pack.py
+++ b/watertap/property_models/NaCl_T_dep_prop_pack.py
@@ -63,7 +63,6 @@ import idaes.core.util.scaling as iscale
 
 from watertap.core.util.scaling import transform_property_constraints
 
-
 # Set up logger
 _log = idaeslog.getLogger(__name__)
 

--- a/watertap/property_models/multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/multicomp_aq_sol_prop_pack.py
@@ -11,10 +11,10 @@
 #################################################################################
 """
 This property package computes a multi-component aqueous solution that can
-contain ionic and/or neutral solute species. It supports basic calculation 
-of component quantities and some physical, chemical and electrical properties. 
+contain ionic and/or neutral solute species. It supports basic calculation
+of component quantities and some physical, chemical and electrical properties.
 
-This property package was formerly named the "ion_DSPMDE_prop_pack" and was originally 
+This property package was formerly named the "ion_DSPMDE_prop_pack" and was originally
 designed for use with the Donnan Steric Pore Model with Dielectric Exclusion (DSPMDE) for
 nanofiltration.
 """
@@ -1835,15 +1835,11 @@ class MCASStateBlockData(StateBlockData):
                 == ElectricalMobilityCalculation.none
             ):
                 if (p, j) not in self.params.config.elec_mobility_data.keys():
-                    raise ConfigurationError(
-                        """ 
+                    raise ConfigurationError(""" 
                         Missing the "elec_mobility_data" configuration to build the elec_mobility_phase_comp 
                         and/or its derived variables for {} in {}. 
                         Provide this configuration or use ElectricalMobilityCalculation.EinsteinRelation.
-                        """.format(
-                            j, self.name
-                        )
-                    )
+                        """.format(j, self.name))
                 else:
                     return (
                         b.elec_mobility_phase_comp[p, j]
@@ -1865,14 +1861,10 @@ class MCASStateBlockData(StateBlockData):
                     )
                 else:
                     if (p, j) in self.params.config.elec_mobility_data.keys():
-                        _log.warning(
-                            """
+                        _log.warning("""
                             The provided elec_mobility_data of {} will be overwritten 
                             by the calculated data for {} because the EinsteinRelation 
-                            method is selected.""".format(
-                                j, self.name
-                            )
-                        )
+                            method is selected.""".format(j, self.name))
 
                     return b.elec_mobility_phase_comp[p, j] == b.diffus_phase_comp[
                         p, j
@@ -2085,13 +2077,11 @@ class MCASStateBlockData(StateBlockData):
                     )
                 else:
                     if len(self.params.ion_set) > 2:
-                        _log.warning(
-                            """ 
+                        _log.warning(""" 
                             Caution should be taken to use a constant solution equivalent conductivity for a multi-electrolyte system.
                             Heterogeneous concentration variation among ions may lead to varying equivalent conductivity and computing
                             the phase equivalent conductivity using the "EquivalentConductivityCalculation.ElectricalMobility" method 
-                            is recommended."""
-                        )
+                            is recommended.""")
                     return (
                         b.equiv_conductivity_phase[p]
                         == self.params.config.equiv_conductivity_phase_data[p]

--- a/watertap/property_models/tests/test_cryst_prop_pack.py
+++ b/watertap/property_models/tests/test_cryst_prop_pack.py
@@ -22,7 +22,6 @@ from watertap.property_models.tests.property_test_harness import (
     PropertyCalculateStateTest,
 )
 
-
 # -----------------------------------------------------------------------------
 
 

--- a/watertap/property_models/unit_specific/activated_sludge/asm2d_reactions.py
+++ b/watertap/property_models/unit_specific/activated_sludge/asm2d_reactions.py
@@ -40,7 +40,6 @@ from idaes.core.util.exceptions import BurntToast
 import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 
-
 # Some more information about this module
 __author__ = "Andrew Lee, Xinhong Liu"
 

--- a/watertap/property_models/unit_specific/activated_sludge/modified_asm2d_reactions.py
+++ b/watertap/property_models/unit_specific/activated_sludge/modified_asm2d_reactions.py
@@ -38,7 +38,6 @@ import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 from idaes.core.scaling import CustomScalerBase, ConstraintScalingScheme
 
-
 # Some more information about this module
 __author__ = "Marcus Holly, Adam Atia, Xinhong Liu"
 

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_asm1_reaction.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_asm1_reaction.py
@@ -14,6 +14,7 @@ Tests for ASM1 reaction package.
 
 Authors: Andrew Lee
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_asm1_thermo.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_asm1_thermo.py
@@ -31,7 +31,6 @@ from idaes.core.util.model_statistics import (
 
 from watertap.core.solvers import get_solver
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_asm2d_reaction.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_asm2d_reaction.py
@@ -23,6 +23,7 @@ Wat. Sci. Tech. Vol. 39, No. 1, pp. 165-182
 nutrient removal in wastewater treatment plants: influence of mathematical model
 assumptions", 2012, Wat. Sci. Tech., Vol. 65 No. 8, pp. 1496-1505
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_asm2d_thermo.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_asm2d_thermo.py
@@ -30,7 +30,6 @@ from idaes.core.util.model_statistics import (
 
 from watertap.core.solvers import get_solver
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_asm3_reaction.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_asm3_reaction.py
@@ -14,6 +14,7 @@ Tests for ASM3 reaction package.
 
 Authors: Chenyu Wang
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_asm3_thermo.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_asm3_thermo.py
@@ -31,7 +31,6 @@ from idaes.core.util.model_statistics import (
 
 from watertap.core.solvers import get_solver
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_modified_asm2d_reaction.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_modified_asm2d_reaction.py
@@ -19,6 +19,7 @@ X. Flores-Alsina, K. Solon, C.K. Mbamba, S. Tait, K.V. Gernaey, U. Jeppsson, D.J
 Modelling phosphorus (P), sulfur (S) and iron (Fe) interactions fordynamic simulations of anaerobic digestion processes,
 Water Research. 95 (2016) 370-382. https://www.sciencedirect.com/science/article/pii/S0043135416301397
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/property_models/unit_specific/activated_sludge/tests/test_modified_asm2d_thermo.py
+++ b/watertap/property_models/unit_specific/activated_sludge/tests/test_modified_asm2d_thermo.py
@@ -31,7 +31,6 @@ from idaes.core.util.model_statistics import (
 
 from watertap.core.solvers import get_solver
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/property_models/unit_specific/anaerobic_digestion/tests/test_adm1_thermo.py
+++ b/watertap/property_models/unit_specific/anaerobic_digestion/tests/test_adm1_thermo.py
@@ -33,7 +33,6 @@ from idaes.core.util.model_statistics import (
 
 from watertap.core.solvers import get_solver
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/property_models/unit_specific/anaerobic_digestion/tests/test_adm1_vapor_thermo.py
+++ b/watertap/property_models/unit_specific/anaerobic_digestion/tests/test_adm1_vapor_thermo.py
@@ -41,7 +41,6 @@ from idaes.core.util.model_statistics import (
 
 from watertap.core.solvers import get_solver
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/property_models/unit_specific/anaerobic_digestion/tests/test_modified_adm1_thermo.py
+++ b/watertap/property_models/unit_specific/anaerobic_digestion/tests/test_modified_adm1_thermo.py
@@ -34,7 +34,6 @@ from idaes.core.util.model_statistics import (
 
 from watertap.core.solvers import get_solver
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/property_models/unit_specific/cryst_prop_pack.py
+++ b/watertap/property_models/unit_specific/cryst_prop_pack.py
@@ -70,7 +70,6 @@ from idaes.core.util.exceptions import (
 )
 import idaes.core.util.scaling as iscale
 
-
 # Set up logger
 _log = idaeslog.getLogger(__name__)
 

--- a/watertap/tools/oli_api/client.py
+++ b/watertap/tools/oli_api/client.py
@@ -57,7 +57,6 @@ from pyomo.common.dependencies import attempt_import
 requests, requests_available = attempt_import("requests", defer_import=False)
 from watertap.tools.oli_api.util.watertap_to_oli_helper_functions import get_oli_name
 
-
 _logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
 formatter = logging.Formatter(

--- a/watertap/unit_models/MD/MD_channel_base.py
+++ b/watertap/unit_models/MD/MD_channel_base.py
@@ -10,11 +10,12 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
-""""
+""" "
 Base constraints and methods for membrane distillation channel
 __author__ = "Elmira Shamlou"
 
 """
+
 from copy import deepcopy
 from enum import Enum, auto
 from pyomo.environ import (

--- a/watertap/unit_models/MD/membrane_distillation_base.py
+++ b/watertap/unit_models/MD/membrane_distillation_base.py
@@ -43,7 +43,6 @@ from watertap.costing.unit_models.membrane_distillation import (
 )
 from watertap.core.util.initialization import interval_initializer
 
-
 __author__ = "Elmira Shamlou"
 
 

--- a/watertap/unit_models/anaerobic_digester.py
+++ b/watertap/unit_models/anaerobic_digester.py
@@ -42,7 +42,6 @@ from pyomo.environ import (
     NonNegativeReals,
 )
 
-
 # Import IDAES cores
 from idaes.core import (
     ControlVolume0DBlock,

--- a/watertap/unit_models/dewatering.py
+++ b/watertap/unit_models/dewatering.py
@@ -10,7 +10,7 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 """
-Dewatering unit model for BSM2 and plant-wide wastewater treatment modeling. 
+Dewatering unit model for BSM2 and plant-wide wastewater treatment modeling.
 This unit inherits from the IDAES separator unit.
 
 Model based on
@@ -22,6 +22,7 @@ Benchmark Simulation Model no. 2 (BSM2)
 
 Modifications made to TSS formulation based on ASM type.
 """
+
 from enum import Enum, auto
 
 # Import IDAES cores

--- a/watertap/unit_models/generic_desalter.py
+++ b/watertap/unit_models/generic_desalter.py
@@ -33,7 +33,6 @@ from idaes.core.util.config import is_physical_parameter_block
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
-
 __author__ = "Alexander V. Dudchenko"
 
 _log = idaeslog.getLogger(__name__)

--- a/watertap/unit_models/generic_separation.py
+++ b/watertap/unit_models/generic_separation.py
@@ -34,7 +34,6 @@ from idaes.core.util.config import is_physical_parameter_block
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
-
 __author__ = "Alexander V. Dudchenko"
 
 _log = idaeslog.getLogger(__name__)

--- a/watertap/unit_models/mvc/components/compressor.py
+++ b/watertap/unit_models/mvc/components/compressor.py
@@ -39,7 +39,6 @@ import idaes.logger as idaeslog
 from watertap.core import InitializationMixin
 from watertap.costing.unit_models.compressor import cost_compressor
 
-
 _log = idaeslog.getLogger(__name__)
 
 

--- a/watertap/unit_models/mvc/components/evaporator.py
+++ b/watertap/unit_models/mvc/components/evaporator.py
@@ -39,7 +39,6 @@ import idaes.logger as idaeslog
 from watertap.core import InitializationMixin
 from watertap.costing.unit_models.evaporator import cost_evaporator
 
-
 _log = idaeslog.getLogger(__name__)
 
 

--- a/watertap/unit_models/nanofiltration_0D.py
+++ b/watertap/unit_models/nanofiltration_0D.py
@@ -30,7 +30,6 @@ from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 
-
 _log = idaeslog.getLogger(__name__)
 
 

--- a/watertap/unit_models/nanofiltration_ZO.py
+++ b/watertap/unit_models/nanofiltration_ZO.py
@@ -44,7 +44,6 @@ from watertap.core import ControlVolume0DBlock, InitializationMixin
 from watertap.costing.unit_models.nanofiltration import cost_nanofiltration
 from watertap.custom_exceptions import FrozenPipes
 
-
 _log = idaeslog.getLogger(__name__)
 
 

--- a/watertap/unit_models/osmotically_assisted_reverse_osmosis_0D.py
+++ b/watertap/unit_models/osmotically_assisted_reverse_osmosis_0D.py
@@ -31,7 +31,6 @@ from watertap.unit_models.osmotically_assisted_reverse_osmosis_base import (
     _add_has_full_reporting,
 )
 
-
 __author__ = "Adam Atia, Chenyu Wang"
 
 

--- a/watertap/unit_models/osmotically_assisted_reverse_osmosis_1D.py
+++ b/watertap/unit_models/osmotically_assisted_reverse_osmosis_1D.py
@@ -31,7 +31,6 @@ from watertap.unit_models.osmotically_assisted_reverse_osmosis_base import (
 )
 import idaes.logger as idaeslog
 
-
 __author__ = "Adam Atia, Chenyu Wang"
 
 # Set up logger

--- a/watertap/unit_models/steam_heater_0D.py
+++ b/watertap/unit_models/steam_heater_0D.py
@@ -23,7 +23,6 @@ from watertap.costing.unit_models.heat_exchanger import (
 from enum import Enum, auto
 from pyomo.common.config import ConfigValue
 
-
 _log = idaeslog.getLogger(__name__)
 
 

--- a/watertap/unit_models/tests/test_anaerobic_digester.py
+++ b/watertap/unit_models/tests/test_anaerobic_digester.py
@@ -19,6 +19,7 @@ Aspects on ADM1 Implementation within the BSM2 Framework.
 Department of Industrial Electrical Engineering and Automation, Lund University, Lund, Sweden, pp.1-35.
 
 """
+
 import pytest
 from pyomo.environ import (
     ConcreteModel,

--- a/watertap/unit_models/tests/test_clarifier.py
+++ b/watertap/unit_models/tests/test_clarifier.py
@@ -12,6 +12,7 @@
 """
 Tests for clarifier.
 """
+
 __author__ = "Chenyu Wang"
 import pytest
 from pyomo.environ import (

--- a/watertap/unit_models/tests/test_cstr.py
+++ b/watertap/unit_models/tests/test_cstr.py
@@ -13,6 +13,7 @@
 Tests for CSTR unit model.
 Authors: Marcus Holly
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/tests/test_dewatering_unit.py
+++ b/watertap/unit_models/tests/test_dewatering_unit.py
@@ -12,6 +12,7 @@
 """
 Tests for dewatering unit example.
 """
+
 from io import StringIO
 import pytest
 from pyomo.environ import (
@@ -81,7 +82,6 @@ from watertap.costing.unit_models.dewatering import (
     DewateringType,
 )
 from idaes.core import UnitModelCostingBlock
-
 
 __author__ = "Alejandro Garciadiego, Adam Atia"
 

--- a/watertap/unit_models/tests/test_electrodialysis_bipolar_1D.py
+++ b/watertap/unit_models/tests/test_electrodialysis_bipolar_1D.py
@@ -44,7 +44,6 @@ from watertap.unit_models.electrodialysis_bipolar_1D import (
 from watertap.core.solvers import get_solver
 from watertap.property_models.multicomp_aq_sol_prop_pack import MCASParameterBlock
 
-
 __author__ = "Johnson Dhanasekaran"
 
 solver = get_solver()

--- a/watertap/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/watertap/unit_models/tests/test_reverse_osmosis_0D.py
@@ -53,7 +53,6 @@ import pytest
 from idaes.core.solvers import petsc
 import numpy as np
 
-
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_solver()

--- a/watertap/unit_models/tests/test_steam_heater_0D.py
+++ b/watertap/unit_models/tests/test_steam_heater_0D.py
@@ -29,7 +29,6 @@ import idaes.core.util.scaling as iscale
 import pytest
 from watertap.unit_models.tests.unit_test_harness import UnitTestHarness
 
-
 solver = get_solver()
 
 

--- a/watertap/unit_models/tests/test_thickener_unit.py
+++ b/watertap/unit_models/tests/test_thickener_unit.py
@@ -12,6 +12,7 @@
 """
 Tests for thickener unit example.
 """
+
 from io import StringIO
 import pytest
 from pyomo.environ import (

--- a/watertap/unit_models/thickener.py
+++ b/watertap/unit_models/thickener.py
@@ -10,7 +10,7 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 """
-Thickener unit model for BSM2 and plant-wide wastewater treatment modeling. 
+Thickener unit model for BSM2 and plant-wide wastewater treatment modeling.
 This unit inherits from the IDAES separator unit.
 
 Model based on
@@ -22,6 +22,7 @@ Benchmark Simulation Model no. 2 (BSM2)
 
 Modifications made to TSS formulation based on ASM type.
 """
+
 from enum import Enum, auto
 
 # Import IDAES cores

--- a/watertap/unit_models/uv_aop.py
+++ b/watertap/unit_models/uv_aop.py
@@ -1020,7 +1020,7 @@ class Ultraviolet0DData(InitializationMixin, UnitModelBlockData):
 
         # TODO: update IDAES control volume to scale mass_transfer and enthalpy_transfer
         for ind, v in self.control_volume.mass_transfer_term.items():
-            (t, p, j) = ind
+            t, p, j = ind
             if iscale.get_scaling_factor(v) is None:
                 sf = iscale.get_scaling_factor(
                     self.control_volume.mass_transfer_term[t, p, j]
@@ -1062,29 +1062,29 @@ class Ultraviolet0DData(InitializationMixin, UnitModelBlockData):
             iscale.constraint_scaling_transform(c, sf)
 
         for ind, c in self.eq_outlet_conc.items():
-            (t, p, j) = ind
+            t, p, j = ind
             sf = iscale.get_scaling_factor(
                 self.control_volume.mass_transfer_term[t, p, j]
             )
             iscale.constraint_scaling_transform(c, sf)
 
         for ind, c in self.eq_electricity_demand_phase_comp.items():
-            (t, p, j) = ind
+            t, p, j = ind
             sf = iscale.get_scaling_factor(self.electricity_demand_phase_comp[t, p, j])
             iscale.constraint_scaling_transform(c, sf)
 
         for ind, c in self.eq_max_phase_electricity_demand.items():
-            (t, p, j) = ind
+            t, p, j = ind
             sf = iscale.get_scaling_factor(self.max_phase_electricity_demand[t, p, j])
             iscale.constraint_scaling_transform(c, sf)
 
         for ind, c in self.eq_electricity_demand_comp.items():
-            (t, j) = ind
+            t, j = ind
             sf = iscale.get_scaling_factor(self.electricity_demand_comp[t, j])
             iscale.constraint_scaling_transform(c, sf)
 
         for ind, c in self.eq_max_electricity_demand.items():
-            (t, j) = ind
+            t, j = ind
             sf = iscale.get_scaling_factor(self.max_component_electricity_demand[t, j])
             iscale.constraint_scaling_transform(c, sf)
 

--- a/watertap/unit_models/zero_order/__init__.py
+++ b/watertap/unit_models/zero_order/__init__.py
@@ -80,7 +80,6 @@ from .injection_well_disposal_zo import InjectionWellDisposalZO
 from .surface_discharge_zo import SurfaceDischargeZO
 from .electrocoagulation_zo import ElectrocoagulationZO
 
-
 # =========================================================================================
 # Units explicitly for Wastewater Resource Recovery effort
 

--- a/watertap/unit_models/zero_order/anaerobic_digestion_reactive_zo.py
+++ b/watertap/unit_models/zero_order/anaerobic_digestion_reactive_zo.py
@@ -19,7 +19,6 @@ from pyomo.environ import Var, units as pyunits
 from idaes.core import declare_process_block_class
 from watertap.core import build_sido_reactive, constant_intensity, ZeroOrderBaseData
 
-
 # Some more information about this module
 __author__ = "Travis Arnold"
 

--- a/watertap/unit_models/zero_order/bioreactor_zo.py
+++ b/watertap/unit_models/zero_order/bioreactor_zo.py
@@ -13,7 +13,6 @@
 This module contains a zero-order representation of a bioreactor unit operation.
 """
 
-
 from idaes.core import declare_process_block_class
 from watertap.core import build_siso, constant_intensity, ZeroOrderBaseData
 

--- a/watertap/unit_models/zero_order/buffer_tank_zo.py
+++ b/watertap/unit_models/zero_order/buffer_tank_zo.py
@@ -14,7 +14,6 @@ This module contains a zero-order representation of a buffer tank unit
 operation.
 """
 
-
 from idaes.core import declare_process_block_class
 from watertap.core import build_pt, constant_intensity, ZeroOrderBaseData
 

--- a/watertap/unit_models/zero_order/cartridge_filtration_zo.py
+++ b/watertap/unit_models/zero_order/cartridge_filtration_zo.py
@@ -14,7 +14,6 @@ This module contains a zero-order representation of a cartridge filtration unit
 operation.
 """
 
-
 from idaes.core import declare_process_block_class
 from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData
 

--- a/watertap/unit_models/zero_order/chemical_addition_zo.py
+++ b/watertap/unit_models/zero_order/chemical_addition_zo.py
@@ -13,6 +13,7 @@
 This module contains a zero-order representation of a chemical addition unit
 operation.
 """
+
 import pyomo.environ as pyo
 
 from idaes.core import declare_process_block_class

--- a/watertap/unit_models/zero_order/cloth_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/cloth_media_filtration_zo.py
@@ -19,7 +19,6 @@ import pyomo.environ as pyo
 from idaes.core import declare_process_block_class
 from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData
 
-
 # Some more information about this module
 __author__ = "Travis Arnold"
 

--- a/watertap/unit_models/zero_order/cooling_supply_zo.py
+++ b/watertap/unit_models/zero_order/cooling_supply_zo.py
@@ -14,7 +14,6 @@ This module contains a zero-order representation of a cooling supply unit
 operation.
 """
 
-
 from idaes.core import declare_process_block_class
 from watertap.core import build_pt, constant_intensity, ZeroOrderBaseData
 

--- a/watertap/unit_models/zero_order/gas_sparged_membrane_zo.py
+++ b/watertap/unit_models/zero_order/gas_sparged_membrane_zo.py
@@ -12,6 +12,7 @@
 """
 This module contains a zero-order representation of a gas-sparged membrane unit.
 """
+
 from types import MethodType
 from idaes.core import declare_process_block_class
 

--- a/watertap/unit_models/zero_order/injection_well_disposal_zo.py
+++ b/watertap/unit_models/zero_order/injection_well_disposal_zo.py
@@ -10,9 +10,10 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 """
-This module contains a zero-order representation of an injection well disposal 
+This module contains a zero-order representation of an injection well disposal
 unit operation.
 """
+
 from idaes.core import declare_process_block_class
 
 from watertap.core import build_pt, constant_intensity, ZeroOrderBaseData

--- a/watertap/unit_models/zero_order/membrane_evaporator_zo.py
+++ b/watertap/unit_models/zero_order/membrane_evaporator_zo.py
@@ -19,7 +19,6 @@ from pyomo.environ import Var, units as pyunits
 from idaes.core import declare_process_block_class
 from watertap.core import build_sido, constant_intensity, ZeroOrderBaseData
 
-
 # Some more information about this module
 __author__ = "Travis Arnold"
 

--- a/watertap/unit_models/zero_order/microbial_battery_zo.py
+++ b/watertap/unit_models/zero_order/microbial_battery_zo.py
@@ -20,7 +20,6 @@ from pyomo.environ import Var, units as pyunits
 from idaes.core import declare_process_block_class
 from watertap.core import build_sido_reactive, constant_intensity, ZeroOrderBaseData
 
-
 # Some more information about this module
 __author__ = "Travis Arnold"
 

--- a/watertap/unit_models/zero_order/peracetic_acid_disinfection_zo.py
+++ b/watertap/unit_models/zero_order/peracetic_acid_disinfection_zo.py
@@ -20,7 +20,6 @@ from pyomo.environ import Var, units as pyunits
 from idaes.core import declare_process_block_class
 from watertap.core import build_sido_reactive, constant_intensity, ZeroOrderBaseData
 
-
 # Some more information about this module
 __author__ = "Travis Arnold"
 

--- a/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_CANDOP_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order CANDO+P model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_aeration_basin_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order aeration basin model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_air_flotation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order air flotation model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_digestion_oxidation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order anaerobic digestion oxidation model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_anaerobic_mbr_mec_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order anaerobic MBR-MEC model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_autothermal_hydrothermal_liquefaction_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_autothermal_hydrothermal_liquefaction_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order autothermal hydrothermal liquefaction model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_backwash_solids_handling_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order backwash solids handling model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bio_active_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order biologically active filtration model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_bioreactor_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order bioreactor model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_blending_reservoir_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order blending reservoir model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_brine_concentrator_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order brine concentrator model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_buffer_tank_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order buffer tank model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cartridge_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order cartridge filtration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_centrifuge_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_centrifuge_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order centrifuge reactor model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chemical_addition_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order chemical addition model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_chlorination_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order Chlorination model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_clarifier_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order clarifier model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_cloth_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cloth_media_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order cloth media filtration model.
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_co2_addition_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order CO2 addition model.
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_coag_and_floc_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order coagulation/flocculation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cofermentation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order cofermentation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_constructed_wetlands_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order constructed wetlands
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_conventional_activated_sludge_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order conventional activated sludge process
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_supply_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order cooling supply model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_cooling_tower_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order cooling tower model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_decarbonator_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order air flotation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_deep_well_injection_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order well field model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dissolved_air_flotation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order dissolved air flotation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dmbr_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order dmbr model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_dual_media_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order dual media filtration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrochemical_nutrient_removal_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order electrochemical nutrient recovery model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_electrocoagulation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrocoagulation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order EC model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_electrodialysis_reversal_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order electrodialysis reversal model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_energy_recovery_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order energy recovery model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_evaporation_pond_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order evaporation pond model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_feed_water_tank_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order feed water tank model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_feed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_feed_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order feed block
 """
+
 import pytest
 
 from pyomo.environ import ConcreteModel, value, Var

--- a/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_filter_press_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order filter press model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_fixed_bed_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order fixed bed model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_gac_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_gac_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order granular activated carbon model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
+++ b/watertap/unit_models/zero_order/tests/test_gas_sparged_membrane.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order gas-sparged membrane unit
 """
+
 import pytest
 
 from types import MethodType

--- a/watertap/unit_models/zero_order/tests/test_hrcs_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_hrcs_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order high-rate contact stabilization (HR-CS) model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_hydrothermal_gasification_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_hydrothermal_gasification_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order hydrothermal gasification model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_injection_well_disposal_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order intrusion mitigation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_intrusion_mitigation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order intrusion mitigation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ion_exchange_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order Ion exchange model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_iron_and_manganese_removal_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order iron and manganese removal model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_landfill_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_landfill_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order landfill model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_mabr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mabr_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order mabr model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_magprex_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_magprex_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order Magprex reactor model for struvite precipitation
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_mbr_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_mbr_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order membrane bioreactor model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_media_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order dual media filtration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_metab_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_metab_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order bioreactor with simple reactions
 """
+
 import pytest
 import os
 
@@ -34,7 +35,6 @@ from watertap.unit_models.zero_order import MetabZO
 from watertap.core.wt_database import Database
 from watertap.core.zero_order_properties import WaterParameterBlock
 from watertap.costing.zero_order_costing import ZeroOrderCosting
-
 
 solver = get_solver()
 

--- a/watertap/unit_models/zero_order/tests/test_microbial_battery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microbial_battery_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order microbial battery model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microfiltration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order microfiltration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_microscreen_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order microscreen filtration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_drinking_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order municipal drinking model.
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_municipal_wwtp_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order municipal wastewater treatment plant model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_nanofiltration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order nanofiltration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_aop_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order Ozone/AOP model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_ozone_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ozone_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order Ozonation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_photothermal_membrane_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order photothermal membrane model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_primary_separator_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order primary separator model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_electricity_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order pump electricity model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_pump_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_pump_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order pump model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_screen_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_screen_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order screen model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_secondary_treatment_wwtp_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order a WWTP with secondary treatment
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sedimentation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order sedimentation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_settling_pond_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order settling pond model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sludge_tank_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order sludge tank model.
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_smp_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_smp_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order smp model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_static_mixer_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order static mixer model.
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_storage_tank_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order storage tank model.
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_struvite_classifier_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_struvite_classifier_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order struvite classifier model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_suboxic_activated_sludge_process_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_suboxic_activated_sludge_process_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order suboxic activated sludge model
 """
+
 import pytest
 
 from pyomo.environ import (

--- a/watertap/unit_models/zero_order/tests/test_supercritical_salt_precipitation_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_supercritical_salt_precipitation_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order autothermal hydrothermal liquefaction model
 """
+
 import pytest
 import os
 

--- a/watertap/unit_models/zero_order/tests/test_surface_discharge.py
+++ b/watertap/unit_models/zero_order/tests/test_surface_discharge.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order surface discharge model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_sw_onshore_intake_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order seawater onshore intake model.
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tramp_oil_tank_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order tramp oil tank model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_tri_media_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order tri media filtration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_ultra_filtration_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order ultra filtration model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_aop_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order UV-AOP model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_uv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_uv_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order UV model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_vfa_recovery_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order VFA recovery model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_waiv_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_waiv_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order wind-aided intensified evaporation model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_walnut_shell_filter_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order walnut shell filter model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_water_pumping_station_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order water pumping station model.
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_well_field_zo.py
+++ b/watertap/unit_models/zero_order/tests/test_well_field_zo.py
@@ -12,6 +12,7 @@
 """
 Tests for zero-order well field model
 """
+
 import pytest
 
 

--- a/watertap/unit_models/zero_order/tests/test_zo_documentation.py
+++ b/watertap/unit_models/zero_order/tests/test_zo_documentation.py
@@ -13,6 +13,7 @@
 Tests that documentation exists for all zero-order unit models.
 To create new documentation, update the unit classification excel sheet and run the automation script.
 """
+
 import pytest
 import os
 


### PR DESCRIPTION
## Fixes/Resolves:

Updating to latest version of black.

>  [!IMPORTANT]
> Merging this PR will require all existing PRs to run `pip -r requirement-dev.txt` and `black` again.

## Summary/Motivation:

It's been 2 years since we updated the version of black we are using. Seems like time to do it.

## Changes proposed in this PR:
- update version, still pinned, in requirements-dev.txt
- re-running new version across all files.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
