### PR TITLE
Update SWRO flowsheet costing

### DIFF
--- a/docs/technical_reference/flowsheets/seawater_RO_desalination.rst
+++ b/docs/technical_reference/flowsheets/seawater_RO_desalination.rst
@@ -17,8 +17,6 @@ Implementation
 This flowsheet uses several different modeling features available in WaterTAP, including:
 
 Costing packages:
-    * :doc:`/technical_reference/costing/watertap_costing`
-    * :doc:`/technical_reference/costing/detailed_unit_model_costing`
     * :doc:`/technical_reference/costing/zero_order_costing`
 Property models:
     * :doc:`/technical_reference/core/water_props`
@@ -72,14 +70,12 @@ some helper functions that group these core functions together for convenience. 
         #. translator block from ``desalination`` to ``posttreatment`` (i.e., ``m.fs.tb_desal_psttrt``)
         #. ``posttreatment`` block
 
-4. Add the system- and unit-level costing packages with ``add_costing()`` and initialize with ``initialize_costing()``:
+4. Add the system- and unit-level costing package with ``add_costing()`` and initialize with ``m.fs.costing.initialize()``:
 
-    Because of the nature of the unit models used in this flowsheet (i.e., both zero order and detailed models), two separate system-level costing packages are required. 
-    ``m.fs.zo_costing = ZeroOrderCosting()`` is used to aggregate costs for zero-order models, and ``m.fs.ro_costing = WaterTAPCosting`` is for the more detailed desalination models. 
+    Because of the nature of the unit models used in this flowsheet (i.e., both zero order and detailed models), ``m.fs.costing = ZeroOrderCosting()`` is used to aggregate costs for both zero-order and detailed models.
     The costing block for each unit model is ``UnitModelCostingBlock`` that points to a system-level aggregation costing package via the configuration keyword ``flowsheet_costing_block``.
-    Each system-level costing package has a ``.cost_process()`` method that is called to aggregate unit level costs and calculate overall process costs.
-    To aggregate results from both costing packages, a separate ``Expression`` is created for ``total_capital_cost`` and ``total_operating_cost``, and each of these are used
-    to calculate the ``LCOW``. Finally, like the unit models, the costing packages are initialized.
+    The system-level costing package has a ``cost_process()`` method that is called to aggregate unit level costs and calculate overall process costs.
+    After ``cost_process()`` is called, the ``LCOW`` and ``specific_energy_consumption`` can be calculated. Finally, like the unit models, the costing package is initialized.
 
 5. Solve the entire flowsheet and display final results with ``display_results()``:
 

--- a/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
@@ -66,7 +66,6 @@ from watertap.unit_models.zero_order import (
     LandfillZO,
 )
 from watertap.costing.zero_order_costing import ZeroOrderCosting
-from watertap.costing import WaterTAPCosting
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)

--- a/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
@@ -85,7 +85,7 @@ def main(erd_type="pressure_exchanger", RO_1D=False):
     display_results(m)
 
     add_costing(m)
-    initialize_costing(m)
+    m.fs.costing.initialize()
     assert_degrees_of_freedom(m, 0)
 
     solve(m, tee=True, checkpoint=f" solve {erd_type} flowsheet with costing")
@@ -597,200 +597,138 @@ def add_costing(m):
     desal = m.fs.desalination
     psttrt = m.fs.posttreatment
 
-    # Add costing package for zero-order units
-    m.fs.zo_costing = ZeroOrderCosting()
-    m.fs.ro_costing = WaterTAPCosting()
-
+    # Add costing package
+    m.fs.costing = ZeroOrderCosting()
+    m.fs.costing.base_currency = pyunits.USD_2023
     # Add costing to zero order units
     # Pre-treatment units
     # This really looks like it should be a feed block in its own right
-    # prtrt.intake.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.zo_costing)
+    # prtrt.intake.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
 
     prtrt.ferric_chloride_addition.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     prtrt.chlorination.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     prtrt.static_mixer.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     prtrt.storage_tank_1.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     prtrt.media_filtration.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     prtrt.backwash_handling.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     prtrt.anti_scalant_addition.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     prtrt.cartridge_filtration.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
 
     # RO Train
     # RO equipment is costed using more detailed costing package
     desal.P1.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.ro_costing,
