### PR TITLE
2-Stage LSRRO GUI Fix

### DIFF
--- a/watertap/flowsheets/lsrro/lsrro_ui.py
+++ b/watertap/flowsheets/lsrro/lsrro_ui.py
@@ -599,19 +599,17 @@ def export_variables(flowsheet=None, exports=None, build_options=None, **kwargs)
         is_output=True,
         output_category="System metrics",
     )
-    if len(fs.Stages) > 1:
-        total_area = sum(fs.ROUnits[i].area for i in fs.Stages)
-        exports.add(
-            obj=total_area,
-            name="Total membrane area",
-            ui_units=pyunits.m**2,
-            display_units="m^2",
-            rounding=2,
-            description="Total membrane area",
-            is_input=False,
-            is_output=True,
-            output_category="System metrics",
-        )
+    exports.add(
+        obj=fs.total_membrane_area,
+        name="Total membrane area",
+        ui_units=pyunits.m**2,
+        display_units="m^2",
+        rounding=2,
+        description="Total membrane area",
+        is_input=False,
+        is_output=True,
+        output_category="System metrics",
+    )
     exports.add(
         obj=fs.annual_feed,
         name="Annual feed flow",

--- a/watertap/flowsheets/lsrro/lsrro_ui.py
+++ b/watertap/flowsheets/lsrro/lsrro_ui.py
@@ -599,18 +599,19 @@ def export_variables(flowsheet=None, exports=None, build_options=None, **kwargs)
         is_output=True,
         output_category="System metrics",
     )
-    total_area = sum(fs.ROUnits[i].area for i in fs.NonFinalStages)
-    exports.add(
-        obj=total_area,
-        name="Total membrane area",
-        ui_units=pyunits.m**2,
-        display_units="m^2",
-        rounding=2,
-        description="Total membrane area",
-        is_input=False,
-        is_output=True,
-        output_category="System metrics",
-    )
+    if len(fs.NonFinalStages) > 1:
+        total_area = sum(fs.ROUnits[i].area for i in fs.NonFinalStages)
+        exports.add(
+            obj=total_area,
+            name="Total membrane area",
+            ui_units=pyunits.m**2,
+            display_units="m^2",
+            rounding=2,
+            description="Total membrane area",
+            is_input=False,
+            is_output=True,
+            output_category="System metrics",
+        )
     exports.add(
         obj=fs.annual_feed,
         name="Annual feed flow",

--- a/watertap/flowsheets/lsrro/lsrro_ui.py
+++ b/watertap/flowsheets/lsrro/lsrro_ui.py
@@ -599,8 +599,8 @@ def export_variables(flowsheet=None, exports=None, build_options=None, **kwargs)
         is_output=True,
         output_category="System metrics",
     )
-    if len(fs.NonFinalStages) > 1:
-        total_area = sum(fs.ROUnits[i].area for i in fs.NonFinalStages)
+    if len(fs.Stages) > 1:
+        total_area = sum(fs.ROUnits[i].area for i in fs.Stages)
         exports.add(
             obj=total_area,
             name="Total membrane area",


### PR DESCRIPTION
## Fixes/Resolves:
A member of the Academy was running the LSRRO flowsheet in the GUI and found out that the 2-stage system couldn't be built.

## Summary/Motivation:
Adds an if statement such that the total membrane area variable isn't built for a 2-stage or 1-stage system

## Changes proposed in this PR:
- Updates the LSRRO UI file

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
