### PR TITLE
Declare `base_currency` and `base_period` in WaterTAPCosting config

### DIFF
--- a/docs/how_to_guides/how_to_add_watertap_costing_to_flowsheet.rst
+++ b/docs/how_to_guides/how_to_add_watertap_costing_to_flowsheet.rst
@@ -33,6 +33,12 @@ This is referred to as the "flowsheet costing block" (contrasted with a "unit mo
 
     m.fs.costing = WaterTAPCosting()
 
+By default, the WaterTAP costing package will aggregate all system costing variables to 2018 USD and use an annual time period for cost calculations.
+These can be modified by passing the ``base_currency`` and ``base_period`` arguments when creating the ``WaterTAPCosting`` instance. For example:
+
+.. code-block:: python
+
+    m.fs.costing = WaterTAPCosting(base_currency=2023, base_period="month")
 
 At this point, the flowsheet costing block only contains instructions to aggregate the costs from the individual unit model costing blocks into overall flowsheet-level costs and metrics.
 To get costing results, we need to add the unit model costing block.

--- a/docs/how_to_guides/how_to_add_watertap_costing_to_flowsheet.rst
+++ b/docs/how_to_guides/how_to_add_watertap_costing_to_flowsheet.rst
@@ -34,11 +34,11 @@ This is referred to as the "flowsheet costing block" (contrasted with a "unit mo
     m.fs.costing = WaterTAPCosting()
 
 By default, the WaterTAP costing package will aggregate all system costing variables to 2018 USD and use an annual time period for cost calculations.
-These can be modified by passing the ``base_currency`` and ``base_period`` arguments when creating the ``WaterTAPCosting`` instance. For example:
+These can be modified by passing the ``base_currency_year`` and ``base_period`` arguments when creating the ``WaterTAPCosting`` instance. For example:
 
 .. code-block:: python
 
-    m.fs.costing = WaterTAPCosting(base_currency=2023, base_period="month")
+    m.fs.costing = WaterTAPCosting(base_currency_year=2023, base_period="month")
 
 At this point, the flowsheet costing block only contains instructions to aggregate the costs from the individual unit model costing blocks into overall flowsheet-level costs and metrics.
 To get costing results, we need to add the unit model costing block.

--- a/docs/how_to_guides/how_to_use_watertap_costing.rst
+++ b/docs/how_to_guides/how_to_use_watertap_costing.rst
@@ -135,7 +135,7 @@ Additional details on the WaterTAP costing package, including equations and defa
         m = ConcreteModel()
         m.fs = FlowsheetBlock(dynamic=False)
         m.fs.properties = SeawaterParameterBlock()
-        m.fs.costing = WaterTAPCosting()
+        m.fs.costing = WaterTAPCosting(base_currency=2023)
 
         m.fs.feed = Feed(property_package=m.fs.properties)
         m.fs.pump1 = Pump(property_package=m.fs.properties)
@@ -337,7 +337,6 @@ Additional details on the WaterTAP costing package, including equations and defa
 
         # Change values of flowsheet-level costing variables if desired
         m.fs.costing.electricity_cost.fix(0.12)
-        m.fs.costing.base_currency = pyunits.USD_2023
 
         # Change values of unit model costing parameters if desired
         m.fs.costing.chem_addition.chemical_capex_slope.fix(2.34e4)
@@ -372,7 +371,8 @@ Adding costing to a WaterTAP model
 This section applies the steps outlined in the :ref:`how to add WaterTAP costing to a flowsheet guide<how_to_add_watertap_costing_to_flowsheet>` for all unit models on this flowsheet.
 
 Adding the WaterTAP costing package to a flowsheet can be done at any point in the flowsheet build prior to adding unit model costing blocks. 
-Below is a build function to create the flowsheet. The costing package is added after added the property package.
+Below is a build function to create the flowsheet. The costing package is added after added the property package. We pass 2023 for the ``base_currency`` argument
+to set the base currency for all system costing calculations. Any value between 1991 and 2023 can be used.
 
 
 .. code-block:: python
@@ -385,7 +385,8 @@ Below is a build function to create the flowsheet. The costing package is added 
         m.fs.properties = SeawaterParameterBlock()
 
         # Add the WaterTAP costing package to the flowsheet
-        m.fs.costing = WaterTAPCosting()
+        # and specify 2023 as the base currency
+        m.fs.costing = WaterTAPCosting(base_currency=2023)
 
         # Add unit models to flowsheet
         m.fs.feed = Feed(property_package=m.fs.properties)
@@ -519,8 +520,8 @@ The following snippet shows how to add costing to the unit models on our flowshe
             period=pyunits.hr,
         )
 
-At this point in the build, you can change values of flowsheet-level costing variables (``electricity_price`` in this example) and change the ``base_currency`` 
-or other costing variables/parameters. In the example below, we also add an ``Objective`` to minimize LCOW.
+At this point in the build, you can change values of flowsheet-level costing variables (``electricity_cost`` in this example). 
+In the example below, we also add an ``Objective`` to minimize LCOW.
 
 .. testcode::
 
@@ -529,7 +530,6 @@ or other costing variables/parameters. In the example below, we also add an ``Ob
 
     # Change values of flowsheet-level costing variables if desired
     m.fs.costing.electricity_cost.fix(0.12)
-    m.fs.costing.base_currency = pyunits.USD_2023
 
     # Change values of unit model costing parameters if desired
     m.fs.costing.chem_addition.chemical_capex_slope.fix(2.34e4)
@@ -575,7 +575,7 @@ Likewise, if the unit model has any fixed operating costs, they can be accessed 
     ro_fixed_operating_cost = value(m.fs.RO.costing.fixed_operating_cost)
     chem_addition_fixed_operating_cost = value(m.fs.chem_addition.costing.fixed_operating_cost)
 
-Importantly, the currency units for these values are only converted to the ``base_currency`` and ``base_period`` defined on the flowsheet costing block if the model developer 
+Importantly, the currency units for these values are only converted to the ``base_currency`` and ``base_period`` defined by the flowsheet costing block configuration if the model developer 
 did so in the costing method. For this reason, it is recommended to make this conversion when creating costing methods to ensure consistency in the reported values.
 If you are unsure, the units for costing variables (or any variable) can be accessed using ``pyunits.get_units(var)`` from the units package and printing the output.
 
@@ -604,8 +604,9 @@ If you are unsure, the units for costing variables (or any variable) can be acce
 System costing results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Costing results for all units with a costing block are aggregated to the system level and converted to be in the same currency year (as defined by ``base_currency``). Operating costs are likewise converted to 
-units of ``base_currency / base_period``. These results are found on the flowsheet costing block (``m.fs.costing``) and for this example includes the following:
+Costing results for all units with a costing block are aggregated to the system level and converted to be in the same currency year as defined by the ``base_currency`` configuration argument for the WaterTAP costing package. 
+Operating costs are likewise converted to units of ``base_currency / base_period``. 
+These results are found on the flowsheet costing block (``m.fs.costing``) and for this example includes the following:
 
 - Total capital cost: ``m.fs.costing.total_capital_cost``
 - Total operating cost: ``m.fs.costing.total_operating_cost``

--- a/docs/how_to_guides/how_to_use_watertap_costing.rst
+++ b/docs/how_to_guides/how_to_use_watertap_costing.rst
@@ -372,7 +372,7 @@ This section applies the steps outlined in the :ref:`how to add WaterTAP costing
 
 Adding the WaterTAP costing package to a flowsheet can be done at any point in the flowsheet build prior to adding unit model costing blocks. 
 Below is a build function to create the flowsheet. The costing package is added after added the property package. We pass 2023 for the ``base_currency_year`` argument
-to set the base currency for all system costing calculations. Any value between 1991 and 2023 can be used.
+to set the base currency for all system costing calculations. Any value between 1990 and 2023 can be used.
 
 
 .. code-block:: python
@@ -595,10 +595,10 @@ If you are unsure, the units for costing variables (or any variable) can be acce
 .. testoutput::
 
     Base currency: USD_2023
-    RO capital cost units: USD_2018
-    Chemical addition capital cost units: USD_2018
-    Pump capital cost units: USD_2018
-    ERD capital cost units: USD_2018
+    RO capital cost units: USD_2023
+    Chemical addition capital cost units: USD_2023
+    Pump capital cost units: USD_2023
+    ERD capital cost units: USD_2023
 
 
 System costing results

--- a/docs/how_to_guides/how_to_use_watertap_costing.rst
+++ b/docs/how_to_guides/how_to_use_watertap_costing.rst
@@ -135,7 +135,7 @@ Additional details on the WaterTAP costing package, including equations and defa
         m = ConcreteModel()
         m.fs = FlowsheetBlock(dynamic=False)
         m.fs.properties = SeawaterParameterBlock()
-        m.fs.costing = WaterTAPCosting(base_currency=2023)
+        m.fs.costing = WaterTAPCosting(base_currency_year=2023)
 
         m.fs.feed = Feed(property_package=m.fs.properties)
         m.fs.pump1 = Pump(property_package=m.fs.properties)
@@ -371,7 +371,7 @@ Adding costing to a WaterTAP model
 This section applies the steps outlined in the :ref:`how to add WaterTAP costing to a flowsheet guide<how_to_add_watertap_costing_to_flowsheet>` for all unit models on this flowsheet.
 
 Adding the WaterTAP costing package to a flowsheet can be done at any point in the flowsheet build prior to adding unit model costing blocks. 
-Below is a build function to create the flowsheet. The costing package is added after added the property package. We pass 2023 for the ``base_currency`` argument
+Below is a build function to create the flowsheet. The costing package is added after added the property package. We pass 2023 for the ``base_currency_year`` argument
 to set the base currency for all system costing calculations. Any value between 1991 and 2023 can be used.
 
 
@@ -386,7 +386,7 @@ to set the base currency for all system costing calculations. Any value between 
 
         # Add the WaterTAP costing package to the flowsheet
         # and specify 2023 as the base currency
-        m.fs.costing = WaterTAPCosting(base_currency=2023)
+        m.fs.costing = WaterTAPCosting(base_currency_year=2023)
 
         # Add unit models to flowsheet
         m.fs.feed = Feed(property_package=m.fs.properties)

--- a/docs/technical_reference/costing/costing_base.rst
+++ b/docs/technical_reference/costing/costing_base.rst
@@ -258,12 +258,12 @@ A to year B are adjusted according to:
 
 WaterTAP uses the `Chemical Engineering Plant Cost Index <https://www.toweringskills.com/financial-analysis/cost-indices/>`_ (CEPCI) 
 to account for the time-value of investments. Aggregated capital and operating costs are 
-adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency`` configuration argument for the WaterTAP costing package. 
-The default costing year is 2018, but users can specify a different year via the ``base_currency`` configuration argument for the WaterTAP costing package (e.g., ``m.fs.costing = WaterTAPCosting(base_currency=2022)``).
+adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency_year`` configuration argument for the WaterTAP costing package. 
+The default costing year is 2018, but users can specify a different year via the ``base_currency_year`` configuration argument for the WaterTAP costing package (e.g., ``m.fs.costing = WaterTAPCosting(base_currency_year=2022)``).
 
 .. important:: 
     Though users **could** directly set the ``base_currency`` on the flowsheet costing block, this is discouraged. 
-    It is recommended to use the ``base_currency`` configuration argument when instantiating the WaterTAP costing package to ensure consistency 
+    It is recommended to use the ``base_currency_year`` configuration argument when instantiating the WaterTAP costing package to ensure consistency 
     across all costing calculations and parameters. 
 
 .. _common_global_costing_parameters:

--- a/docs/technical_reference/costing/costing_base.rst
+++ b/docs/technical_reference/costing/costing_base.rst
@@ -258,9 +258,13 @@ A to year B are adjusted according to:
 
 WaterTAP uses the `Chemical Engineering Plant Cost Index <https://www.toweringskills.com/financial-analysis/cost-indices/>`_ (CEPCI) 
 to account for the time-value of investments. Aggregated capital and operating costs are 
-adjusted to the desired year for the model, accessible on the costing block as ``base_currency``. 
-The default costing year is 2018, but the user can directly set the ``base_currency`` at 
-the flowsheet level (e.g., ``m.fs.costing.base_currency = pyo.units.USD_2020``).
+adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency`` configuration argument for the WaterTAP costing package. 
+The default costing year is 2018, but users can specify a different year via the ``base_currency`` configuration argument for the WaterTAP costing package (e.g., ``m.fs.costing = WaterTAPCosting(base_currency=2022)``).
+
+.. important:: 
+    Though users **could** directly set the ``base_currency`` on the flowsheet costing block, this is discouraged. 
+    It is recommended to use the ``base_currency`` configuration argument when instantiating the WaterTAP costing package to ensure consistency 
+    across all costing calculations and parameters. 
 
 .. _common_global_costing_parameters:
 

--- a/docs/technical_reference/costing/costing_base.rst
+++ b/docs/technical_reference/costing/costing_base.rst
@@ -243,6 +243,7 @@ without changing the base costing package implementation.
         flowsheet_costing_block=m.fs.costing,
     )
 