-        costing_method_arguments={"cost_electricity_flow": False},
+        flowsheet_costing_block=m.fs.costing,
+        costing_method_arguments={"cost_electricity_flow": True},
     )
-    desal.RO.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.ro_costing)
+    desal.RO.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
     if m.erd_type == "pressure_exchanger":
-        # desal.S1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.ro_costing)
+        # desal.S1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         desal.M1.costing = UnitModelCostingBlock(
-            flowsheet_costing_block=m.fs.ro_costing
+            flowsheet_costing_block=m.fs.costing
         )
         desal.PXR.costing = UnitModelCostingBlock(
-            flowsheet_costing_block=m.fs.ro_costing
+            flowsheet_costing_block=m.fs.costing
         )
         desal.P2.costing = UnitModelCostingBlock(
-            flowsheet_costing_block=m.fs.ro_costing,
-            costing_method_arguments={"cost_electricity_flow": False},
+            flowsheet_costing_block=m.fs.costing,
+            costing_method_arguments={"cost_electricity_flow": True},
         )
     elif m.erd_type == "pump_as_turbine":
         pass
-        # desal.ERD.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.ro_costing)
+        # desal.ERD.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
     else:
         raise ConfigurationError(
             f"erd_type was {m.erd_type}, costing only implemented "
             "for pressure_exchanger or pump_as_turbine"
         )
 
-    # For non-zero order unit operations, we need to register costed flows
-    # separately.
-    # However, to keep costs consistent, we will register these with the ZO
-    # Costing package
-    m.fs.zo_costing.cost_flow(desal.P1.work_mechanical[0], "electricity")
-    if m.erd_type == "pressure_exchanger":
-        m.fs.zo_costing.cost_flow(desal.P2.work_mechanical[0], "electricity")
-    elif m.erd_type == "pump_as_turbine":
-        pass
-        # m.fs.zo_costing.cost_flow(
-        #     desal.ERD.work_mechanical[0], "electricity")
-    else:
-        raise ConfigurationError(
-            f"erd_type was {m.erd_type}, costing only implemented "
-            "for pressure_exchanger or pump_as_turbine"
-        )
+    # # For non-zero order unit operations, we need to register costed flows
+    # # separately.
+    # # We will register electricity flow for detailed models with the ZO
+    # # Costing package
+    # m.fs.costing.cost_flow(desal.P1.work_mechanical[0], "electricity")
+    # if m.erd_type == "pressure_exchanger":
+    #     m.fs.costing.cost_flow(desal.P2.work_mechanical[0], "electricity")
+    # elif m.erd_type == "pump_as_turbine":
+    #     pass
+    #     # m.fs.costing.cost_flow(
+    #     #     desal.ERD.work_mechanical[0], "electricity")
+    # else:
+    #     raise ConfigurationError(
+    #         f"erd_type was {m.erd_type}, costing only implemented "
+    #         "for pressure_exchanger or pump_as_turbine"
+    #     )
 
     # Post-treatment units
     psttrt.storage_tank_2.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     psttrt.uv_aop.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     psttrt.co2_addition.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     psttrt.lime_addition.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     psttrt.storage_tank_3.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
 
     # Product and disposal
     m.fs.municipal.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
     m.fs.landfill.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.zo_costing
+        flowsheet_costing_block=m.fs.costing
     )
 
     # Aggregate unit level costs and calculate overall process costs
