### PR TITLE
Point to pandas unbound branch in ideas-pse [for testing]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # primary requirements for unit and property models
     # allow X.Y.Z stable release(s) and X.Y+1.dev0 (i.e. the main branch after X.Y.Z)
     # disallow X.Y+1.0rc0 (i.e. forcing a manual update to this requirement)
-    "idaes-pse>=2.11.0",
+    "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/refs/pull/1789/head.zip",
     "pyomo>=6.6.1",
     "watertap-solvers",
     "pyyaml",            # watertap.core.wt_database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # primary requirements for unit and property models
     # allow X.Y.Z stable release(s) and X.Y+1.dev0 (i.e. the main branch after X.Y.Z)
     # disallow X.Y+1.0rc0 (i.e. forcing a manual update to this requirement)
-    "idaes-pse @ https://github.com/IDAES/idaes-pse/archive/refs/pull/1789/head.zip",
+    "idaes-pse>=2.11.0",
     "pyomo>=6.6.1",
     "watertap-solvers",
     "pyyaml",            # watertap.core.wt_database

--- a/watertap/core/util/flowsheet.py
+++ b/watertap/core/util/flowsheet.py
@@ -90,9 +90,9 @@ def list_ports(block, descend_into=False):
                     "Unit Model": type(unit).__name__.removeprefix("_Scalar"),
                     "Port Name": name,
                     "Port": port.name,
-                    "Source": connected["Source"] or None,
-                    "Destination": connected["Destination"] or None,
-                    "Arc": connected["Arc"] or None,
+                    "Source": connected["Source"] or "None",
+                    "Destination": connected["Destination"] or "None",
+                    "Arc": connected["Arc"] or "None",
                 }
             )
 


### PR DESCRIPTION
## Fixes/Resolves:

#1794 

## Summary/Motivation:
Unbounding pandas starting from idaes-pse could be the key to continuing conda-forge packaging. This PR sees how the change affects watertap downstream and addresses forthcoming issues.


## Changes proposed in this PR:
* Modified the `list_ports` function in `watertap/core/util/flowsheet.py` to set the string `"None"` instead of Python's `None` object


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