+.. _costing_base_costing_index_and_tea_factors:
 
 Costing Index and Technoeconomic Factors
 ----------------------------------------
@@ -258,13 +259,10 @@ A to year B are adjusted according to:
 
 WaterTAP uses the `Chemical Engineering Plant Cost Index <https://www.toweringskills.com/financial-analysis/cost-indices/>`_ (CEPCI) 
 to account for the time-value of investments. Aggregated capital and operating costs are 
-adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency_year`` configuration argument for the WaterTAP costing package. 
-The default costing year is 2018, but users can specify a different year via the ``base_currency_year`` configuration argument for the WaterTAP costing package (e.g., ``m.fs.costing = WaterTAPCosting(base_currency_year=2022)``).
+adjusted to the desired year for the model, accessible on the costing block as ``base_currency``.
+See :ref:`zero order costing documentation <zero_order_costing_tea_factors>` or :ref:`WaterTAP costing documentation <watertap_costing_tea_factors>` for how to set the base currency for each costing package. 
 
-.. important:: 
-    Though users **could** directly set the ``base_currency`` on the flowsheet costing block, this is discouraged. 
-    It is recommended to use the ``base_currency_year`` configuration argument when instantiating the WaterTAP costing package to ensure consistency 
-    across all costing calculations and parameters. 
+The default costing year is 2018, but any year between 1990 and 2023 can be used.
 
 .. _common_global_costing_parameters:
 

--- a/docs/technical_reference/costing/watertap_costing.rst
+++ b/docs/technical_reference/costing/watertap_costing.rst
@@ -7,6 +7,7 @@ WaterTAP Costing Package
 
 The WaterTAP costing package contains the costing package with simplified technoeconomic data. It inherits all the functionality and parameters of the :ref:`WaterTAPCostingBlockData` base class :ref:`technical_reference/costing/costing_base:Common Global Costing Parameters`.
 
+.. _watertap_costing_tea_factors:
 
 Costing Index and Technoeconomic Factors
 ----------------------------------------
@@ -19,6 +20,22 @@ The following technoeconomic factors are specific to the WaterTAP Costing Packag
 Total investment factor                           :math:`f_{toti}`    ``total_investment_factor``              1.0             Total investment factor (investment cost / equipment cost)
 Maintenance-labor-chemical factor                 :math:`f_{mlc}`     ``maintenance_labor_chemical_factor``    0.03            Maintenance, labor, and chemical factor (fraction of equipment cost / year)
 =============================================  ====================  =======================================  ===============  ==============================================================================
+
+For the WaterTAP costing package, the base currency year and base period should be set using the ``base_currency_year`` and ``base_period`` configuration arguments when instantiating the costing package.
+
+
+.. code-block:: python
+
+    m.fs.costing = WaterTAPCosting(base_currency_year=2021, base_period="year")
+
+
+The default costing year is 2018, but any year between 1990 and 2023 can be used. Any unit of time can be used for the base period.
+
+
+.. important:: 
+    Though users **could** directly set the ``base_currency`` on the flowsheet costing block (e.g., ``m.fs.costing.base_currency = pyunits.USD_2023``), this is discouraged. 
+    It is recommended to use the ``base_currency_year`` configuration argument when instantiating the WaterTAP costing package to ensure consistency 
+    across all costing calculations and parameters. 
 
 Costing Calculations
 --------------------

