### PR TITLE
Add python 3.12 and 3.13 to workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -182,6 +182,8 @@ jobs:
         python-version:
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
         os:
           - linux
           - win64

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,6 +80,8 @@ jobs:
         python-version:
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
         os:
           - linux
           - win64

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
@@ -76,8 +76,16 @@ class TestFullFlowsheetBioPFalse:
     def test_numerical_issues(self, system_frame):
         dt = DiagnosticsToolbox(system_frame)
         warnings, _ = dt._collect_numerical_warnings()
-        assert len(warnings) == 1
+        assert len(warnings) == 3
         assert "WARNING: 3 Variables at or outside bounds (tol=0.0E+00)" in warnings
+        assert (
+            "WARNING: 2 Variables with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
+            in warnings
+        )
+        assert (
+            "WARNING: 2 Constraints with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
+            in warnings
+        )
 
     @pytest.mark.component
     def test_solve(self, system_frame):
@@ -194,8 +202,16 @@ class TestFullFlowsheetBioPTrue:
     def test_numerical_issues(self, system_frame):
         dt = DiagnosticsToolbox(system_frame)
         warnings, _ = dt._collect_numerical_warnings()
-        assert len(warnings) == 1
+        assert len(warnings) == 3
         assert "WARNING: 3 Variables at or outside bounds (tol=0.0E+00)" in warnings
+        assert (
+            "WARNING: 2 Variables with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
+            in warnings
+        )
+        assert (
+            "WARNING: 2 Constraints with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
+            in warnings
+        )
 
     @pytest.mark.component
     def test_solve(self, system_frame):
@@ -339,7 +355,7 @@ class TestScaledBioPFalse:
         cond = jacobian_cond(jac=jac, scaled=False)
         assert (
             # Python 3.9-3.11
-            cond == pytest.approx(4.3021828e15, rel=1e-2)
+            cond == pytest.approx(3.69544622e15, rel=1e-2)
             # Python 3.12
             or cond == pytest.approx(2.987651e15, rel=1e-2)
         )
@@ -392,5 +408,5 @@ class TestScaledBioPTrue:
         jac, _ = get_jacobian(sm, scaled=False)
 
         assert (jacobian_cond(jac=jac, scaled=False)) == pytest.approx(
-            7.43640e14, rel=1e-2
+            8.89557845e14, rel=1e-2
         )

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
@@ -325,7 +325,7 @@ class TestScaledBioPFalse:
         # Check condition number to confirm scaling
         jac, _ = get_jacobian(m, scaled=False)
         assert jacobian_cond(jac=jac, scaled=False) == pytest.approx(
-            2.987650e15, rel=1e-2
+            4.302764e15, rel=1e-2
         )
 
     @pytest.mark.solver

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
@@ -339,7 +339,7 @@ class TestScaledBioPFalse:
         cond = jacobian_cond(jac=jac, scaled=False)
         assert (
             # Python 3.9-3.11
-            cond == pytest.approx(3.69544622e15, rel=1e-2)
+            cond == pytest.approx(4.3021828e15, rel=1e-2)
             # Python 3.12
             or cond == pytest.approx(2.987651e15, rel=1e-2)
         )
@@ -392,5 +392,5 @@ class TestScaledBioPTrue:
         jac, _ = get_jacobian(sm, scaled=False)
 
         assert (jacobian_cond(jac=jac, scaled=False)) == pytest.approx(
-            8.89557845e14, rel=1e-2
+            7.43640e14, rel=1e-2
         )

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
@@ -43,6 +43,14 @@ is_reference_platform = (
 is_linux_platform = (
     platform.system() == "Linux" and platform.python_version_tuple()[0] == "3"
 )
+is_linux_platform_new = (
+    platform.system() == "Linux"
+    and platform.python_version_tuple()[0] in ("3.12", "3.13")
+)
+is_linux_platform_old = (
+    platform.system() == "Linux"
+    and platform.python_version_tuple()[0] in ("3.10", "3.11")
+)
 
 reference_platform_only = pytest.mark.xfail(
     condition=(not is_reference_platform),
@@ -56,6 +64,20 @@ linux_platform_only = pytest.mark.xfail(
     run=True,
     strict=False,
     reason="These tests are expected to pass only on the Linux platform (Python 3)",
+)
+
+linux_platform_new_only = pytest.mark.xfail(
+    condition=(not is_linux_platform_new),
+    run=True,
+    strict=False,
+    reason="These tests are expected to pass only on the Linux platform (Python 3.12, 3.13)",
+)
+
+linux_platform_old_only = pytest.mark.xfail(
+    condition=(not is_linux_platform_old),
+    run=True,
+    strict=False,
+    reason="These tests are expected to pass only on the Linux platform (Python 3.10, 3.11)",
 )
 
 
@@ -318,14 +340,26 @@ class TestScaledBioPFalse:
 
     @pytest.mark.solver
     @pytest.mark.component
-    @linux_platform_only
-    def test_condition_number_on_linux(self, system_frame):
+    @linux_platform_new_only
+    def test_condition_number_on_linux_new(self, system_frame):
         m = system_frame
 
         # Check condition number to confirm scaling
         jac, _ = get_jacobian(m, scaled=False)
         assert jacobian_cond(jac=jac, scaled=False) == pytest.approx(
             4.302764e15, rel=1e-2
+        )
+
+    @pytest.mark.solver
+    @pytest.mark.component
+    @linux_platform_old_only
+    def test_condition_number_on_linux_old(self, system_frame):
+        m = system_frame
+
+        # Check condition number to confirm scaling
+        jac, _ = get_jacobian(m, scaled=False)
+        assert jacobian_cond(jac=jac, scaled=False) == pytest.approx(
+            2.987650e15, rel=1e-2
         )
 
     @pytest.mark.solver

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
@@ -76,16 +76,8 @@ class TestFullFlowsheetBioPFalse:
     def test_numerical_issues(self, system_frame):
         dt = DiagnosticsToolbox(system_frame)
         warnings, _ = dt._collect_numerical_warnings()
-        assert len(warnings) == 3
+        assert len(warnings) == 1
         assert "WARNING: 3 Variables at or outside bounds (tol=0.0E+00)" in warnings
-        assert (
-            "WARNING: 2 Variables with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
-            in warnings
-        )
-        assert (
-            "WARNING: 2 Constraints with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
-            in warnings
-        )
 
     @pytest.mark.component
     def test_solve(self, system_frame):
@@ -202,16 +194,8 @@ class TestFullFlowsheetBioPTrue:
     def test_numerical_issues(self, system_frame):
         dt = DiagnosticsToolbox(system_frame)
         warnings, _ = dt._collect_numerical_warnings()
-        assert len(warnings) == 3
+        assert len(warnings) == 1
         assert "WARNING: 3 Variables at or outside bounds (tol=0.0E+00)" in warnings
-        assert (
-            "WARNING: 2 Variables with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
-            in warnings
-        )
-        assert (
-            "WARNING: 2 Constraints with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
-            in warnings
-        )
 
     @pytest.mark.component
     def test_solve(self, system_frame):


### PR DESCRIPTION
## Fixes/Resolves:
[Issue #1657](https://github.com/watertap-org/watertap/issues/1657)

## Summary/Motivation:
Add support for newer python versions

## Changes proposed in this PR:
- adds additional pytest jobs with python versions 3.12 and 3.13
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
