### PR TITLE
Add auto publish to pypi on tag creation workflow: version 1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Create and Publish idaes-pse PyPI package
+name: Create and Publish watertap PyPI package
 
 on:
   push:
@@ -14,9 +14,7 @@ env:
   PIP_PROGRESS_BAR: "off"
   PYTHON_VERSION: "3.11"
   PACKAGE_NAME: "watertap"
-  EXTRAS_REQUIRE: "[testing]"
-  SNAPSHOT_EXTRAS: "[oli_api,notebooks]"
-
+  
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,46 +26,34 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install build helpers
+      - name: Validate tag matches pyproject version
         run: |
-          pip install build wheel packaging
-
-      - name: Set version from tag in pyproject.toml
-        run: |
+          pip install packaging
           python - <<'PY'
-          import os, re, pathlib
+          import pathlib, re, os
           from packaging.version import Version, InvalidVersion
-
-          raw_tag = os.environ["GITHUB_REF_NAME"]  # must be like 1.7.0, 1.8.0.dev1, 1.7.0rc1
-
-          if raw_tag.startswith("v"):
-              raise SystemExit(f"Tag '{raw_tag}' is invalid: tags must not start with 'v'")
-
+      
+          tag = os.environ["GITHUB_REF_NAME"]  # e.g. 1.7.0
+          text = pathlib.Path("pyproject.toml").read_text()
+      
+          m = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+          if not m:
+              raise SystemExit("Could not find version = \"...\" in pyproject.toml")
+      
+          project_version_raw = m.group(1)
+      
           try:
-              normalized = str(Version(raw_tag))
+              tag_norm = str(Version(tag))
+              proj_norm = str(Version(project_version_raw))
           except InvalidVersion as e:
-              raise SystemExit(f"Tag '{raw_tag}' is not a valid PEP 440 version: {e}")
-
-          p = pathlib.Path("pyproject.toml")
-          txt = p.read_text()
-
-          new, n = re.subn(
-              r'(?m)^version\s*=\s*"[^"]+"',
-              f'version = "{normalized}"',
-              txt,
-              count=1,
-          )
-          if n != 1:
-              raise SystemExit("Could not find exactly one top-level version = \"...\" entry")
-
-          p.write_text(new)
-          print(f"Set pyproject.toml version to {normalized}")
+              raise SystemExit(f"Invalid version encountered: {e}")
+      
+          if tag_norm != proj_norm:
+              print(f"::warning title=Version mismatch::Tag '{tag}' ({tag_norm}) != pyproject version '{project_version_raw}' ({proj_norm})")
+              raise SystemExit(1)
+      
+          print(f"Tag matches pyproject version: {tag_norm}")
           PY
-
-      - name: Verify pyproject version
-        run: grep -n '^version = ' pyproject.toml
-
       - name: Generate dist files
         run: |
           pip install build wheel
@@ -186,7 +172,7 @@ jobs:
 
   upload-pypi:
     needs: [install-test-pypi]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     environment: release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,217 @@
