### PR TITLE
Fix MW bug in surrogate crystallizer by adding explicit molecular weight definition for solids

### DIFF
--- a/watertap/unit_models/surrogate_crystallizer.py
+++ b/watertap/unit_models/surrogate_crystallizer.py
@@ -44,6 +44,12 @@ _log = idaeslog.getLogger(__name__)
 __author__ = "Oluwamayowa Amusat, Adam Atia"
 
 
+def _none_or_dict(val):
+    if val is None or isinstance(val, dict):
+        return val
+    raise ValueError("solids_mwts must be None or a dictionary")
+
+
 @declare_process_block_class("SurrogateCrystallizer")
 class SurrogateCrystallizerData(UnitModelBlockData):
     """
@@ -135,6 +141,16 @@ see property package for documentation.}""",
         ),
     )
 
+    CONFIG.declare(
+        "solids_mol_wts",
+        ConfigValue(
+            default=None,
+            domain=_none_or_dict,  # only None or dict allowed
+            description="Optional molecular weights for solids in Kg/mol",
+            doc="""Optional list of molecular weights for solids in Kg/mol. Units must be included in definition. If not provided, molecular weights of the solids will be assumed to be accurately computable from the ions.""",
+        ),
+    )
+
     def build(self):
 
         # Call UnitModel.build to setup dynamics
@@ -144,6 +160,12 @@ see property package for documentation.}""",
         units_meta = self.config.property_package.get_metadata().get_derived_units
 
         self.solids_list = Set(initialize=self.config.solids_ions_dict.keys())
+
+        # Check that the solids are the same
+        if self.config.solids_mol_wts:
+            assert set(self.config.solids_ions_dict.keys()) == set(
+                self.config.solids_mol_wts.keys()
+            )
 
         # Add ion in solid ratios as parameters
         dict1 = dict()
@@ -337,12 +359,19 @@ see property package for documentation.}""",
             if j == "H2O":
                 return Constraint.Skip
             else:
+                if b.config.solids_mol_wts:
+                    solid_mol_wt = b.config.solids_mol_wts
+                else:
+                    solid_mol_wt = {
+                        q: sum(
+                            b.mwc[q, j] * b.properties_in[0].params.mw_comp[j]
+                            for j in b.config.property_package.ion_set
+                        )
+                        for q in b.solids_list
+                    }
                 return b.flow_mass_sol_comp_true[j] == sum(
                     (b.mwc[q, j] * b.properties_in[0].params.mw_comp[j])
-                    / sum(
-                        b.mwc[q, j] * b.properties_in[0].params.mw_comp[j]
-                        for j in b.config.property_package.ion_set
-                    )
+                    / solid_mol_wt[q]
                     * b.flow_mass_sol_comp_apparent[q]
                     for q in b.solids_list
                 )

--- a/watertap/unit_models/tests/test_surrogate_crystallizer.py
+++ b/watertap/unit_models/tests/test_surrogate_crystallizer.py
@@ -229,3 +229,122 @@ def test_rbf_surrogate():
     res = solver.solve(m)
     assert_optimal_termination(res)
     m.fs.cryst.report()
