### PR TITLE
Update `set_base_currency_base_period` method on costing package

### DIFF
--- a/watertap/costing/tests/test_costing_base.py
+++ b/watertap/costing/tests/test_costing_base.py
@@ -144,6 +144,7 @@ def test_set_base_currency_base_period():
     m.fs = idc.FlowsheetBlock(dynamic=False)
 
     m.fs.costing = WaterTAPCosting()
+    m.fs.costing.cost_process()
 
     assert pyo.units.get_units(
         m.fs.costing.electricity_cost._units
@@ -154,6 +155,12 @@ def test_set_base_currency_base_period():
     assert pyo.units.get_units(
         m.fs.costing.plant_lifetime._units
     ) == pyo.units.get_units(pyo.units.year)
+    assert pyo.units.get_units(
+        m.fs.costing.total_capital_cost._units
+    ) == pyo.units.get_units(pyo.units.USD_2018)
+    assert pyo.units.get_units(
+        m.fs.costing.total_operating_cost._units
+    ) == pyo.units.get_units(pyo.units.USD_2018 / pyo.units.year)
 
     m.fs.costing.set_base_currency_base_period(
         base_currency_year=2023, base_period="month"
@@ -168,6 +175,12 @@ def test_set_base_currency_base_period():
     assert pyo.units.get_units(
         m.fs.costing.plant_lifetime._units
     ) == pyo.units.get_units(pyo.units.month)
+    assert pyo.units.get_units(
+        m.fs.costing.total_capital_cost._units
+    ) == pyo.units.get_units(pyo.units.USD_2023)
+    assert pyo.units.get_units(
+        m.fs.costing.total_operating_cost._units
+    ) == pyo.units.get_units(pyo.units.USD_2023 / pyo.units.month)
 
 
 @pytest.mark.component

--- a/watertap/costing/tests/test_costing_base.py
+++ b/watertap/costing/tests/test_costing_base.py
@@ -139,6 +139,38 @@ def test_watertap_costing_package():
 
 
 @pytest.mark.component
+def test_set_base_currency_base_period():
+    m = pyo.ConcreteModel()
+    m.fs = idc.FlowsheetBlock(dynamic=False)
+
+    m.fs.costing = WaterTAPCosting()
+
+    assert pyo.units.get_units(
+        m.fs.costing.electricity_cost._units
+    ) == pyo.units.get_units(pyo.units.USD_2018 / pyo.units.kWh)
+    assert pyo.units.get_units(
+        m.fs.costing.defined_flows["electricity"]._units
+    ) == pyo.units.get_units(pyo.units.USD_2018 / pyo.units.kWh)
+    assert pyo.units.get_units(
+        m.fs.costing.plant_lifetime._units
+    ) == pyo.units.get_units(pyo.units.year)
+
+    m.fs.costing.set_base_currency_base_period(
+        base_currency_year=2023, base_period="month"
+    )
+
+    assert pyo.units.get_units(
+        m.fs.costing.electricity_cost._units
+    ) == pyo.units.get_units(pyo.units.USD_2023 / pyo.units.kWh)
+    assert pyo.units.get_units(
+        m.fs.costing.defined_flows["electricity"]._units
+    ) == pyo.units.get_units(pyo.units.USD_2023 / pyo.units.kWh)
+    assert pyo.units.get_units(
+        m.fs.costing.plant_lifetime._units
+    ) == pyo.units.get_units(pyo.units.month)
+
+
+@pytest.mark.component
 def test_breakdowns():
     m = lsrro.build()
 

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -58,13 +58,19 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         # Set a base period for all operating costs
         self.base_period = getattr(pyo.units, base_period)
 
-        # These are declared after setting the base currency and base period
-        # in build_global_params
+        # These are declared in build_global_params
         if self.find_component("electricity_cost") is not None:
             self.electricity_cost._units = self.base_currency / pyo.units.kWh
 
         if self.find_component("plant_lifetime") is not None:
             self.plant_lifetime._units = self.base_period
+
+        # These are declared in build_process_costs
+        if self.find_component("total_capital_cost") is not None:
+            self.total_capital_cost._units = self.base_currency
+
+        if self.find_component("total_operating_cost") is not None:
+            self.total_operating_cost._units = self.base_currency / self.base_period
 
     def add_LCOW(self, flow_rate, name="LCOW"):
         """

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -50,11 +50,21 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         # Register currency and conversion rates based on CE Index
         register_idaes_currency_units()
 
-    def set_base_currency_base_period(self):
+    def set_base_currency_base_period(
+        self, base_currency_year=2018, base_period="year"
+    ):
         # Set the base year for all costs
-        self.base_currency = pyo.units.USD_2018
+        self.base_currency = getattr(pyo.units, f"USD_{base_currency_year}")
         # Set a base period for all operating costs
-        self.base_period = pyo.units.year
+        self.base_period = getattr(pyo.units, base_period)
+
+        # These are declared after setting the base currency and base period
+        # in build_global_params
+        if self.find_component("electricity_cost") is not None:
+            self.electricity_cost._units = self.base_currency / pyo.units.kWh
+
+        if self.find_component("plant_lifetime") is not None:
+            self.plant_lifetime._units = self.base_period
 
     def add_LCOW(self, flow_rate, name="LCOW"):
         """


### PR DESCRIPTION
## Fixes/Resolves:

partially #1860 

## Summary/Motivation:

#1860 

## Changes proposed in this PR:
- extend `set_base_currency_ base_period` to change the units of other variables in the costing package to use newly declared `base_currency` and `base_period`
- test this functionality

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
