### PR TITLE
remove python 3.9

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,7 +78,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
         os:
@@ -179,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
+          - '3.10'
           - '3.11'
         os:
           - linux
@@ -233,7 +232,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
+          - '3.10'
           - '3.11'
         os:
           - linux

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "pyyaml",  # watertap.core.wt_database
         # for parameter_sweep
         "parameter-sweep >=0.1.0",
-        "numpy",
+        "numpy <= 2.3.0",  # avoid numpy 2.4 compatibility issues. TODO: unpin this for future release
         "pint<0.25",
     ],
     extras_require={

--- a/watertap/tools/oli_api/flash.py
+++ b/watertap/tools/oli_api/flash.py
@@ -1119,8 +1119,7 @@ def flatten_results(processed_requests):
                 elif "data" in values:
                     # intended for vaporDiffusivityMatrix
                     mat_dim = int(sqrt(len(values["data"])))
-                    diffmat = reshape(values["data"], newshape=(mat_dim, mat_dim))
-
+                    diffmat = reshape(values["data"], shape=(mat_dim, mat_dim))
                     extracted_values = {
                         f'({values["speciesNames"][i]},{values["speciesNames"][j]})': {
                             "units": values["unit"],


### PR DESCRIPTION
## Fixes/Resolves:

[Issue #1726](https://github.com/watertap-org/watertap/issues/1726)

## Summary/Motivation:
1. Python 3.9 is at end of life. 
2. New versions of watertap requirements are not supporting python 3.9 so workflows are failing

> TODO: remove any mention of 3.9 from read the docs and other documentatoin

## Changes proposed in this PR:
- remove 3.9 from CI
- update supported pythons in setup.py to exclude python 3.9
- fixed pylint bug to enable merge
- pinned numpy to last version to enable merge

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