+
+
+@pytest.mark.component
+def test_rbf_surrogate_with_solids_weights():
+    m = ConcreteModel()
+    m.case = "BGW1"
+    m.fs = FlowsheetBlock(dynamic=False)
+
+    input_ions = ["Cl_-", "Na_+", "SO4_2-", "Mg_2+", "Ca_2+", "K_+", "HCO3_-"]
+    solids_list = {
+        "Calcite_g": {"Ca_2+": 1, "HCO3_-": 1},
+        "Anhydrite_g": {"Ca_2+": 1, "SO4_2-": 1},
+        "Glauberite_g": {"Ca_2+": 1, "Na_+": 2, "SO4_2-": 2},
+        "Halite_g": {"Na_+": 1, "Cl_-": 1},
+    }
+    solids_weights_kg_mol = {
+        "Calcite_g": (100 / 1000) * pyunits.kg / pyunits.mol,
+        "Anhydrite_g": (136.14 / 1000) * pyunits.kg / pyunits.mol,
+        "Glauberite_g": (278.18 / 1000) * pyunits.kg / pyunits.mol,
+        "Halite_g": (58.44 / 1000) * pyunits.kg / pyunits.mol,
+    }
+
+    m.fs.cryst_prop_feed = MCASParameterBlock(
+        solute_list=input_ions,
+        material_flow_basis=MaterialFlowBasis.mass,
+    )
+
+    m.fs.water_properties_vapor = WaterParameterBlock()
+
+    # Create crystallizer framework
+    m.fs.cryst = SurrogateCrystallizer(
+        property_package=m.fs.cryst_prop_feed,
+        vapor_property_package=m.fs.water_properties_vapor,
+        solids_ions_dict=solids_list,
+        solids_mol_wts=solids_weights_kg_mol,
+    )
+
+    # Feed composition
+    feed = {
+        "ion_composition_g_kg": {
+            "Na_+": 91.49859876,
+            "K_+": 3.185931759,
+            "Cl_-": 159.0941278,
+            "Ca_2+": 0.788476605,
+            "Mg_2+": 10.5806906,
+            "HCO3_-": 1.614773395,
+            "SO4_2-": 22.20893266,
+        },
+        "water_content_kg": 12.0764972138554,
+    }
+
+    g_to_kg = 1e-3
+    for i in m.fs.cryst_prop_feed.component_list:
+        if i == "H2O":
+            m.fs.cryst.inlet.flow_mass_phase_comp[0.0, "Liq", i].fix(
+                feed["water_content_kg"]
+            )
+        else:
+            m.fs.cryst.inlet.flow_mass_phase_comp[0.0, "Liq", i].fix(
+                feed["water_content_kg"] * feed["ion_composition_g_kg"][i] * g_to_kg
+            )
+
+    m.fs.cryst.inlet.temperature.fix(298.15)
+    m.fs.cryst.inlet.pressure.fix(101325)
+
+    assert_units_consistent(m)
+
+    # Create dummy variables for inputs and outputs
+    surrogate_inputs = {
+        "Temperature": {
+            "flowsheet_var": m.fs.cryst.temperature_operating,
+            "var_bounds": (303.15, 372.15),
+        },
+        "Evaporation percent": {
+            "flowsheet_var": m.fs.cryst.evaporation_percent,
+            "var_bounds": (30.0, 98.0),
+        },
+    }
+    m.fs.o1 = Var(units=pyunits.atm)
+    m.fs.o2 = Var(units=pyunits.g / pyunits.s)
+    m.fs.o3 = Var(units=pyunits.g / pyunits.s)
+    m.fs.o4 = Var(units=pyunits.g / pyunits.s)
+    m.fs.o5 = Var(units=pyunits.g / pyunits.s)
+    surrogate_outputs = {
+        "Vapor Pressure (atm)": {"flowsheet_var": m.fs.o1, "Solid": False},
+        "Calcite_g": {"flowsheet_var": m.fs.o2, "Solid": True},
+        "Anhydrite_g": {"flowsheet_var": m.fs.o3, "Solid": True},
+        "Glauberite_g": {"flowsheet_var": m.fs.o4, "Solid": True},
+        "Halite_g": {"flowsheet_var": m.fs.o5, "Solid": True},
+    }
+
+    add_crystallizer_rbf_model(
+        m.fs.cryst,
+        surrogate_inputs_with_bounds=surrogate_inputs,
+        surrogate_outputs=surrogate_outputs,
+        surrogate_to_flowsheet_basis_ratio=1,
+    )
+
+    # Costing
+    m.fs.costing = WaterTAPCosting()
+    m.fs.cryst.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing,
+    )
+    m.fs.costing.cost_process()
+
+    # Edit bound on liquid pressures from property package
+    m.fs.cryst.properties_out_liq[0].pressure.setlb(1000)
+
+    # 1. Simulate single case
+    m.fs.cryst.temperature_operating.fix(40 + 273.15)
+    m.fs.cryst.evaporation_percent.fix(60)
+
+    # Initialize and solve
+    assert degrees_of_freedom(m) == 0
+    m.fs.cryst.initialize()
+    solver = get_solver()
+    res = solver.solve(m)
+    assert_optimal_termination(res)
+    m.fs.cryst.report()


### PR DESCRIPTION
## Summary/Motivation:
Current implementation of surrogate crystallizer computes the solid molecular weight from ion speciation. While that works most of the time, it can sometimes cause material balance issues when dealing with solids like calcite:

``mol wt. (caco3) != mol wt. (ca) + mol wt. (hco3)``

## Changes proposed in this PR:
- Add optional argument to support user-specified molecular weights for solids.
- Keep previous approach (computation from ion mol. weights) as fall back if user does not supply molecular weight dictionary
- Add tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