--- a/docs/technical_reference/costing/zero_order_costing.rst
+++ b/docs/technical_reference/costing/zero_order_costing.rst
@@ -76,13 +76,13 @@ Costs from year A to year B are adjusted according to:
 
 WaterTAP uses the `Chemical Engineering Plant Cost Index <https://www.toweringskills.com/financial-analysis/cost-indices/>`_ (CEPCI) 
 to account for the time-value of investments. Aggregated capital and operating costs are 
-adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency`` entry in the case study yaml *or* the ``base_currency`` configuration argument for the zero order costing package. 
-The default costing year is 2018, but users can specify a different year via the ``base_currency`` configuration argument for the zero order costing package (e.g., ``m.fs.costing = ZeroOrderCosting(base_currency=2022)``)
+adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency`` entry in the case study yaml *or* the ``base_currency_year`` configuration argument for the zero order costing package. 
+The default costing year is 2018, but users can specify a different year via the ``base_currency_year`` configuration argument for the zero order costing package (e.g., ``m.fs.costing = ZeroOrderCosting(base_currency_year=2022)``)
 *if* the provided case study yaml file does not contain a ``base_currency`` entry.
 
 .. important:: 
     Though users **could** directly set the ``base_currency`` on the flowsheet costing block, this is discouraged. 
-    It is recommended to specify the base currency in the case study yaml or use the ``base_currency`` configuration argument when instantiating the zero order costing package to ensure consistency 
+    It is recommended to specify the base currency in the case study yaml or use the ``base_currency_year`` configuration argument when instantiating the zero order costing package to ensure consistency 
     across all costing calculations and parameters. 
 
 

--- a/docs/technical_reference/costing/zero_order_costing.rst
+++ b/docs/technical_reference/costing/zero_order_costing.rst
@@ -76,9 +76,15 @@ Costs from year A to year B are adjusted according to:
 
 WaterTAP uses the `Chemical Engineering Plant Cost Index <https://www.toweringskills.com/financial-analysis/cost-indices/>`_ (CEPCI) 
 to account for the time-value of investments. Aggregated capital and operating costs are 
-adjusted to the desired year for the model, accessible on the costing block as ``base_currency``. 
-The default costing year is 2018, but the user can directly set the ``base_currency`` at 
-the flowsheet level (e.g., ``m.fs.costing.base_currency = pyo.units.USD_2023``) or via a provided case study ``.yaml``.
+adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency`` entry in the case study yaml *or* the ``base_currency`` configuration argument for the zero order costing package. 
+The default costing year is 2018, but users can specify a different year via the ``base_currency`` configuration argument for the zero order costing package (e.g., ``m.fs.costing = ZeroOrderCosting(base_currency=2022)``)
+*if* the provided case study yaml file does not contain a ``base_currency`` entry.
+
+.. important:: 
+    Though users **could** directly set the ``base_currency`` on the flowsheet costing block, this is discouraged. 
+    It is recommended to specify the base currency in the case study yaml or use the ``base_currency`` configuration argument when instantiating the zero order costing package to ensure consistency 
+    across all costing calculations and parameters. 
+
 
 Other technoeconomic factors used to calculate various system metrics, capital, and operating costs are presented in the table below:
 

--- a/docs/technical_reference/costing/zero_order_costing.rst
+++ b/docs/technical_reference/costing/zero_order_costing.rst
@@ -14,7 +14,7 @@ parameter values.
 Usage
 -----
 
-The ZeroOrderCosting class contains all the variables and constraints needed to cost a unit model derived from the :ref:`ZeroOrderBaseData`. It also inherits the functionality of the :ref:`WaterTAPCostingBlockData`.
+The ZeroOrderCosting class inherits the functionality of the :ref:`WaterTAPCostingBlockData` and contains all the variables and constraints needed to cost a unit model derived from the :ref:`ZeroOrderBaseData`.
 
 The code below shows an outline of how the ZeroOrderCostingData class is intended to be used to cost zero-order type models.
 
@@ -64,6 +64,8 @@ Total annualized cost                           :math:`C_{annual}`    ``total_an
 
 Calculations for each of these costs are presented below.
 
+.. _zero_order_costing_tea_factors:
+
 Costing Index and Technoeconomic Factors
 ----------------------------------------
 
@@ -76,13 +78,15 @@ Costs from year A to year B are adjusted according to:
 
 WaterTAP uses the `Chemical Engineering Plant Cost Index <https://www.toweringskills.com/financial-analysis/cost-indices/>`_ (CEPCI) 
 to account for the time-value of investments. Aggregated capital and operating costs are 
-adjusted to the desired year for the model, accessible on the costing block as ``base_currency`` and defined by the ``base_currency`` entry in the case study yaml *or* the ``base_currency_year`` configuration argument for the zero order costing package. 
-The default costing year is 2018, but users can specify a different year via the ``base_currency_year`` configuration argument for the zero order costing package (e.g., ``m.fs.costing = ZeroOrderCosting(base_currency_year=2022)``)
-*if* the provided case study yaml file does not contain a ``base_currency`` entry.
+adjusted to the desired year for the model, accessible on the costing block as ``base_currency``.
+For the zero order costing package, this is set preferentially by a ``base_currency`` entry in 
+the case study yaml file. If the case study yaml file does not contain a ``base_currency`` entry, 
+it is defined via the ``base_currency_year`` configuration argument  (e.g., ``m.fs.costing = ZeroOrderCosting(base_currency_year=2022)``).
+In either case, the default costing year is 2018, but users can specify a different year between 1990 and 2023.
 
 .. important:: 
-    Though users **could** directly set the ``base_currency`` on the flowsheet costing block, this is discouraged. 
-    It is recommended to specify the base currency in the case study yaml or use the ``base_currency_year`` configuration argument when instantiating the zero order costing package to ensure consistency 
+    Though users **could** directly set the ``base_currency`` on the flowsheet costing block (e.g., ``m.fs.costing.base_currency = pyunits.USD_2023``), this is discouraged. 
+    It is recommended to specify the base currency via the case study yaml or the ``base_currency_year`` configuration argument when instantiating the zero order costing package to ensure consistency 
     across all costing calculations and parameters. 
 
 

--- a/tutorials/BSM2.ipynb
+++ b/tutorials/BSM2.ipynb
@@ -661,15 +661,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "a6c1fadc-243d-4307-9707-4a8ede50e4cb",
    "metadata": {},
    "outputs": [],
    "source": [
     "def add_costing(m):\n",
     "    # Base class for creating WaterTAP costing packages\n",
-    "    m.fs.costing = WaterTAPCosting()\n",
-    "    m.fs.costing.base_currency = pyo.units.USD_2020\n",
+    "    m.fs.costing = WaterTAPCosting(base_currency_year=2020)\n",
     "\n",
     "    # Unit model costing blocks\n",
     "    m.fs.R1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)\n",

--- a/tutorials/modeling_multicomponent_rejection.ipynb
+++ b/tutorials/modeling_multicomponent_rejection.ipynb
@@ -879,7 +879,6 @@
     "m.fs.costing.disposal_cost.fix()\n",
     "m.fs.costing.register_flow_type(\"disposal\", m.fs.costing.disposal_cost)\n",
     "m.fs.costing.cost_flow(m.fs.disposal.properties[0].flow_vol_phase[\"Liq\"], \"disposal\")\n",
-    "m.fs.costing.base_currency = pyunits.USD_2018\n",
     "m.fs.costing.cost_process()\n",
     "\n",
     "m.fs.costing.add_annual_water_production(m.fs.product.properties[0].flow_vol)\n",

--- a/watertap/costing/tests/test_costing_base.py
+++ b/watertap/costing/tests/test_costing_base.py
@@ -29,7 +29,7 @@ def test_watertap_costing_config():
     m.fs.costing = WaterTAPCosting()
     m.fs.costing.cost_process()
 
-    assert m.fs.costing.config.base_currency == 2018
+    assert m.fs.costing.config.base_currency_year == 2018
     assert m.fs.costing.base_currency == pyo.units.USD_2018
     assert m.fs.costing.config.base_period == "year"
     assert m.fs.costing.base_period == pyo.units.year
@@ -40,7 +40,7 @@ def test_watertap_costing_config():
     ):
         m = pyo.ConcreteModel()
         m.fs = idc.FlowsheetBlock(dynamic=False)
