### PR TITLE
Reveal `add_flow_component_breakdown` Method in WaterTAP Costing

### DIFF
--- a/watertap/costing/tests/test_costing_base.py
+++ b/watertap/costing/tests/test_costing_base.py
@@ -185,3 +185,34 @@ def test_breakdowns():
         sum(m.fs.costing.specific_electrical_carbon_intensity_component.values())
     )
     assert pytest.approx(seci) == summed_seci
+
+
+@pytest.mark.component
+def test_breakdowns_with_no_unit():
+    m = lsrro.build()
+
+    m.fs.BoosterPumps[:].control_volume.work[0.0].value = 42e6
+    m.fs.EnergyRecoveryDevices[:].control_volume.work[0.0].value = -42e6
+    m.fs.electricity_flow_with_no_unit = pyo.Var(units=pyo.units.kW, initialize=1234)
+
+    m.fs.costing.cost_flow(m.fs.electricity_flow_with_no_unit, "electricity")
+
+    m.fs.costing.add_flow_component_breakdown(
+        "electricity",
+        m.fs.product.properties[0].flow_vol,
+        period=pyo.units.year,
+    )
+    assert hasattr(m.fs.costing, "electricity_component")
+    assert (
+        "fs.electricity_flow_with_no_unit"
+        in m.fs.costing.electricity_component.index_set()
+    )
+
+    m.fs.costing.add_flow_component_breakdown(
+        "electricity",
+        m.fs.product.properties[0].flow_vol,
+        name="biff",
+        period=pyo.units.millisecond,
+    )
+    assert hasattr(m.fs.costing, "biff_component")
+    assert "fs.electricity_flow_with_no_unit" in m.fs.costing.biff_component.index_set()

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -304,8 +304,8 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
                 doc=f"Specific energy consumption based on flow {flow_rate.name}",
             ),
         )
