### PR TITLE
Add Contact Info to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ refer to the [Getting Started for Developers](https://watertap.readthedocs.io/en
 
 For general inquiries about WaterTAP, including potential collaborations, partnerships, and analyses,
 please reach out to us at [watertap-contact@lbl.gov](watertap-contact@lbl.gov). For technical questions or issues encountered while
-using WaterTAP, please contact our support team at [watertap-support@lbl.gov](watertap-support@lbl.gov). For al other inquiries
+using WaterTAP, please contact our support team at [watertap-support@lbl.gov](watertap-support@lbl.gov). For all other inquiries
 about WaterTAP, please contact Adam Atia at [Adam.Atia@netl.doe.gov](Adam.Atia@netl.doe.gov).
 
 We are always eager to explore new opportunities and facilitate tailored solutions to problems in

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ The WaterTAP documentation is available online at <https://watertap.readthedocs.
 If you want to clone the repository and work directly with the code, please
 refer to the [Getting Started for Developers](https://watertap.readthedocs.io/en/stable/getting_started.html#for-watertap-developers) section of the documentation.
 
+## Contact
+
+For general inquiries about WaterTAP, including potential collaborations, partnerships, and analyses,
+please reach out to us at [watertap-contact@lbl.gov](watertap-contact@lbl.gov). For technical questions or issues encountered while
+using WaterTAP, please contact our support team at [watertap-support@lbl.gov](watertap-support@lbl.gov). For al other inquiries
+about WaterTAP, please contact [Adam Atia](Adam.Atia@netl.doe.gov).
+
+We are always eager to explore new opportunities and facilitate tailored solutions to problems in
+the water treatment industry.
+
 ## Cite this work
 
 To cite this work, please use the "Cite this repository" feature available on the right side of this repository page.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ refer to the [Getting Started for Developers](https://watertap.readthedocs.io/en
 For general inquiries about WaterTAP, including potential collaborations, partnerships, and analyses,
 please reach out to us at [watertap-contact@lbl.gov](watertap-contact@lbl.gov). For technical questions or issues encountered while
 using WaterTAP, please contact our support team at [watertap-support@lbl.gov](watertap-support@lbl.gov). For al other inquiries
-about WaterTAP, please contact [Adam Atia](Adam.Atia@netl.doe.gov).
+about WaterTAP, please contact Adam Atia at [Adam.Atia@netl.doe.gov](Adam.Atia@netl.doe.gov).
 
 We are always eager to explore new opportunities and facilitate tailored solutions to problems in
 the water treatment industry.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,16 @@ The WaterTAP development team is composed of researchers from:
 * SLAC National Accelerator Laboratory
 * Stanford University
 
+Contact
+-------
+For general inquiries about WaterTAP, including potential collaborations, partnerships, and analyses,
+please reach out to us at watertap-contact@lbl.gov. For technical questions or issues encountered while
+using WaterTAP, please contact our support team at watertap-support@lbl.gov. For al other inquiries
+about WaterTAP, please contact `Adam Atia <Adam.Atia@netl.doe.gov>`_.
+
+We are always eager to explore new opportunities and facilitate tailored solutions to problems in
+the water treatment industry.
+
 Cite this work
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Contact
 -------
 For general inquiries about WaterTAP, including potential collaborations, partnerships, and analyses,
 please reach out to us at watertap-contact@lbl.gov. For technical questions or issues encountered while
-using WaterTAP, please contact our support team at watertap-support@lbl.gov. For al other inquiries
+using WaterTAP, please contact our support team at watertap-support@lbl.gov. For all other inquiries
 about WaterTAP, please contact Adam Atia at `Adam.Atia@netl.doe.gov <Adam.Atia@netl.doe.gov>`_.
 
 We are always eager to explore new opportunities and facilitate tailored solutions to problems in

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Contact
 For general inquiries about WaterTAP, including potential collaborations, partnerships, and analyses,
 please reach out to us at watertap-contact@lbl.gov. For technical questions or issues encountered while
 using WaterTAP, please contact our support team at watertap-support@lbl.gov. For al other inquiries
-about WaterTAP, please contact `Adam Atia <Adam.Atia@netl.doe.gov>`_.
+about WaterTAP, please contact Adam Atia at `Adam.Atia@netl.doe.gov <Adam.Atia@netl.doe.gov>`_.
 
 We are always eager to explore new opportunities and facilitate tailored solutions to problems in
 the water treatment industry.


### PR DESCRIPTION
## Fixes/Resolves:

Adds contact info to the ReadTheDocs and GitHub ReadMe page since they were hard to find.

## Summary/Motivation:
Not many people find our contact info by visiting this page: https://www.nawihub.org/knowledge/watertap/

## Changes proposed in this PR:
- Add contact info to ReadTheDocs homepage
- Add contact info to WaterTAP ReadMe

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