-    m.fs.zo_costing.cost_process()
-    m.fs.ro_costing.cost_process()
-
-    # Combine results from costing packages and calculate overall metrics
-    @m.Expression()
-    def total_capital_cost(b):
-        return (
-            pyunits.convert(
-                m.fs.zo_costing.total_capital_cost, to_units=pyunits.USD_2018
-            )
-            + m.fs.ro_costing.total_capital_cost
-        )
-
-    @m.Expression()
-    def total_operating_cost(b):
-        return (
-            pyunits.convert(
-                m.fs.zo_costing.total_fixed_operating_cost,
-                to_units=pyunits.USD_2018 / pyunits.year,
-            )
-            + pyunits.convert(
-                m.fs.zo_costing.total_variable_operating_cost,
-                to_units=pyunits.USD_2018 / pyunits.year,
-            )
-            + m.fs.ro_costing.total_operating_cost
-        )
-
-    @m.Expression()
-    def LCOW(b):
-        return (
-            b.total_capital_cost * b.fs.zo_costing.capital_recovery_factor
-            + b.total_operating_cost
-        ) / (
-            pyunits.convert(
-                b.fs.municipal.properties[0].flow_vol,
-                to_units=pyunits.m**3 / pyunits.year,
-            )
-            * b.fs.zo_costing.utilization_factor
-        )
-
-    @m.Expression()
-    def SEC(b):
-        # Note: there is no electricity flow in ro_costing
-        return pyunits.convert(
-            b.fs.zo_costing.aggregate_flow_electricity
-            / b.fs.municipal.properties[0].flow_vol,
-            to_units=pyunits.kWh / pyunits.m**3,
-        )
-
+    m.fs.costing.cost_process()
+    m.fs.costing.add_LCOW(m.fs.municipal.properties[0].flow_vol)
+    m.fs.costing.add_specific_energy_consumption(m.fs.municipal.properties[0].flow_vol)
     assert_units_consistent(m)
 
-
-def initialize_costing(m):
-    m.fs.zo_costing.initialize()
-    m.fs.ro_costing.initialize()
-
-
 def display_costing(m):
-    # m.fs.zo_costing.display()
-    # m.fs.ro_costing.display()
-
-    m.total_capital_cost.display()
-    m.total_operating_cost.display()
-    m.LCOW.display()
-    m.SEC.display()
+    m.fs.costing.total_capital_cost.display()
+    m.fs.costing.total_operating_cost.display()
+    m.fs.costing.LCOW.display()
+    m.fs.costing.specific_energy_consumption.display()
 
     print("\nUnit Capital Costs\n")
-    for u in m.fs.zo_costing._registered_unit_costing:
+    for u in m.fs.costing._registered_unit_costing:
         print(
             u.name,
             " :   ",
-            value(pyunits.convert(u.capital_cost, to_units=pyunits.USD_2018)),
-        )
-    for u in m.fs.ro_costing._registered_unit_costing:
-        print(
-            u.name,
-            " :   ",
-            value(pyunits.convert(u.capital_cost, to_units=pyunits.USD_2018)),
+            value(pyunits.convert(u.capital_cost, to_units=m.fs.costing.base_currency)),
         )
 
     print("\nUtility Costs\n")
-    for f in m.fs.zo_costing.used_flows:
+    for f in m.fs.costing.used_flows:
         print(
             f,
             " :   ",
             value(
                 pyunits.convert(
-                    m.fs.zo_costing.aggregate_flow_costs[f],
-                    to_units=pyunits.USD_2018 / pyunits.year,
+                    m.fs.costing.aggregate_flow_costs[f],
+                    to_units=m.fs.costing.base_currency / m.fs.costing.base_period,
                 )
             ),
         )

--- a/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
@@ -639,12 +639,8 @@ def add_costing(m):
     desal.RO.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
     if m.erd_type == "pressure_exchanger":
         # desal.S1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
-        desal.M1.costing = UnitModelCostingBlock(
-            flowsheet_costing_block=m.fs.costing
-        )
-        desal.PXR.costing = UnitModelCostingBlock(
-            flowsheet_costing_block=m.fs.costing
-        )
+        desal.M1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
+        desal.PXR.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         desal.P2.costing = UnitModelCostingBlock(
             flowsheet_costing_block=m.fs.costing,
             costing_method_arguments={"cost_electricity_flow": True},
@@ -679,9 +675,7 @@ def add_costing(m):
     psttrt.storage_tank_2.costing = UnitModelCostingBlock(
         flowsheet_costing_block=m.fs.costing
     )
-    psttrt.uv_aop.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.costing
-    )
+    psttrt.uv_aop.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
     psttrt.co2_addition.costing = UnitModelCostingBlock(
         flowsheet_costing_block=m.fs.costing
     )
