### PR TITLE
Test watertap with Idaes-pse 2.11.0rc0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         # primary requirements for unit and property models
         # allow X.Y.Z stable release(s) and X.Y+1.dev0 (i.e. the main branch after X.Y.Z)
         # disallow X.Y+1.0rc0 (i.e. forcing a manual update to this requirement)
-        "idaes-pse>=2.10.0",
+        "idaes-pse>=2.11.0rc0",
         "pyomo>=6.6.1",
         "watertap-solvers",
         "pyyaml",  # watertap.core.wt_database

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
@@ -216,8 +216,7 @@ class TestFullFlowsheet:
 
     @pytest.mark.requires_idaes_solver
     @pytest.mark.component
-    @pytest.mark.xfail(
-        reason="This test is volitile due to BSM2 performance")
+    @pytest.mark.xfail(reason="This test is volitile due to BSM2 performance")
     @reference_platform_only
     def test_optimization_windows(self, optimized_system_frame):
         m = optimized_system_frame

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
@@ -216,6 +216,8 @@ class TestFullFlowsheet:
 
     @pytest.mark.requires_idaes_solver
     @pytest.mark.component
+    @pytest.mark.xfail(
+        reason="This test is volitile due to BSM2 performance")
     @reference_platform_only
     def test_optimization_windows(self, optimized_system_frame):
         m = optimized_system_frame


### PR DESCRIPTION
## Summary/Motivation:

See how watertap interacts with the new idaes-pse release (candidate).

## Changes proposed in this PR:
- Updated the required version of `idaes-pse` from `>=2.10.0` to `>=2.11.0rc0` in `setup.py`, allowing the use of the latest release candidate

- xfails a volatile test

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