-        m.fs.costing = WaterTAPCosting(base_currency=1901)
+        m.fs.costing = WaterTAPCosting(base_currency_year=1901)
 
     with pytest.raises(
         ConfigurationError,
@@ -62,10 +62,10 @@ def test_watertap_costing_config():
 
     m = pyo.ConcreteModel()
     m.fs = idc.FlowsheetBlock(dynamic=False)
-    m.fs.costing = WaterTAPCosting(base_currency=2009, base_period="month")
+    m.fs.costing = WaterTAPCosting(base_currency_year=2009, base_period="month")
     m.fs.costing.cost_process()
 
-    assert m.fs.costing.config.base_currency == 2009
+    assert m.fs.costing.config.base_currency_year == 2009
     assert m.fs.costing.base_currency == pyo.units.USD_2009
     assert m.fs.costing.config.base_period == "month"
     assert m.fs.costing.base_period == pyo.units.month

--- a/watertap/costing/tests/test_costing_base.py
+++ b/watertap/costing/tests/test_costing_base.py
@@ -15,9 +15,60 @@ import pytest
 from pyomo.util.check_units import assert_units_consistent
 import pyomo.environ as pyo
 import idaes.core as idc
+from idaes.core.util.exceptions import ConfigurationError
 
 from watertap.costing.watertap_costing_package import WaterTAPCosting
 import watertap.flowsheets.lsrro.lsrro as lsrro
+
+
+@pytest.mark.component
+def test_watertap_costing_config():
+    m = pyo.ConcreteModel()
+    m.fs = idc.FlowsheetBlock(dynamic=False)
+    m.fs.costing = WaterTAPCosting()
+    m.fs.costing.cost_process()
+
+    assert m.fs.costing.config.base_currency == 2018
+    assert m.fs.costing.base_currency == pyo.units.USD_2018
+    assert m.fs.costing.config.base_period == "year"
+    assert m.fs.costing.base_period == pyo.units.year
+
+    with pytest.raises(
+        ConfigurationError,
+        match="Base currency year must be between 1990 and 2023, but got 1901",
+    ):
+        m = pyo.ConcreteModel()
+        m.fs = idc.FlowsheetBlock(dynamic=False)
+        m.fs.costing = WaterTAPCosting(base_currency=1901)
+        m.fs.costing.cost_process()
+        _ = m.fs.costing.base_currency
+
+    with pytest.raises(
+        ConfigurationError,
+        match="Base period must be one of 'year', 'month', or 'day', but got parsec",
+    ):
+        m = pyo.ConcreteModel()
+        m.fs = idc.FlowsheetBlock(dynamic=False)
+        m.fs.costing = WaterTAPCosting(base_period="parsec")
+        m.fs.costing.cost_process()
+        _ = m.fs.costing.base_currency
+
+    m = pyo.ConcreteModel()
+    m.fs = idc.FlowsheetBlock(dynamic=False)
+    m.fs.costing = WaterTAPCosting(base_currency=2009, base_period="month")
+    m.fs.costing.cost_process()
+
+    assert m.fs.costing.config.base_currency == 2009
+    assert m.fs.costing.base_currency == pyo.units.USD_2009
+    assert m.fs.costing.config.base_period == "month"
+    assert m.fs.costing.base_period == pyo.units.month
+
+    assert pyo.units.get_units(m.fs.costing.total_capital_cost) == pyo.units.get_units(
+        pyo.units.USD_2009
+    )
+    assert pyo.units.get_units(
+        m.fs.costing.total_operating_cost
+    ) == pyo.units.get_units(pyo.units.USD_2009 / pyo.units.month)
 
 
 @pytest.mark.component

--- a/watertap/costing/tests/test_costing_base.py
+++ b/watertap/costing/tests/test_costing_base.py
@@ -11,6 +11,7 @@
 #################################################################################
 
 import pytest
+import re
 
 from pyomo.util.check_units import assert_units_consistent
 import pyomo.environ as pyo
@@ -43,11 +44,21 @@ def test_watertap_costing_config():
 
     with pytest.raises(
         ConfigurationError,
-        match="Base period must be one of 'year', 'month', or 'day', but got parsec",
+        match="pierogis is not a valid unit.",
     ):
         m = pyo.ConcreteModel()
         m.fs = idc.FlowsheetBlock(dynamic=False)
-        m.fs.costing = WaterTAPCosting(base_period="parsec")
+        m.fs.costing = WaterTAPCosting(base_period="pierogis")
+
+    with pytest.raises(
+        ConfigurationError,
+        match=re.escape(
+            "base_period configuration must be a unit of time but got kilogram [mass]."
+        ),
+    ):
+        m = pyo.ConcreteModel()
+        m.fs = idc.FlowsheetBlock(dynamic=False)
+        m.fs.costing = WaterTAPCosting(base_period="kilogram")
 
     m = pyo.ConcreteModel()
     m.fs = idc.FlowsheetBlock(dynamic=False)

--- a/watertap/costing/tests/test_costing_base.py
+++ b/watertap/costing/tests/test_costing_base.py
@@ -40,8 +40,6 @@ def test_watertap_costing_config():
         m = pyo.ConcreteModel()
         m.fs = idc.FlowsheetBlock(dynamic=False)
         m.fs.costing = WaterTAPCosting(base_currency=1901)
-        m.fs.costing.cost_process()
-        _ = m.fs.costing.base_currency
 
     with pytest.raises(
         ConfigurationError,
@@ -50,8 +48,6 @@ def test_watertap_costing_config():
         m = pyo.ConcreteModel()
         m.fs = idc.FlowsheetBlock(dynamic=False)
         m.fs.costing = WaterTAPCosting(base_period="parsec")
-        m.fs.costing.cost_process()
-        _ = m.fs.costing.base_currency
 
     m = pyo.ConcreteModel()
     m.fs = idc.FlowsheetBlock(dynamic=False)

--- a/watertap/costing/tests/test_util.py
+++ b/watertap/costing/tests/test_util.py
@@ -149,9 +149,7 @@ def test_rectifier_costing():
     # build generic models
     m = pyo.ConcreteModel()
     m.fs = idc.FlowsheetBlock(dynamic=False)
-    m.fs.costing = WaterTAPCosting()
-    # change base units for value assertions
-    m.fs.costing.base_currency = pyo.units.USD_2021
+    m.fs.costing = WaterTAPCosting(base_currency_year=2018)
     m.fs.unit = idc.UnitModelBlock()
 
     # build power variable required for cost_rectifier
@@ -178,12 +176,12 @@ def test_rectifier_costing():
     assert pyo.check_optimal_termination(results)
 
     # check values
-    assert pytest.approx(59320, rel=1e-3) == pyo.value(m.fs.unit.costing.capital_cost)
+    assert pytest.approx(50531, rel=1e-3) == pyo.value(m.fs.unit.costing.capital_cost)
     assert pytest.approx(111.1, rel=1e-3) == pyo.value(m.fs.unit.costing.ac_power)
     assert pytest.approx(111.1, rel=1e-3) == pyo.value(
         m.fs.costing.aggregate_flow_electricity
     )
-    assert pytest.approx(80040, rel=1e-3) == pyo.value(
+    assert pytest.approx(68180, rel=1e-3) == pyo.value(
         m.fs.costing.aggregate_flow_costs["electricity"]
     )
 

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -14,6 +14,7 @@ Tests for general zero-order costing methods
 """
 
 import os
+import re
 import yaml
 import tempfile
 import pytest
@@ -40,6 +41,7 @@ from idaes.core.util.model_statistics import (
     number_unfixed_variables,
 )
 from idaes.core.util.misc import add_object_reference
+from idaes.core.util.exceptions import ConfigurationError
 
 from watertap.costing.zero_order_costing import (
     ZeroOrderCosting,
@@ -502,20 +504,20 @@ class TestWorkflow:
 
 @pytest.mark.component
 def test_watertap_costing_config_zo():
-    # Create a temporary case study file without base_currency and base_period
+
     here = os.path.dirname(os.path.abspath(__file__))
-    default_cs_path = f"{os.path.dirname(os.path.dirname(here))}/data/techno_economic/default_case_study.yaml"
 
-    with open(default_cs_path, "r", encoding="utf-8") as default_cs:
-        data = default_cs.read()
-        data = yaml.load(data, Loader=yaml.Loader)
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+    m.fs.costing = ZeroOrderCosting()
 
+    data = _load_case_study_definition(m.fs.costing)
     data.pop("base_currency", None)
     data.pop("base_period", None)
 
-    with tempfile.NamedTemporaryFile(
-        suffix=".yaml", delete=False, mode="w", encoding="utf-8"
-    ) as tf:
+    # Create a temporary case study file without base_currency and base_period
+    temp_path = f"{here}/temp.yaml"
+    with open(temp_path, "w", encoding="utf-8") as tf:
         yaml.safe_dump(data, tf, sort_keys=False)
         temp_path = tf.name
 
@@ -524,15 +526,51 @@ def test_watertap_costing_config_zo():
     m.fs.costing = ZeroOrderCosting(
         case_study_definition=temp_path, base_currency=2000, base_period="day"
     )
-    # m.fs.costing.cost_process()
+    m.fs.costing.cost_process()
 
-    # assert m.fs.costing.config.base_currency == 2000
-    # assert m.fs.costing.base_currency == pyunits.USD_2000
-    # assert m.fs.costing.config.base_period == "day"
-    # assert m.fs.costing.base_period == pyunits.day
-    # assert pyunits.get_units(m.fs.costing.total_capital_cost) == pyunits.get_units(
-    #     pyunits.USD_2000
-    # )
-    # assert pyunits.get_units(
-    #     m.fs.costing.total_operating_cost
-    # ) == pyunits.get_units(pyunits.USD_2000 / pyunits.day)
+    assert m.fs.costing.config.base_currency == 2000
+    assert m.fs.costing.base_currency == pyunits.USD_2000
+    assert m.fs.costing.config.base_period == "day"
+    assert m.fs.costing.base_period == pyunits.day
+    assert pyunits.get_units(m.fs.costing.total_capital_cost) == pyunits.get_units(
+        pyunits.USD_2000
+    )
+    assert pyunits.get_units(m.fs.costing.total_operating_cost) == pyunits.get_units(
+        pyunits.USD_2000 / pyunits.day
+    )
+
+    # Check invalid base_currency and base_period configurations
+    with pytest.raises(
+        ConfigurationError,
+        match="Base currency year must be between 1990 and 2023, but got 1492",
+    ):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+        m.fs.costing = ZeroOrderCosting(
+            case_study_definition=temp_path, base_currency=1492
+        )
+    # base_period must be a valid pyunit
+    with pytest.raises(
+        ConfigurationError,
+        match="cheese is not a valid unit.",
+    ):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+        m.fs.costing = ZeroOrderCosting(
+            case_study_definition=temp_path, base_period="cheese"
+        )
+
+    # if base_period is a valid pyunit, it must be a unit of time
+    with pytest.raises(
+        ConfigurationError,
+        match=re.escape(
+            "base_period configuration must be a unit of time but got kilogram [mass]."
+        ),
+    ):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+        m.fs.costing = ZeroOrderCosting(
+            case_study_definition=temp_path, base_period="kilogram"
+        )
+
+    os.remove(temp_path)

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -16,7 +16,6 @@ Tests for general zero-order costing methods
 import os
 import re
 import yaml
-import tempfile
 import pytest
 
 from pyomo.environ import (

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -336,6 +336,8 @@ class TestWorkflow:
         m.fs.params = WaterParameterBlock(solute_list=["sulfur", "toc", "tss"])
 
         m.fs.costing = ZeroOrderCosting()
+        # NOTE: setting base_currency in this way is discouraged
+        # It is recommended to set the base_currency through the case study definition file
         m.fs.costing.base_currency = pyunits.USD_2020
 
         return m
@@ -508,7 +510,11 @@ def test_watertap_costing_config_zo():
 
     m = ConcreteModel()
     m.fs = FlowsheetBlock(dynamic=False)
-    m.fs.costing = ZeroOrderCosting()
+    m.fs.costing = ZeroOrderCosting(base_currency_year=2001)
+    # check that passing base_currency_year when it is also defined in 
+    # yaml will use the base_currency_year from yaml
+    assert m.fs.costing.config.base_currency_year == 2001
+    assert m.fs.costing.base_currency == pyunits.MUSD_2018
 
     data = _load_case_study_definition(m.fs.costing)
     data.pop("base_currency", None)
@@ -523,11 +529,11 @@ def test_watertap_costing_config_zo():
     m = ConcreteModel()
     m.fs = FlowsheetBlock(dynamic=False)
     m.fs.costing = ZeroOrderCosting(
-        case_study_definition=temp_path, base_currency=2000, base_period="day"
+        case_study_definition=temp_path, base_currency_year=2000, base_period="day"
     )
     m.fs.costing.cost_process()
 
-    assert m.fs.costing.config.base_currency == 2000
+    assert m.fs.costing.config.base_currency_year == 2000
     assert m.fs.costing.base_currency == pyunits.USD_2000
     assert m.fs.costing.config.base_period == "day"
     assert m.fs.costing.base_period == pyunits.day
@@ -538,7 +544,7 @@ def test_watertap_costing_config_zo():
         pyunits.USD_2000 / pyunits.day
     )
 
-    # Check invalid base_currency and base_period configurations
+    # Check invalid base_currency_year and base_period configurations
     with pytest.raises(
         ConfigurationError,
         match="Base currency year must be between 1990 and 2023, but got 1492",
@@ -546,7 +552,7 @@ def test_watertap_costing_config_zo():
         m = ConcreteModel()
         m.fs = FlowsheetBlock(dynamic=False)
         m.fs.costing = ZeroOrderCosting(
-            case_study_definition=temp_path, base_currency=1492
+            case_study_definition=temp_path, base_currency_year=1492
         )
     # base_period must be a valid pyunit
     with pytest.raises(

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -13,6 +13,9 @@
 Tests for general zero-order costing methods
 """
 
+import os
+import yaml
+import tempfile
 import pytest
 
 from pyomo.environ import (
@@ -495,3 +498,41 @@ class TestWorkflow:
         assert pytest.approx(0.231345, rel=1e-5) == value(
             model.fs.costing.electricity_intensity
         )
+
+
+@pytest.mark.component
+def test_watertap_costing_config_zo():
+    # Create a temporary case study file without base_currency and base_period
+    here = os.path.dirname(os.path.abspath(__file__))
+    default_cs_path = f"{os.path.dirname(os.path.dirname(here))}/data/techno_economic/default_case_study.yaml"
+
+    with open(default_cs_path, "r", encoding="utf-8") as default_cs:
+        data = default_cs.read()
+        data = yaml.load(data, Loader=yaml.Loader)
+
+    data.pop("base_currency", None)
+    data.pop("base_period", None)
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".yaml", delete=False, mode="w", encoding="utf-8"
+    ) as tf:
+        yaml.safe_dump(data, tf, sort_keys=False)
+        temp_path = tf.name
+
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+    m.fs.costing = ZeroOrderCosting(
+        case_study_definition=temp_path, base_currency=2000, base_period="day"
+    )
+    # m.fs.costing.cost_process()
+
+    # assert m.fs.costing.config.base_currency == 2000
+    # assert m.fs.costing.base_currency == pyunits.USD_2000
+    # assert m.fs.costing.config.base_period == "day"
+    # assert m.fs.costing.base_period == pyunits.day
+    # assert pyunits.get_units(m.fs.costing.total_capital_cost) == pyunits.get_units(
+    #     pyunits.USD_2000
+    # )
+    # assert pyunits.get_units(
+    #     m.fs.costing.total_operating_cost
+    # ) == pyunits.get_units(pyunits.USD_2000 / pyunits.day)

--- a/watertap/costing/tests/test_zero_order_costing.py
+++ b/watertap/costing/tests/test_zero_order_costing.py
@@ -511,7 +511,7 @@ def test_watertap_costing_config_zo():
     m = ConcreteModel()
     m.fs = FlowsheetBlock(dynamic=False)
     m.fs.costing = ZeroOrderCosting(base_currency_year=2001)
-    # check that passing base_currency_year when it is also defined in 
+    # check that passing base_currency_year when it is also defined in
     # yaml will use the base_currency_year from yaml
     assert m.fs.costing.config.base_currency_year == 2001
     assert m.fs.costing.base_currency == pyunits.MUSD_2018

--- a/watertap/costing/unit_models/tests/test_electrolyzer.py
+++ b/watertap/costing/unit_models/tests/test_electrolyzer.py
@@ -35,8 +35,7 @@ class TestElectrolyzerCosting:
         solver.solve(m)
 
         # build costing model block
-        m.fs.costing = WaterTAPCosting()
-        m.fs.costing.base_currency = pyo.units.USD_2020
+        m.fs.costing = WaterTAPCosting(base_currency_year=2020)
 
         m.fs.unit.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         m.fs.costing.cost_process()

--- a/watertap/costing/unit_models/tests/test_electrolyzer.py
+++ b/watertap/costing/unit_models/tests/test_electrolyzer.py
@@ -66,6 +66,6 @@ class TestElectrolyzerCosting:
         assert pytest.approx(82.50, rel=1e-3) == pyo.value(
             m.fs.costing.aggregate_flow_electricity
         )
-        assert pytest.approx(50040, rel=1e-3) == pyo.value(
+        assert pytest.approx(50623.64, rel=1e-3) == pyo.value(
             m.fs.costing.aggregate_flow_costs["electricity"]
         )

--- a/watertap/costing/unit_models/tests/test_gac.py
+++ b/watertap/costing/unit_models/tests/test_gac.py
@@ -42,8 +42,7 @@ class TestGACCosting:
     def test_robust_costing_pressure(self, build):
         m = build
 
-        m.fs.costing = WaterTAPCosting()
-        m.fs.costing.base_currency = pyo.units.USD_2020
+        m.fs.costing = WaterTAPCosting(base_currency_year=2020)
 
         m.fs.unit.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         m.fs.costing.cost_process()
@@ -77,8 +76,7 @@ class TestGACCosting:
     def test_robust_costing_gravity(self, build):
         mr_grav = build
 
-        mr_grav.fs.costing = WaterTAPCosting()
-        mr_grav.fs.costing.base_currency = pyo.units.USD_2020
+        mr_grav.fs.costing = WaterTAPCosting(base_currency_year=2020)
 
         mr_grav.fs.unit.costing = UnitModelCostingBlock(
             flowsheet_costing_block=mr_grav.fs.costing,
@@ -115,8 +113,7 @@ class TestGACCosting:
     def test_robust_costing_modular_contactors(self, build):
         m = build
 
-        m.fs.costing = WaterTAPCosting()
-        m.fs.costing.base_currency = pyo.units.USD_2020
+        m.fs.costing = WaterTAPCosting(base_currency_year=2020)
 
         m.fs.unit.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         m.fs.costing.cost_process()
@@ -143,8 +140,7 @@ class TestGACCosting:
         unit_feed.flow_mol_phase_comp["Liq", "H2O"].fix(10 * 824.0736620370348)
         unit_feed.flow_mol_phase_comp["Liq", "TCE"].fix(10 * 5.644342973110135e-05)
 
-        m.fs.costing = WaterTAPCosting()
-        m.fs.costing.base_currency = pyo.units.USD_2020
+        m.fs.costing = WaterTAPCosting(base_currency_year=2020)
 
         m.fs.unit.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         m.fs.costing.cost_process()

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -56,7 +56,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
             doc="Base period for operating costs. If not provided, default is year.",
         ),
     )
-    
+
     # Define default mapping of costing methods to unit models
     unit_mapping = {
         Mixer: cost_mixer,

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -75,7 +75,10 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         and set the base_currency and base_period attributes.
         """
 
-        if "_cs_def" in self.config and self._cs_def is not None:
+        self.base_currency = None
+        self.base_period = None
+
+        if "case_study_definition" in self.config:
             # it is a ZeroOrderCosting block, so we preferentially
             # use the values from the _cs_def if available
             if "base_currency" in self._cs_def:
@@ -83,7 +86,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
             if "base_period" in self._cs_def:
                 self.base_period = getattr(pyo.units, self._cs_def["base_period"])
 
-        else:
+        if self.base_currency is None:
             if not 1990 <= self.config.base_currency <= 2023:
                 raise ConfigurationError(
                     f"Base currency year must be between 1990 and 2023, but got {self.config.base_currency}"
@@ -91,6 +94,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
 
             self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency}")
 
+        if self.base_period is None:
             try:
                 self.base_period = getattr(pyo.units, self.config.base_period)
             except AttributeError:

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -11,6 +11,7 @@
 #################################################################################
 
 import pyomo.environ as pyo
+from pyomo.common.config import ConfigValue
 
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.core.expr.visitor import identify_variables
@@ -21,6 +22,7 @@ from idaes.core.base.costing_base import FlowsheetCostingBlockData
 from idaes.models.unit_models import Mixer, HeatExchanger, Heater, CSTR
 
 import idaes.logger as idaeslog
+from idaes.core.util.exceptions import ConfigurationError
 
 from watertap.core.util.misc import is_constant_up_to_units
 from watertap.costing.unit_models.mixer import cost_mixer
@@ -38,6 +40,23 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
     and for anonymous expressions in flow costs.
     """
 
+    CONFIG = FlowsheetCostingBlockData.CONFIG()
+    CONFIG.declare(
+        "base_currency",
+        ConfigValue(
+            default=2018,
+            domain=int,
+            doc="Base year for currency units. If not provided, default is 2018.",
+        ),
+    )
+    CONFIG.declare(
+        "base_period",
+        ConfigValue(
+            default="year",
+            doc="Base period for operating costs. If not provided, default is year.",
+        ),
+    )
+    
     # Define default mapping of costing methods to unit models
     unit_mapping = {
         Mixer: cost_mixer,
@@ -49,12 +68,6 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
     def register_currency_definitions(self):
         # Register currency and conversion rates based on CE Index
         register_idaes_currency_units()
-
-    def set_base_currency_base_period(self):
-        # Set the base year for all costs
-        self.base_currency = pyo.units.USD_2018
-        # Set a base period for all operating costs
-        self.base_period = pyo.units.year
 
     def add_LCOW(self, flow_rate, name="LCOW"):
         """
@@ -500,7 +513,19 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         """
 
         self.register_currency_definitions()
-        self.set_base_currency_base_period()
+
+        if not 1990 <= self.config.base_currency <= 2023:
+            raise ConfigurationError(
+                f"Base currency year must be between 1990 and 2023, but got {self.config.base_currency}"
+            )
+
+        self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency}")
+
+        if self.config.base_period not in ["year", "month", "day"]:
+            raise ConfigurationError(
+                f"Base period must be one of 'year', 'month', or 'day', but got {self.config.base_period}"
+            )
+        self.base_period = getattr(pyo.units, self.config.base_period)
 
         self.utilization_factor = pyo.Var(
             initialize=0.9,

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -20,9 +20,9 @@ from idaes.core.base.costing_base import register_idaes_currency_units
 from idaes.core import declare_process_block_class, UnitModelBlockData
 from idaes.core.base.costing_base import FlowsheetCostingBlockData
 from idaes.models.unit_models import Mixer, HeatExchanger, Heater, CSTR
+from idaes.core.util.exceptions import ConfigurationError
 
 import idaes.logger as idaeslog
-from idaes.core.util.exceptions import ConfigurationError
 
 from watertap.core.util.misc import is_constant_up_to_units
 from watertap.costing.unit_models.mixer import cost_mixer
@@ -68,6 +68,42 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
     def register_currency_definitions(self):
         # Register currency and conversion rates based on CE Index
         register_idaes_currency_units()
+
+    def validate_watertap_costing_config(self):
+        """
+        Validate the configuration of a WaterTAP costing block.
+        and set the base_currency and base_period attributes.
+        """
+
+        if "_cs_def" in self.config and self._cs_def is not None:
+            # it is a ZeroOrderCosting block, so we preferentially
+            # use the values from the _cs_def if available
+            if "base_currency" in self._cs_def:
+                self.base_currency = getattr(pyo.units, self._cs_def["base_currency"])
+            if "base_period" in self._cs_def:
+                self.base_period = getattr(pyo.units, self._cs_def["base_period"])
+
+        else:
+            if not 1990 <= self.config.base_currency <= 2023:
+                raise ConfigurationError(
+                    f"Base currency year must be between 1990 and 2023, but got {self.config.base_currency}"
+                )
+
+            self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency}")
+
+            try:
+                self.base_period = getattr(pyo.units, self.config.base_period)
+            except AttributeError:
+                raise ConfigurationError(
+                    f"{self.config.base_period} is not a valid unit."
+                )
+
+            self.base_period = getattr(pyo.units, self.config.base_period)
+
+            if not self.base_period._pint_unit.dimensionality == "[time]":
+                msg = f"base_period configuration must be a unit of time "
+                msg += f"but got {self.config.base_period} {self.base_period._pint_unit.dimensionality}."
+                raise ConfigurationError(msg)
 
     def add_LCOW(self, flow_rate, name="LCOW"):
         """
@@ -513,19 +549,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
         """
 
         self.register_currency_definitions()
-
-        if not 1990 <= self.config.base_currency <= 2023:
-            raise ConfigurationError(
-                f"Base currency year must be between 1990 and 2023, but got {self.config.base_currency}"
-            )
-
-        self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency}")
-
-        if self.config.base_period not in ["year", "month", "day"]:
-            raise ConfigurationError(
-                f"Base period must be one of 'year', 'month', or 'day', but got {self.config.base_period}"
-            )
-        self.base_period = getattr(pyo.units, self.config.base_period)
+        self.validate_watertap_costing_config()
 
         self.utilization_factor = pyo.Var(
             initialize=0.9,

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -92,7 +92,9 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
                     f"Base currency year must be between 1990 and 2023, but got {self.config.base_currency_year}"
                 )
 
-            self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency_year}")
+            self.base_currency = getattr(
+                pyo.units, f"USD_{self.config.base_currency_year}"
+            )
 
         if self.base_period is None:
             try:

--- a/watertap/costing/watertap_costing_package.py
+++ b/watertap/costing/watertap_costing_package.py
@@ -42,7 +42,7 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
 
     CONFIG = FlowsheetCostingBlockData.CONFIG()
     CONFIG.declare(
-        "base_currency",
+        "base_currency_year",
         ConfigValue(
             default=2018,
             domain=int,
@@ -87,12 +87,12 @@ class WaterTAPCostingBlockData(FlowsheetCostingBlockData):
                 self.base_period = getattr(pyo.units, self._cs_def["base_period"])
 
         if self.base_currency is None:
-            if not 1990 <= self.config.base_currency <= 2023:
+            if not 1990 <= self.config.base_currency_year <= 2023:
                 raise ConfigurationError(
-                    f"Base currency year must be between 1990 and 2023, but got {self.config.base_currency}"
+                    f"Base currency year must be between 1990 and 2023, but got {self.config.base_currency_year}"
                 )
 
-            self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency}")
+            self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency_year}")
 
         if self.base_period is None:
             try:

--- a/watertap/costing/zero_order_costing.py
+++ b/watertap/costing/zero_order_costing.py
@@ -53,7 +53,7 @@ class ZeroOrderCostingData(WaterTAPCostingDetailedData):
         ConfigValue(
             default=None,
             doc="Path to YAML file defining global parameters for case study. If "
-            "not provided, default values from the WaterTap database are used.",
+            "not provided, default values from the WaterTAP database are used.",
         ),
     )
 
@@ -65,18 +65,6 @@ class ZeroOrderCostingData(WaterTAPCostingDetailedData):
             )
         else:
             register_idaes_currency_units()