@@ -693,18 +687,15 @@ def add_costing(m):
     )
 
     # Product and disposal
-    m.fs.municipal.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.costing
-    )
-    m.fs.landfill.costing = UnitModelCostingBlock(
-        flowsheet_costing_block=m.fs.costing
-    )
+    m.fs.municipal.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
+    m.fs.landfill.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
 
     # Aggregate unit level costs and calculate overall process costs
     m.fs.costing.cost_process()
     m.fs.costing.add_LCOW(m.fs.municipal.properties[0].flow_vol)
     m.fs.costing.add_specific_energy_consumption(m.fs.municipal.properties[0].flow_vol)
     assert_units_consistent(m)
+
 
 def display_costing(m):
     m.fs.costing.total_capital_cost.display()

--- a/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
+++ b/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination.py
@@ -637,6 +637,7 @@ def add_costing(m):
     )
     desal.RO.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
     if m.erd_type == "pressure_exchanger":
+        # NOTE: Costing for the S1 splitter is neglected. Keeping the commented line below for awareness.
         # desal.S1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         desal.M1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         desal.PXR.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
@@ -646,29 +647,15 @@ def add_costing(m):
         )
     elif m.erd_type == "pump_as_turbine":
         pass
+        # NOTE: Costing for the ERD is neglected. Keeping the commented line below for awareness.
+        # This change was applied here: https://github.com/watertap-org/watertap/commit/7180306a61755e6bc640f6b18f03a572f6de3850
+        # TODO: There is a need to verify if the costing for the ERD should be reincorporated with the line below, or if it is somehow accounted for already and uncommenting the line below would lead to double counting.
         # desal.ERD.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
     else:
         raise ConfigurationError(
             f"erd_type was {m.erd_type}, costing only implemented "
             "for pressure_exchanger or pump_as_turbine"
         )
-
-    # # For non-zero order unit operations, we need to register costed flows
-    # # separately.
-    # # We will register electricity flow for detailed models with the ZO
-    # # Costing package
-    # m.fs.costing.cost_flow(desal.P1.work_mechanical[0], "electricity")
-    # if m.erd_type == "pressure_exchanger":
-    #     m.fs.costing.cost_flow(desal.P2.work_mechanical[0], "electricity")
-    # elif m.erd_type == "pump_as_turbine":
-    #     pass
-    #     # m.fs.costing.cost_flow(
-    #     #     desal.ERD.work_mechanical[0], "electricity")
-    # else:
-    #     raise ConfigurationError(
-    #         f"erd_type was {m.erd_type}, costing only implemented "
-    #         "for pressure_exchanger or pump_as_turbine"
-    #     )
 
     # Post-treatment units
     psttrt.storage_tank_2.costing = UnitModelCostingBlock(
@@ -725,4 +712,4 @@ def display_costing(m):
 
 
 if __name__ == "__main__":
-    m = main(erd_type="pressure_exchanger", RO_1D=False)
+    m = main(erd_type="pump_as_turbine", RO_1D=False)

--- a/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination_ui.py
+++ b/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination_ui.py
@@ -16,7 +16,6 @@ from watertap.flowsheets.seawater_RO_desalination.seawater_RO_desalination impor
     initialize_system,
     solve,
     add_costing,
-    initialize_costing,
 )
 from pyomo.environ import units as pyunits
 
@@ -487,19 +486,15 @@ def export_variables(flowsheet=None, exports=None, build_options=None, **kwargs)
     )
 
     # System costing
