### PR TITLE
Update requirement version for parameter-sweep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "watertap-solvers",
     "pyyaml",            # watertap.core.wt_database
     # for parameter_sweep
+    "parameter-sweep >= 0.2.0rc1",
     "numpy",
     "pint<0.25",
 ]
@@ -71,10 +72,6 @@ oli_api = [
 
 reaktoro = [
     "reaktoro-pse @ git+https://github.com/watertap-org/reaktoro-pse",
-]
-
-parameter_sweep = [
-    "parameter_sweep @ git+https://github.com/watertap-org/parameter-sweep"
 ]
 
 all = ["watertap[testing,notebooks,oli_api,reaktoro]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "watertap-solvers",
     "pyyaml",            # watertap.core.wt_database
     # for parameter_sweep
-    "parameter-sweep @ git+https://github.com/watertap-org/parameter-sweep",
     "numpy",
     "pint<0.25",
 ]
@@ -72,6 +71,10 @@ oli_api = [
 
 reaktoro = [
     "reaktoro-pse @ git+https://github.com/watertap-org/reaktoro-pse",
+]
+
+parameter_sweep = [
+    "parameter_sweep @ git+https://github.com/watertap-org/parameter-sweep"
 ]
 
 all = ["watertap[testing,notebooks,oli_api,reaktoro]"]


### PR DESCRIPTION
## Fixes/Resolves:

(replace this with the issue # fixed or resolved, if no issue exists then a brief statement of what this PR does)

## Summary/Motivation:
Currently, there is an incompatible circular dependency between parameter-sweep and watertap.
Versions are out of sync which causes parameter-sweep tests to fail. This is a temporary fix to get parameter-sweep workflows to pass. After the final release, this version will be updated to 0.2.0.

## Changes proposed in this PR:
- Updated the `parameter-sweep` dependency to require version `>= 0.2.0rc1` in `pyproject.toml`, replacing the previous direct GitHub reference.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