-
-    def set_base_currency_base_period(self):
-        # Set the base year for all costs
-        if "base_currency" in self._cs_def:
-            self.base_currency = getattr(pyo.units, self._cs_def["base_currency"])
-        else:
-            self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency}")
-        # Set a base period for all operating costs
-        if "base_period" in self._cs_def:
-            self.base_period = getattr(pyo.units, self._cs_def["base_period"])
-        else:
-            self.base_period = getattr(pyo.units, {self.config.base_period})
 
     def build_global_params(self):
         """
@@ -141,5 +129,4 @@ def _load_case_study_definition(self):
             "Could not find specified case study definition file. "
             "Please check the path provided."
         )
-
     return yaml.load(lines, yaml.Loader)

--- a/watertap/costing/zero_order_costing.py
+++ b/watertap/costing/zero_order_costing.py
@@ -68,9 +68,15 @@ class ZeroOrderCostingData(WaterTAPCostingDetailedData):
 
     def set_base_currency_base_period(self):
         # Set the base year for all costs
-        self.base_currency = getattr(pyo.units, self._cs_def["base_currency"])
+        if "base_currency" in self._cs_def:
+            self.base_currency = getattr(pyo.units, self._cs_def["base_currency"])
+        else:
+            self.base_currency = getattr(pyo.units, f"USD_{self.config.base_currency}")
         # Set a base period for all operating costs
-        self.base_period = getattr(pyo.units, self._cs_def["base_period"])
+        if "base_period" in self._cs_def:
+            self.base_period = getattr(pyo.units, self._cs_def["base_period"])
+        else:
+            self.base_period = getattr(pyo.units, {self.config.base_period})
 
     def build_global_params(self):
         """