-    # TODO: Should we expose costing parameters? The separate ZO and RO costing complicates this
-    # If so,consider only exposing one input, but fixing the other behind the scenes as well
-    # Also note that the costing packages assume different parameter values (elec_cost, utilization factor, etc.)
-
     # --- Output data ---
     # Municipal
     exports.add(
         obj=fs.municipal.properties[0].flow_vol,
-        name="Municipal water volume flow",
+        name="Municipal water (product) volume flow",
         ui_units=pyunits.m**3 / pyunits.day,
         display_units="m3/day",
         rounding=2,
-        description="Municipal water volumetric flowrate",
+        description="Municipal water (product) volumetric flowrate",
         is_input=False,
         is_output=True,
         output_category="Outlets",
@@ -510,7 +505,7 @@ def export_variables(flowsheet=None, exports=None, build_options=None, **kwargs)
         ui_units=pyunits.kg / pyunits.s,
         display_units="kg/s",
         rounding=2,
-        description="Municipal water mass flow",
+        description="Municipal water (product) mass flow",
         is_input=False,
         is_output=True,
         output_category="Outlets",
@@ -651,76 +646,47 @@ def export_variables(flowsheet=None, exports=None, build_options=None, **kwargs)
     )
 
     # System metrics
-    total_capital_cost = (
-        pyunits.convert(fs.zo_costing.total_capital_cost, to_units=pyunits.USD_2018)
-        + fs.ro_costing.total_capital_cost
-    )
-    exports.add(
-        obj=total_capital_cost,
-        name="Total capital cost",
-        ui_units=pyunits.USD_2018,
-        display_units="USD_2018",
-        rounding=3,
-        description="Total capital cost in USD_2018",
-        is_input=False,
-        is_output=True,
-        output_category="System metrics",
-    )
-    total_operating_cost = (
-        pyunits.convert(
-            fs.zo_costing.total_fixed_operating_cost,
-            to_units=pyunits.USD_2018 / pyunits.year,
-        )
-        + pyunits.convert(
-            fs.zo_costing.total_variable_operating_cost,
-            to_units=pyunits.USD_2018 / pyunits.year,
-        )
-        + fs.ro_costing.total_operating_cost
-    )
-    exports.add(
-        obj=total_operating_cost,
-        name="Total operating cost",
-        ui_units=pyunits.USD_2018 / pyunits.yr,
-        display_units="USD_2018/yr",
-        rounding=3,
-        description="Total operating cost in USD_2018 per year",
-        is_input=False,
-        is_output=True,
-        output_category="System metrics",
-    )
-    lcow = (
-        total_capital_cost * fs.zo_costing.capital_recovery_factor
-        + total_operating_cost
-    ) / (
-        pyunits.convert(
-            fs.municipal.properties[0].flow_vol,
-            to_units=pyunits.m**3 / pyunits.year,
-        )
-        * fs.zo_costing.utilization_factor
-    )
+    base_currency_str = str(fs.costing.base_currency)
+    base_period_str = "year" if fs.costing.base_period == pyunits.year else str(fs.costing.base_period)
 
     exports.add(
-        obj=lcow,
+        obj=fs.costing.total_capital_cost,
+        name="Total capital cost",
+        ui_units=fs.costing.base_currency,
+        display_units=base_currency_str,
+        rounding=3,
+        description=f"Total capital cost in {base_currency_str}",
+        is_input=False,
+        is_output=True,
+        output_category="System metrics",
+    )
+    exports.add(
+        obj=fs.costing.total_operating_cost,
+        name="Total operating cost",
+        ui_units=fs.costing.base_currency / fs.costing.base_period,
+        display_units=base_currency_str + "/" + base_period_str,
+        rounding=3,
+        description=f"Total operating cost in {base_currency_str} per {base_period_str}",
+        is_input=False,
+        is_output=True,
+        output_category="System metrics",
+    )
+    exports.add(
+        obj=fs.costing.LCOW,
         name="Levelized cost of water",
-        ui_units=pyunits.USD_2018 / pyunits.m**3,
-        display_units="$/m3 of product water",
+        ui_units=fs.costing.base_currency / pyunits.m**3,
+        display_units=f"${base_currency_str}/m3 of product water",
         rounding=3,
         description="Levelized cost of water (LCOW)",
         is_input=False,
         is_output=True,
         output_category="System metrics",
     )