-        self._add_flow_component_breakdowns(
-            "electricity", name, flow_rate, utilization_factor=1.0, period=pyo.units.hr
+        self.add_flow_component_breakdown(
+            "electricity", flow_rate, name=name, period=pyo.units.hr
         )
 
     def add_annual_water_production(self, flow_rate, name="annual_water_production"):
@@ -314,7 +314,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         Args:
             flow_rate - flow rate of water (volumetric) to be used in
                         calculating annual water production
-            name (optional) - name for the annual water productionvariable
+            name (optional) - name for the annual water production
                               Expression (default: annual_water_production)
         """
         self.add_component(
@@ -362,40 +362,46 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
                 doc=f"Specific electrical carbon intensity based on flow {flow_rate.name}",
             ),
         )
-        self._add_flow_component_breakdowns(
+        self.add_flow_component_breakdown(
             "electricity",
-            name,
             flow_rate,
+            name=name,
             period=pyo.units.hr,
-            utilization_factor=1.0,
             multiplier=self.electrical_carbon_intensity,
         )
 
-    def _add_flow_component_breakdowns(
+    def add_flow_component_breakdown(
         self,
         flow_name,
-        name,
         flow_rate,
+        name=None,
         period=None,
-        utilization_factor=None,
         multiplier=1.0,
     ):
         """
-        Add per-component breakdowns for specific `flow_name` consumption with base-name `name`
-        at `flow_rate`.
-        Optional `multiplier` for the flow and period specification (default is 1 hour),
-        and specified `utilization_factor` (default is self.utilization_factor).
+        Add per-component breakdowns for a registered flow type normalized by a flow rate over a period
+        Args:
+            flow_name - name of registered flow
+            flow_rate - flow rate of water (volumetric) to be used for normalization
+            name (optional)- base name for the component Expression (default is flow_name)
+            period (optional) - time period for normalization (default is base_period)
+            multiplier (optional) - multiplier for the flow (default is 1.0)
         """
-        if utilization_factor is None:
-            utilization_factor = self.utilization_factor
+        # NOTE: utilization_factor cancels in final expression but is included for convention
+
         if period is None:
             period = self.base_period
+
+        if name is None:
+            name = flow_name
+
         denominator = (
             pyo.units.convert(flow_rate, to_units=pyo.units.m**3 / period)
-            * utilization_factor
+            * self.utilization_factor
         )
         f_units = pyo.units.get_units(getattr(self, f"aggregate_flow_{flow_name}"))
         c_units = f_units * pyo.units.get_units(multiplier)
+        expr_units = c_units / pyo.units.get_units(denominator)
 
         try:
             flows = self._registered_flows[flow_name]
@@ -413,15 +419,17 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
             flow_std = pyo.units.convert(flow_expr, to_units=f_units)
             unit = self._find_flow_unit(flow_expr)
             if unit is not None:
-                specific_flow_consumption[unit.name] += (
-                    flow_std * utilization_factor * multiplier
-                ) / denominator
+                specific_flow_consumption[unit.name] += pyo.units.convert(
+                    (flow_std * self.utilization_factor * multiplier) / denominator,
+                    to_units=expr_units,
+                )
                 continue
             _log.warning(f"Could not find unique unit for flow {flow_expr}")
             flow_name = self._get_flow_name(flow_expr)
-            specific_flow_consumption[flow_name] += (
-                flow_std * utilization_factor * multiplier
-            ) / denominator
+            specific_flow_consumption[flow_name] += pyo.units.convert(
+                (flow_std * self.utilization_factor * multiplier) / denominator,
+                to_units=expr_units,
+            )
 
     def build_process_costs(self):
         """

--- a/watertap/flowsheets/ion_exchange/ion_exchange_demo.py
+++ b/watertap/flowsheets/ion_exchange/ion_exchange_demo.py
@@ -129,6 +129,29 @@ def ix_build(ions, target_ion=None, hazardous_waste=False, regenerant="NaCl"):
     m.fs.feed.properties[0].conc_mass_phase_comp[...]
     m.fs.product.properties[0].conc_mass_phase_comp[...]
 
+    # Add costing blocks to the flowsheet
+    # Here, the ion exchange model has its own unit-level costing Block
+    m.fs.ion_exchange.costing = UnitModelCostingBlock(
+        flowsheet_costing_block=m.fs.costing  # Indicating which flowsheet costing block to use to aggregate unit-level costs to the system-level costs
+    )
+    # Call cost_process() method to create system-wide global parameters and add aggregating constraints to costing model
+    m.fs.costing.cost_process()
+    # Designate the volumetric flow on the Product block to be the stream used as the annual water production
+    m.fs.costing.add_annual_water_production(
+        m.fs.product.properties[0].flow_vol_phase["Liq"]
+    )
+    # Add LCOW variable to costing block
+    m.fs.costing.add_LCOW(m.fs.product.properties[0].flow_vol_phase["Liq"])
+    # Add specific energy consumption variable to costing block
+    m.fs.costing.add_specific_energy_consumption(
+        m.fs.product.properties[0].flow_vol_phase["Liq"]
+    )
+    m.fs.costing.add_flow_component_breakdown(
+        "NaCl",
+        m.fs.product.properties[0].flow_vol_phase["Liq"],
+        name="regenerant_usage",
+    )
+
     # Arcs are used to "connect" Ports on unit process models to Ports on other unit process models
     # For example, in this next line the outlet Port on the Feed model is connected to the inlet Port on the ion exchange model
     m.fs.feed_to_ix = Arc(source=m.fs.feed.outlet, destination=ix.inlet)
@@ -314,6 +337,10 @@ def display_results(m):
     )
     print(
         f'{"Specific Energy Consumption":<40s}{f"{m.fs.costing.specific_energy_consumption():<39,.5f}"}{"kWh/m3":<40s}'
+    )
+    regen_usage = m.fs.costing.regenerant_usage_component["fs.ion_exchange"]
+    print(
+        f'{f"Specific {ix.config.regenerant} Consumption":<40s}{f"{regen_usage():<39,.5f}"}{"kg/m3":<40s}'
     )
     print(
         f'{f"Annual Regenerant cost ({ix.config.regenerant})":<40s}{f"${m.fs.costing.aggregate_flow_costs[ix.config.regenerant]():<39,.2f}"}{"$/yr":<40s}'

--- a/watertap/flowsheets/ion_exchange/ion_exchange_demo.py
+++ b/watertap/flowsheets/ion_exchange/ion_exchange_demo.py
@@ -129,29 +129,6 @@ def ix_build(ions, target_ion=None, hazardous_waste=False, regenerant="NaCl"):
     m.fs.feed.properties[0].conc_mass_phase_comp[...]
     m.fs.product.properties[0].conc_mass_phase_comp[...]
 
-    # Add costing blocks to the flowsheet
-    # Here, the ion exchange model has its own unit-level costing Block
-    m.fs.ion_exchange.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.costing  # Indicating which flowsheet costing block to use to aggregate unit-level costs to the system-level costs
-    )
-    # Call cost_process() method to create system-wide global parameters and add aggregating constraints to costing model
-    m.fs.costing.cost_process()
-    # Designate the volumetric flow on the Product block to be the stream used as the annual water production
-    m.fs.costing.add_annual_water_production(
-        m.fs.product.properties[0].flow_vol_phase["Liq"]
-    )
-    # Add LCOW variable to costing block
-    m.fs.costing.add_LCOW(m.fs.product.properties[0].flow_vol_phase["Liq"])
-    # Add specific energy consumption variable to costing block
-    m.fs.costing.add_specific_energy_consumption(
-        m.fs.product.properties[0].flow_vol_phase["Liq"]
-    )
-    m.fs.costing.add_flow_component_breakdown(
-        "NaCl",
-        m.fs.product.properties[0].flow_vol_phase["Liq"],
-        name="regenerant_usage",
-    )
-
     # Arcs are used to "connect" Ports on unit process models to Ports on other unit process models
     # For example, in this next line the outlet Port on the Feed model is connected to the inlet Port on the ion exchange model
     m.fs.feed_to_ix = Arc(source=m.fs.feed.outlet, destination=ix.inlet)