--- a/watertap/flowsheets/dye_desalination/dye_desalination.py
+++ b/watertap/flowsheets/dye_desalination/dye_desalination.py
@@ -638,10 +638,8 @@ def add_costing(m, dye_revenue=False, brine_revenue=False):
     )
 
     m.fs.zo_costing = ZeroOrderCosting(case_study_definition=source_file)
-    m.fs.zo_costing.base_currency = pyunits.USD_2023
-    m.fs.ro_costing = WaterTAPCosting()
+    m.fs.ro_costing = WaterTAPCosting(base_currency_year=2023)
     m.fs.ro_costing.electricity_cost = value(m.fs.zo_costing.electricity_cost)
-    m.fs.ro_costing.base_currency = pyunits.USD_2023
     m.fs.ro_costing.utilization_factor.fix(0.85)
     # Assume the same capital recovery factor as zo_costing
     zo_crf = m.fs.zo_costing.capital_recovery_factor

--- a/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
+++ b/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
@@ -125,7 +125,7 @@ class TestDyewithROFlowsheetwithPretreatment:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(14.7707, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(14.8644, rel=1e-3) == value(m.fs.LCOW)
         assert pytest.approx(11.4088, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component

--- a/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
+++ b/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
@@ -126,7 +126,7 @@ class TestDyewithROFlowsheetwithPretreatment:
 
         # check costing
         assert pytest.approx(14.8644, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(11.4088, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(11.3704, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):

--- a/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
+++ b/watertap/flowsheets/dye_desalination/tests/test_dye_desalination.py
@@ -125,7 +125,7 @@ class TestDyewithROFlowsheetwithPretreatment:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(14.91054, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(14.7707, rel=1e-3) == value(m.fs.LCOW)
         assert pytest.approx(11.4088, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
@@ -226,8 +226,8 @@ class TestDyewithROFlowsheetDefault:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(14.81836, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(11.32730, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(14.77073, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(11.28754, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):
@@ -327,8 +327,8 @@ class TestDyewith0DROFlowsheet:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(15.305355, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(11.386109, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(15.255767, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(11.34593, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     def test_display(self, system_frame):
@@ -430,8 +430,8 @@ class TestDyewithROFlowsheetwithDewatering:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(0.965823, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(-0.2653945, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(0.93277, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(-0.29625, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     @pytest.mark.requires_idaes_solver
@@ -528,8 +528,8 @@ class TestDyewithROFlowsheetwithGAC:
         assert_optimal_termination(results)
 
         # check costing
-        assert pytest.approx(0.426391, rel=1e-3) == value(m.fs.LCOW)
-        assert pytest.approx(-0.77, rel=1e-3) == value(m.fs.LCOT)
+        assert pytest.approx(0.393246, rel=1e-3) == value(m.fs.LCOW)
+        assert pytest.approx(-0.8009, rel=1e-3) == value(m.fs.LCOT)
 
     @pytest.mark.component
     @pytest.mark.requires_idaes_solver

--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2.py
@@ -1057,8 +1057,7 @@ def initialize_system(m):
 
 
 def add_costing(m):
-    m.fs.costing = WaterTAPCosting()
-    m.fs.costing.base_currency = pyo.units.USD_2020
+    m.fs.costing = WaterTAPCosting(base_currency_year=2020)
 
     # Costing Blocks
     m.fs.R1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)

--- a/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/BSM2_P_extension.py
@@ -756,8 +756,7 @@ def solve(m, solver=None):
 
 
 def add_costing(m):
-    m.fs.costing = WaterTAPCosting()
-    m.fs.costing.base_currency = pyo.units.USD_2020
+    m.fs.costing = WaterTAPCosting(base_currency_year=2020)
 
     # Costing Blocks
     m.fs.R1.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_BSM2_P_extension.py
@@ -185,7 +185,7 @@ class TestFullFlowsheetBioPFalse:
             24026877.393, rel=1e-3
         )
         assert value(m.fs.costing.total_operating_cost) == pytest.approx(
-            923153.285, rel=1e-3
+            925495.1, rel=1e-3
         )
 
     @pytest.mark.solver
@@ -304,7 +304,7 @@ class TestFullFlowsheetBioPTrue:
             24003751.225, rel=1e-3
         )
         assert value(m.fs.costing.total_operating_cost) == pytest.approx(
-            922338.478, rel=1e-3
+            924678.89, rel=1e-3
         )
 
     @pytest.mark.solver

--- a/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
+++ b/watertap/flowsheets/full_water_resource_recovery_facility/test/test_full_WRRF_with_ASM1_ADM1.py
@@ -196,7 +196,7 @@ class TestFullFlowsheet:
             17756958.700, rel=1e-3
         )
         assert value(m.fs.costing.total_operating_cost) == pytest.approx(
-            689487.623, rel=1e-3
+            691302.07, rel=1e-3
         )
 
     @pytest.mark.component

--- a/watertap/flowsheets/gac/gac.py
+++ b/watertap/flowsheets/gac/gac.py
@@ -236,8 +236,7 @@ def optimize(m, solver=None):
 
 
 def add_costing(m, cost_contactor_type="pressure"):
-    m.fs.costing = WaterTAPCosting()
-    m.fs.costing.base_currency = pyo.units.USD_2021
+    m.fs.costing = WaterTAPCosting(base_currency_year=2021)
     m.fs.gac.costing = UnitModelCostingBlock(
         flowsheet_costing_block=m.fs.costing,
         costing_method_arguments={"contactor_type": cost_contactor_type},

--- a/watertap/flowsheets/mvc/mvc_single_stage.py
+++ b/watertap/flowsheets/mvc/mvc_single_stage.py
@@ -23,7 +23,6 @@ from pyomo.environ import (
 )
 from pyomo.network import Arc, SequentialDecomposition
 
-import pyomo.environ as pyo
 from idaes.core import FlowsheetBlock
 from watertap.core.solvers import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom

--- a/watertap/flowsheets/mvc/mvc_single_stage.py
+++ b/watertap/flowsheets/mvc/mvc_single_stage.py
@@ -327,7 +327,7 @@ def add_Q_ext(m, time_point=None):
 
 
 def add_costing(m):
-    m.fs.costing = WaterTAPCosting()
+    m.fs.costing = WaterTAPCosting(base_currency_year=2020)
     m.fs.pump_feed.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
     m.fs.pump_distillate.costing = UnitModelCostingBlock(
         flowsheet_costing_block=m.fs.costing
@@ -353,7 +353,6 @@ def add_costing(m):
     m.fs.costing.add_annual_water_production(m.fs.distillate.properties[0].flow_vol)
     m.fs.costing.add_LCOW(m.fs.distillate.properties[0].flow_vol)
     m.fs.costing.add_specific_energy_consumption(m.fs.distillate.properties[0].flow_vol)
-    m.fs.costing.base_currency = pyo.units.USD_2020
 
 
 def set_operating_conditions(m):

--- a/watertap/flowsheets/mvc/tests/test_mvc_single_stage.py
+++ b/watertap/flowsheets/mvc/tests/test_mvc_single_stage.py
@@ -293,7 +293,7 @@ class TestMVC:
         assert value(m.fs.costing.specific_energy_consumption) == pytest.approx(
             22.02, rel=1e-2
         )
-        assert value(m.fs.costing.LCOW) == pytest.approx(23.47, rel=1e-2)
+        assert value(m.fs.costing.LCOW) == pytest.approx(23.232, rel=1e-2)
 
         # Check mass balance
         assert pytest.approx(

--- a/watertap/unit_models/tests/test_electrocoagulation.py
+++ b/watertap/unit_models/tests/test_electrocoagulation.py
@@ -583,10 +583,10 @@ class TestECCosting(UnitTestHarness):
             "aggregate_variable_operating_cost": 0.0,
             "aggregate_flow_electricity": 146.33,
             "aggregate_flow_aluminum": 64565.49,
-            "aggregate_flow_costs": {"electricity": 118796.73, "aluminum": 162263.39},
+            "aggregate_flow_costs": {"electricity": 89793.59, "aluminum": 162263.39},
             "total_capital_cost": 1168409.07,
-            "total_operating_cost": 599638.93,
-            "LCOW": 1.1831,
+            "total_operating_cost": 573536.11,
+            "LCOW": 1.1400,
             "SEC": 1.9064,
         }
 

--- a/watertap/unit_models/tests/test_electrocoagulation.py
+++ b/watertap/unit_models/tests/test_electrocoagulation.py
@@ -564,8 +564,7 @@ class TestECCosting(UnitTestHarness):
     @pytest.mark.component
     def test_costing(self):
         m = build_ec_costing()
-        m.fs.costing = WaterTAPCosting()
-        m.fs.costing.base_currency = pyunits.USD_2023
+        m.fs.costing = WaterTAPCosting(base_currency_year=2023)
         m.fs.unit.costing = UnitModelCostingBlock(flowsheet_costing_block=m.fs.costing)
         m.fs.costing.electrocoagulation.sludge_handling_cost.fix(0.025)
         m.fs.costing.cost_process()


### PR DESCRIPTION
## Fixes/Resolves:

#1860 

## Summary/Motivation:

#1860 

## Changes proposed in this PR:
- declare `base_currency_year` and `base_period` via configuration argument for WaterTAP costing package
- remove `set_base_currency_base_period` 
- test this functionality
- update docs to reflect this change
- make changes throughout repo where it makes sense to set `base_currency_year` as a config where we previously did e.g., `m.fs.costing.base_currency = pyunits.USD_2020` 
- add logging statements to costing package that shows what `base_currency` and `base_period` are set to _and_ how they were set (i.e., either from the case study yaml or via the config)

from yaml: 
```
2026-09-15 12:49:12 [INFO] idaes.watertap.costing.watertap_costing_package: Setting base_currency from case study yaml: MUSD_2018
2026-09-15 12:49:12 [INFO] idaes.watertap.costing.watertap_costing_package: Setting base_period from case study yaml: year
```
from config:
```
2026-09-15 12:49:12 [INFO] idaes.watertap.costing.watertap_costing_package: Setting base_currency from config: USD_2011
2026-09-15 12:49:12 [INFO] idaes.watertap.costing.watertap_costing_package: Setting base_period from config: year
```
## NOTE
There are many ZO tests where we directly set the base currency via e.g., `m.fs.costing.base_currency = pyunits.USD_2014`. The docs will say that we discourage this behavior after this PR. The "official" way to do this would be to set base currency via the yaml and then, if it is not in the yaml, to use the `base_currency_year` in the costing package configuration. However, setting the base currency directly like this in the tests was done in these ZO model tests to check the costing calculations against the reference; to set `base_currency` the _suggested_ way (via yaml) we would need to have a separate yaml for each of these tests, which seems silly for this purpose. 

As an alternative, I could refactor this so that `base_currency` in ZO costing package will preferentially use the `base_currency_year` config rather than the entry in the yaml. But that is not the current status. I opted to maintain the current "framework" for ZO models where we allow users to set their technoeconomic parameters via the case study yaml. 

TODO:
- [x] test for ZO costing
- [x] add to documentation
- [x] modify necessary how-tos

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