-
-    sec = pyunits.convert(
-        fs.zo_costing.aggregate_flow_electricity / fs.municipal.properties[0].flow_vol,
-        to_units=pyunits.kWh / pyunits.m**3,
-    )
-
     exports.add(
-        obj=sec,
+        obj=fs.costing.specific_energy_consumption,
         name="Specific energy consumption",
         ui_units=pyunits.kWh / pyunits.m**3,
-        display_units="kWh/yr of product water",
+        display_units="kWh/m3 of product water",
         rounding=3,
         description="Specific energy consumption (SEC)",
         is_input=False,
@@ -744,7 +710,7 @@ def build_flowsheet(build_options=None, **kwargs):
     solve(m)
 
     add_costing(m)
-    initialize_costing(m)
+    m.fs.costing.initialize()
     # Solve flowsheet with costing
     solve(m)
 

--- a/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination_ui.py
+++ b/watertap/flowsheets/seawater_RO_desalination/seawater_RO_desalination_ui.py
@@ -647,7 +647,11 @@ def export_variables(flowsheet=None, exports=None, build_options=None, **kwargs)
 
     # System metrics
     base_currency_str = str(fs.costing.base_currency)
-    base_period_str = "year" if fs.costing.base_period == pyunits.year else str(fs.costing.base_period)
+    base_period_str = (
+        "year"
+        if fs.costing.base_period == pyunits.year
+        else str(fs.costing.base_period)
+    )
 
     exports.add(
         obj=fs.costing.total_capital_cost,

--- a/watertap/flowsheets/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
+++ b/watertap/flowsheets/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
@@ -179,7 +179,7 @@ def test_seawater_RO_desalination_pump_as_turbine():
     assert pytest.approx(2.9557e-2, rel=1e-4) == value(
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
-    
+
     assert m.fs.costing.base_currency == pyunits.USD_2023
     assert value(m.fs.costing.LCOW) == pytest.approx(1.3638, rel=1e-3)
 

--- a/watertap/flowsheets/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
+++ b/watertap/flowsheets/seawater_RO_desalination/tests/test_seawater_RO_desalination.py
@@ -11,7 +11,7 @@
 #################################################################################
 
 import pytest
-from pyomo.environ import value
+from pyomo.environ import value, units as pyunits
 from watertap.flowsheets.seawater_RO_desalination.seawater_RO_desalination import (
     main,
 )
@@ -97,7 +97,8 @@ def test_seawater_RO_desalination_pressure_exchanger():
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
 
-    assert value(m.LCOW) == pytest.approx(0.829189, rel=1e-5)
+    assert m.fs.costing.base_currency == pyunits.USD_2023
+    assert value(m.fs.costing.LCOW) == pytest.approx(1.042, rel=1e-3)
 
 
 @pytest.mark.component
@@ -178,8 +179,9 @@ def test_seawater_RO_desalination_pump_as_turbine():
     assert pytest.approx(2.9557e-2, rel=1e-4) == value(
         muni.outlet.flow_mass_comp[0.0, "tds"]
     )
-
-    assert value(m.LCOW) == pytest.approx(1.09970, rel=1e-5)
+    
+    assert m.fs.costing.base_currency == pyunits.USD_2023
+    assert value(m.fs.costing.LCOW) == pytest.approx(1.3638, rel=1e-3)
 
     @pytest.mark.component
     def test_main_0D(self):


### PR DESCRIPTION
## Fixes/Resolves:

## Summary/Motivation:
A bug was identified for costing of the seawater RO flowsheet. Because two cost packages are used in the flowsheet, at least one shared parameter (each costing package has its own parameter)--i.e., wacc factor-- had a different values used. For example, the ZO costing package used a value of 5% for WACC, while the watertap costing package used a value near 10%. 

This PR eliminates usage of two costing packages and associated complexities (e.g., add custom constraints to remedy usage of more than one costing package) of doing so.

## Changes proposed in this PR:
- reduce down to usage of the ZO costing package, which is compatible with ZO and detailed models
- set base currency to latest available in IDAES now, which is USD_2023

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