@@ -195,6 +172,12 @@ def add_costing(m):
     # Add specific energy consumption variable to costing block
     m.fs.costing.add_specific_energy_consumption(
         m.fs.product.properties[0].flow_vol_phase["Liq"]
+    )
+    # Add breakdown of NaCl usage per unit product flow to costing package with name "regenerant_usage"
+    m.fs.costing.add_flow_component_breakdown(
+        "NaCl",
+        m.fs.product.properties[0].flow_vol_phase["Liq"],
+        name="regenerant_usage",
     )
 
 

--- a/watertap/flowsheets/ion_exchange/tests/test_ion_exchange_demo.py
+++ b/watertap/flowsheets/ion_exchange/tests/test_ion_exchange_demo.py
@@ -10,7 +10,9 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
+import math
 import pytest
+
 from pyomo.environ import (
     ConcreteModel,
     value,
@@ -23,7 +25,6 @@ from pyomo.network import Port
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
-from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import Feed, Product
 from watertap.unit_models.ion_exchange_0D import (
@@ -32,11 +33,10 @@ from watertap.unit_models.ion_exchange_0D import (
     RegenerantChem,
     IsothermType,
 )
+
 from watertap.property_models.multicomp_aq_sol_prop_pack import MCASParameterBlock
-
 import watertap.flowsheets.ion_exchange.ion_exchange_demo as ixf
-
-import math
+from watertap.core.solvers import get_solver
 
 __author__ = "Kurban Sitterley"
 


### PR DESCRIPTION
## Fixes/Resolves:

Related to #1810, split off from #1697, 

## Summary/Motivation:

The `add_flow_component_breakdown` method is currently a "hidden" method but it is useful for flows that aren't electricity; for example, it has been used for heat flows in a separate project. This PR will unhide that method, add a test for it, and add an example of it being used for a non-electricity flow (NaCl) into the IX demo.

## Changes proposed in this PR:
- reveal `add_flow_component_breakdown` method in WaterTAP costing
- test it
- add example of it being used for NaCl flow to IX flowsheet

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