+name: Create and Publish idaes-pse PyPI package
+
+on:
+  push:
+    tags:
+      - "*"
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+env:
+  PYTEST_ADDOPTS: --color=yes
+  PIP_PROGRESS_BAR: "off"
+  PYTHON_VERSION: "3.11"
+  PACKAGE_NAME: "watertap"
+  EXTRAS_REQUIRE: "[testing]"
+  SNAPSHOT_EXTRAS: "[oli_api,notebooks]"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code to be packaged
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Generate dist files
+        run: |
+          pip install build wheel
+          python -m build
+
+      - name: Check that the dist directory's size is below PyPI's maximum
+        run: |
+          ls -lh dist/*
+          _maxsize=100000  # 100 MB
+          _dirsize=$(du -s dist/ | cut -f 1) ; echo $_dirsize
+          echo "::notice title=dist::Total size of dist/ directory is $_dirsize kB"
+          [ "$_dirsize" -lt "$_maxsize" ]
+
+      - name: Upload dist files as artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  test-whl:
+    needs: [build]
+    name: Test watertap from .whl file
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install from .whl file
+        run: |
+          ls -lh dist/
+          whl_file="$(ls dist/*.whl)"
+          echo "$whl_file"
+          pip install "${whl_file}[testing]"
+
+      - name: Check that installed package has the expected tag
+        run: |
+          pip install packaging
+          python -c '
+          import sys
+          from importlib.metadata import version
+          from packaging.version import Version
+
+          name = sys.argv[1]
+          tag = sys.argv[2]
+          normalized_tag = str(Version(tag))
+          pkg_version = version(name)
+
+          print(f"{name=}\n{tag=}\n{normalized_tag=}\n{pkg_version=}")
+          assert pkg_version == normalized_tag
+          ' "watertap" "${{ github.ref_name }}"
+
+      - name: Run tests
+        working-directory: /tmp
+        run: |
+          idaes get-extensions --extra petsc --verbose
+          pip install pytest
+          pytest --pyargs watertap
+
+  upload-test-pypi:
+    needs: [test-whl]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: test-release
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - name: Upload dist files to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  install-test-pypi:
+    runs-on: ubuntu-latest
+    needs: [upload-test-pypi]
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install watertap==${{ github.ref_name }} from TestPyPI
+        env:
+          _wait_time_s: 15
+          _pip_install_flags: --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/
+          _pip_install_target: watertap[testing]==${{ github.ref_name }}
+        run: |
+          until pip install $_pip_install_flags "$_pip_install_target"
+          do
+            echo "pip install failed; waiting $_wait_time_s seconds"
+            sleep "$_wait_time_s"
+          done
+      - name: Install OS deps for ipopt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liblapack3 libblas3 libgfortran5
+      - name: Run tests
+        run: |
+          idaes get-extensions --extra petsc --verbose
+          pip install pytest
+          pytest --pyargs watertap
+
+  upload-pypi:
+    needs: [install-test-pypi]
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+    environment: release
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - name: Upload dist files to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+
+  env-snapshot:
+    name: Create and collect env snapshot
+    needs: [upload-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      ENV_NAME: watertap-${{ github.ref_name }}
+      OUTPUT_DIR: watertap-${{ github.ref_name }}
+
+    steps:
+      - name: Set up Conda environment with Python
+        uses: conda-incubator/setup-miniconda@v4
+        with:
+          miniforge-version: latest
+          activate-environment: ${{ env.ENV_NAME }}
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install watertap==${{ github.ref_name }}[all] from PyPI
+        run: |
+          pip install "watertap[all]==${{ github.ref_name }}"
+
+      - name: Create output directory
+        run: mkdir "$OUTPUT_DIR"
+
+      - name: Save environment info (requirements.txt)
+        working-directory: ${{ env.OUTPUT_DIR }}
+        run: |
+          pip freeze > requirements.txt
+          cat requirements.txt
+
+      - name: Save environment info (environment.yml)
+        working-directory: ${{ env.OUTPUT_DIR }}
+        run: |
+          conda env export \
+            -n "$ENV_NAME" \
+            --no-builds \
+            -f environment.yml
+          cat environment.yml
+
+      - name: Save as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ENV_NAME }}
+          path: ${{ env.OUTPUT_DIR }}/
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            ${{ env.OUTPUT_DIR }}/requirements.txt
+            ${{ env.OUTPUT_DIR }}/environment.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,45 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install build helpers
+        run: |
+          pip install build wheel packaging
+
+      - name: Set version from tag in pyproject.toml
+        run: |
+          python - <<'PY'
+          import os, re, pathlib
+          from packaging.version import Version, InvalidVersion
+
+          raw_tag = os.environ["GITHUB_REF_NAME"]  # must be like 1.7.0, 1.8.0.dev1, 1.7.0rc1
+
+          if raw_tag.startswith("v"):
+              raise SystemExit(f"Tag '{raw_tag}' is invalid: tags must not start with 'v'")
+
+          try:
+              normalized = str(Version(raw_tag))
+          except InvalidVersion as e:
+              raise SystemExit(f"Tag '{raw_tag}' is not a valid PEP 440 version: {e}")
+
+          p = pathlib.Path("pyproject.toml")
+          txt = p.read_text()
+
+          new, n = re.subn(
+              r'(?m)^version\s*=\s*"[^"]+"',
+              f'version = "{normalized}"',
+              txt,
+              count=1,
+          )
+          if n != 1:
+              raise SystemExit("Could not find exactly one top-level version = \"...\" entry")
+
+          p.write_text(new)
+          print(f"Set pyproject.toml version to {normalized}")
+          PY
+
+      - name: Verify pyproject version
+        run: grep -n '^version = ' pyproject.toml
+
       - name: Generate dist files
         run: |
           pip install build wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dev = [
     "watertap[testing,notebooks,oli_api,reaktoro]",
 ]
 
-all = ["watertap[testing,notebooks,oli_api,reaktoro]"]
+all = ["watertap[testing,notebooks,oli_api,reaktoro,exposan]"]
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
## Fixes/Resolves:

#1775 

## Summary/Motivation:
Set up automated release on tag creation. Since dynamic verisoning is not yet set up, pyproject will need to be updated before creating a tag (matching version = "x"). 

## Changes proposed in this PR:
- create publish.yml
- a new optional dependency was added in #1635: added the `exposan` option to the `[all]` set

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
